### PR TITLE
Bug fixes for building parallel-netcdf and py-scipy with latest Intel oneAPI compilers (incl. classic)

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -131,6 +131,11 @@ class ParallelNetcdf(AutotoolsPackage):
             # the repository.
             autoreconf('-iv')
 
+    def setup_build_environment(self, env):
+        if self.spec['mpi'].satisfies('intel-oneapi-mpi'):
+            # fix I_MPI_SUBSTITUTE_INSTALLDIR problem by setting I_MPI_ROOT
+            env.set('I_MPI_ROOT', self.spec['mpi'].prefix)
+
     def configure_args(self):
         args = ['--with-mpi=%s' % self.spec['mpi'].prefix,
                 'SEQ_CC=%s' % spack_cc]

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -95,6 +95,12 @@ class PyScipy(PythonPackage):
         if self.spec.satisfies('@:1.4 %gcc@10:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
 
+        # https://github.com/scipy/scipy/issues/14935
+        # Disable pythran backend with latest Intel compilers
+        if self.spec.satisfies('%intel@2021:') or \
+            self.spec.satisfies('%intel-oneapi-compilers@2021:'):
+            env.set('SCIPY_USE_PYTHRAN', '0')
+
         # Kluge to get the gfortran linker to work correctly on Big
         # Sur, at least until a gcc release > 10.2 is out with a fix.
         # (There is a fix in their development tree.)


### PR DESCRIPTION
Bug fixes for building parallel-netcdf and py-scipy with latest Intel oneAPI compilers (incl. classic).

- For parallel-netcdf, one needs to substitute `I_MPI_SUBSTITUTE_DIR` with `I_MPI_ROOT`. The issue is that the spack compiler wrappers don't set `I_MPI_ROOT` when building parallel-netcdf, and on systems where the sysadmins did not search-and-replace `I_MPI_SUBSTITUTE_DIR` in the MPI compiler wrappers (for example, on Cheyenne), this leads to a problem. Note that the spack install of intel-oneapi-mpi does replace those after installation, and on many systems the sysadmins do that manually as well, but we can't rely on it.
```
cat /glade/u/apps/opt/intel/2021.2/mpi/latest/bin/mpif90
...
# Directory locations: Fixed for any MPI implementation.
# Set from the directory arguments to configure (e.g., --prefix=/usr/local)
prefix=I_MPI_SUBSTITUTE_INSTALLDIR
# The environment variable I_MPI_ROOT may be used to override installation folder path
if [ -n "$I_MPI_ROOT" ] ; then
    prefix=$I_MPI_ROOT;
fi

exec_prefix=__EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__
sysconfdir=${prefix}/etc
includedir=${prefix}/include
libdir=${prefix}/lib
...
```
- For py-scipy, one has to turn off the py-pythran backend for the latest Intel compilers, because support is still experimental and the build fails (see https://github.com/scipy/scipy/issues/14935). This may result in a slight degradation of performance, but as mentioned in the scipy issue one can still expect decent performance from cython.

These bugfixes have been tested successfully on gaea and Cheyenne with Intel 2021.2.0 and 2021.3.0 (classic compilers).

Fixes #14 
Working towards #15 