### PR TITLE
Lib fixes

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -23,9 +23,10 @@ class Bufr(CMakePackage):
     version('11.5.0', sha256='d154839e29ef1fe82e58cf20232e9f8a4f0610f0e8b6a394b7ca052e58f97f43')
 
     def _setup_bufr_environment(self, env, suffix):
-        libname = 'libufr_{0}'.format(suffix)
+        libname = 'libbufr_{0}'.format(suffix)
         lib = find_libraries(libname, root=self.prefix,
                              shared=False, recursive=True)
+
         lib_envname = 'BUFR_LIB{0}'.format(suffix)
         inc_envname = 'BUFR_INC{0}'.format(suffix)
         include_dir = 'include_{0}'.format(suffix)

--- a/var/spack/repos/builtin/packages/w3nco/package.py
+++ b/var/spack/repos/builtin/packages/w3nco/package.py
@@ -23,5 +23,4 @@ class W3nco(CMakePackage):
 
     version('2.4.1', sha256='48b06e0ea21d3d0fd5d5c4e7eb50b081402567c1bff6c4abf4fd4f3669070139')
 
-    if sys.platform == 'darwin' and macos_version() >= Version('12.0'):
-        patch('darwin/apple-clang-13.0.0-times.patch')
+    patch('darwin/apple-clang-13.0.0-times.patch', when="%apple-clang platform=darwin")


### PR DESCRIPTION
* Fix typo in libbufr
* Remove the check for macOS 12.0 in the w3nco patch. Check for `%apple-clang` instead. Tested with gcc and apple-clang.