### PR TITLE
Update py-pythran and py-scipy package to enable building py-scipy 1.7.3 on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/py-pythran/package.py
+++ b/var/spack/repos/builtin/packages/py-pythran/package.py
@@ -14,6 +14,7 @@ class PyPythran(PythonPackage):
     homepage = "https://github.com/serge-sans-paille/pythran"
     pypi     = "pythran/pythran-0.9.11.tar.gz"
 
+    version('0.11.0', sha256='0b2cba712e09f7630879dff69f268460bfe34a6d6000451b47d598558a92a875')
     version('0.10.0', sha256='9dac8e1d50f33d4676003e350b1f0c878ce113e6f907920e92dc103352cac5bf')
     version('0.9.12', sha256='5d50dc74dca1d3f902941865acbae981fc24cceeb9d54673d68d6b5c8c1b0001')
     version('0.9.11', sha256='a317f91e2aade9f6550dc3bf40b5caeb45b7e012daf27e2b3e4ad928edb01667')

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -73,7 +73,7 @@ class PyScipy(PythonPackage):
     depends_on('py-numpy@1.16.5:1.22+blas+lapack', when='@1.6.2:', type=('build', 'link', 'run'))
     depends_on('py-cython@0.29.18:2', when='@1.7:', type='build')
     depends_on('py-pythran@0.9.11', when='@1.7.0:1.7.1', type=('build', 'link'))
-    depends_on('py-pythran@0.9.12:0.9', when='@1.7.2:', type=('build', 'link'))
+    depends_on('py-pythran@0.9.12:', when='@1.7.2:', type=('build', 'link'))
     depends_on('py-pytest', type='test')
 
     # NOTE: scipy picks up Blas/Lapack from numpy, see


### PR DESCRIPTION
Add version 0.11.0 of `py-pythran` package and enable building `py-scipy` 1.7.2+ with `py-pythran` 0.9.12+

With this change, `py-scipy` 1.7.3 builds on macOS with llvm-clang 13.0.0 and Python 3.9.

Fixes https://github.com/NOAA-EMC/spack-stack/issues/30