### PR TITLE
Update ESMF, netcdf-c, netcdf-fortran, netcdf-cxx4, libjpeg-turbo, py-numpy packages

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -126,12 +126,14 @@ class Esmf(MakefilePackage):
         # C++ compilers are being used to build the ESMF library.
         if self.compiler.name == 'gcc':
             os.environ['ESMF_COMPILER'] = 'gfortran'
-            gfortran_major_version = int(spack.compiler.get_compiler_version_output(self.compiler.fc, '-dumpversion').split('.')[0])
+            gfortran_major_version = int(spack.compiler.get_compiler_version_output(
+                                    self.compiler.fc, '-dumpversion').split('.')[0])
         elif self.compiler.name == 'intel':
             os.environ['ESMF_COMPILER'] = 'intel'
         elif self.compiler.name in ['clang', 'apple-clang']:
             os.environ['ESMF_COMPILER'] = 'gfortranclang'
-            gfortran_major_version = int(spack.compiler.get_compiler_version_output(self.compiler.fc, '-dumpversion').split('.')[0])
+            gfortran_major_version = int(spack.compiler.get_compiler_version_output(
+                                    self.compiler.fc, '-dumpversion').split('.')[0])
         elif self.compiler.name == 'nag':
             os.environ['ESMF_COMPILER'] = 'nag'
         elif self.compiler.name == 'pgi':
@@ -156,7 +158,8 @@ class Esmf(MakefilePackage):
             # Build an optimized version of the library.
             os.environ['ESMF_BOPT'] = 'O'
 
-        if self.compiler.name in ['gcc', 'clang', 'apple-clang'] and gfortran_major_version>=10:
+        if self.compiler.name in ['gcc', 'clang', 'apple-clang'] and \
+            gfortran_major_version >= 10:
             os.environ['ESMF_F90COMPILEOPTS'] = '-fallow-argument-mismatch'
 
         #######

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -127,13 +127,13 @@ class Esmf(MakefilePackage):
         if self.compiler.name == 'gcc':
             os.environ['ESMF_COMPILER'] = 'gfortran'
             gfortran_major_version = int(spack.compiler.get_compiler_version_output(
-                                    self.compiler.fc, '-dumpversion').split('.')[0])
+                self.compiler.fc, '-dumpversion').split('.')[0])
         elif self.compiler.name == 'intel':
             os.environ['ESMF_COMPILER'] = 'intel'
         elif self.compiler.name in ['clang', 'apple-clang']:
             os.environ['ESMF_COMPILER'] = 'gfortranclang'
             gfortran_major_version = int(spack.compiler.get_compiler_version_output(
-                                    self.compiler.fc, '-dumpversion').split('.')[0])
+                self.compiler.fc, '-dumpversion').split('.')[0])
         elif self.compiler.name == 'nag':
             os.environ['ESMF_COMPILER'] = 'nag'
         elif self.compiler.name == 'pgi':
@@ -159,7 +159,7 @@ class Esmf(MakefilePackage):
             os.environ['ESMF_BOPT'] = 'O'
 
         if self.compiler.name in ['gcc', 'clang', 'apple-clang'] and \
-            gfortran_major_version >= 10:
+                gfortran_major_version >= 10:
             os.environ['ESMF_F90COMPILEOPTS'] = '-fallow-argument-mismatch'
 
         #######
@@ -168,7 +168,7 @@ class Esmf(MakefilePackage):
 
         # ESMF_OS must be set for Cray systems
         if 'platform=cray' in self.spec:
-            os.environ['ESMF_OS']='Unicos'
+            os.environ['ESMF_OS'] = 'Unicos'
 
         #######
         # MPI #

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -160,6 +160,14 @@ class Esmf(MakefilePackage):
             os.environ['ESMF_F90COMPILEOPTS'] = '-fallow-argument-mismatch'
 
         #######
+        # OS  #
+        #######
+
+        # ESMF_OS must be set for Cray systems
+        if 'platform=cray' in self.spec:
+            os.environ['ESMF_OS']='Unicos'
+
+        #######
         # MPI #
         #######
 

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -41,9 +41,13 @@ class LibjpegTurbo(Package):
     depends_on('libtool', type='build', when='@1.3.1:1.5.3')
     depends_on('cmake', type='build', when='@1.5.90:')
 
+    variant('shared', default=True, description='Build shared libraries')
+    variant('static', default=True, description='Build static libraries')
+
     @property
     def libs(self):
-        return find_libraries('libjpeg*', root=self.prefix, recursive=True)
+        shared = '+shared' in self.spec
+        return find_libraries('libjpeg*', root=self.prefix, shared=shared, recursive=True)
 
     def flag_handler(self, name, flags):
         if self.spec.satisfies('@1.5.90:'):
@@ -72,9 +76,15 @@ class LibjpegTurbo(Package):
     def install(self, spec, prefix):
         cmake_args = [
             '-GUnix Makefiles',
-            '-DENABLE_SHARED=ON',
-            '-DENABLE_STATIC=ON'
             ]
+        if self.spec.satisfies('+shared'):
+            cmake_args.append('-DENABLE_SHARED=ON')
+        else:
+            cmake_args.append('-DENABLE_SHARED=OFF')
+        if self.spec.satisfies('+static'):
+            cmake_args.append('-DENABLE_STATIC=ON')
+        else:
+            cmake_args.append('-DENABLE_STATIC=OFF')
         if hasattr(self, 'cmake_flag_args'):
             cmake_args.extend(self.cmake_flag_args)
         cmake_args.extend(std_cmake_args)

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -70,7 +70,11 @@ class LibjpegTurbo(Package):
 
     @when('@1.5.90:')
     def install(self, spec, prefix):
-        cmake_args = ['-GUnix Makefiles']
+        cmake_args = [
+            '-GUnix Makefiles',
+            '-DENABLE_SHARED=ON',
+            '-DENABLE_STATIC=ON'
+            ]
         if hasattr(self, 'cmake_flag_args'):
             cmake_args.extend(self.cmake_flag_args)
         cmake_args.extend(std_cmake_args)

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -68,10 +68,9 @@ class NetcdfC(AutotoolsPackage):
     # variant('cdmremote', default=False,
     #         description='Enable CDM Remote support')
 
-    # The patch for 4.7.0 touches configure.ac. See force_autoreconf below.
-    depends_on('autoconf', type='build', when='@4.7.0')
-    depends_on('automake', type='build', when='@4.7.0')
-    depends_on('libtool', type='build', when='@4.7.0')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
 
     depends_on("m4", type='build')
     depends_on("hdf~netcdf", when='+hdf4')
@@ -119,8 +118,7 @@ class NetcdfC(AutotoolsPackage):
 
     @property
     def force_autoreconf(self):
-        # The patch for 4.7.0 touches configure.ac.
-        return self.spec.satisfies('@4.7.0')
+        True
 
     def configure_args(self):
         cflags = []

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -62,13 +62,16 @@ class NetcdfCxx4(AutotoolsPackage):
     def configure_args(self):
         config_args = []
 
-        # We need to build with MPI wrappers if either of the parallel I/O
-        # features is enabled in netcdf-c:
-        # https://www.unidata.ucar.edu/software/netcdf/docs/building_netcdf_fortran.html
-        netcdf_c_spec = self.spec['netcdf-c']
-        if '+mpi' in netcdf_c_spec or '+parallel-netcdf' in netcdf_c_spec:
+        if self.spec.satisfies('^hdf5+mpi'):
+            # The package itself does not need the MPI libraries but includes
+            # <hdf5.h> (in the C code only), which requires <mpi.h> when HDF5 is
+            # built with the MPI support. Using the MPI wrapper introduces
+            # overlinking to MPI libraries and we would prefer not to use it but
+            # it is the only reliable way to provide the compiler with the
+            # correct path to <mpi.h>. For example, <mpi.h> of a MacPorts-built
+            # MPICH might reside in /opt/local/include/mpich-gcc10, which Spack
+            # does not know about and cannot inject with its compiler wrapper.
             config_args.append('CC=%s' % self.spec['mpi'].mpicc)
-            config_args.append('CXX=%s' % self.spec['mpi'].mpicxx)
 
         if '+static' in self.spec:
             config_args.append('--enable-static')

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -28,10 +28,6 @@ class NetcdfCxx4(AutotoolsPackage):
 
     depends_on('netcdf-c')
 
-    depends_on('automake', type='build')
-    depends_on('autoconf', type='build')
-    depends_on('libtool', type='build')
-    depends_on('m4', type='build')
     depends_on('doxygen', when='+doc', type='build')
 
     conflicts('~shared', when='~static')
@@ -39,8 +35,6 @@ class NetcdfCxx4(AutotoolsPackage):
     patch('https://github.com/Unidata/netcdf-cxx4/commit/e7cc5bab02cf089dc79616456a0a951fee979fe9.patch',
           sha256='4ddf6db9dc0c5f754cb3d68b1dbef8c385cf499f6e5df8fbccae3749336ba84a',
           when='@:4.3.1 platform=darwin')
-
-    force_autoreconf = True
 
     def flag_handler(self, name, flags):
         if name == 'cflags' and '+pic' in self.spec:

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -39,6 +39,8 @@ class NetcdfCxx4(AutotoolsPackage):
     def flag_handler(self, name, flags):
         if name == 'cflags' and '+pic' in self.spec:
             flags.append(self.compiler.cc_pic_flag)
+        if name == 'cxxflags' and '+pic' in self.spec:
+            flags.append(self.compiler.cxx_pic_flag)
         elif name == 'cppflags':
             flags.append('-I' + self.spec['netcdf-c'].prefix.include)
         elif name == 'ldflags':

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -59,7 +59,6 @@ class NetcdfCxx4(AutotoolsPackage):
 
     def configure_args(self):
         config_args = self.enable_or_disable('shared')
-        config_args += self.with_or_without('pic')
 
         if '+doc' in self.spec:
             config_args.append('--enable-doxygen')

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -60,7 +60,14 @@ class NetcdfCxx4(AutotoolsPackage):
         )
 
     def configure_args(self):
-        config_args = []
+        config_args = self.enable_or_disable('static')
+        config_args += self.enable_or_disable('shared')
+        config_args += self.with_or_without('pic')
+
+        if '+doc' in self.spec:
+            config_args.append('--enable-doxygen')
+        else:
+            config_args.append('--disable-doxygen')
 
         if self.spec.satisfies('^hdf5+mpi'):
             # The package itself does not need the MPI libraries but includes
@@ -71,26 +78,6 @@ class NetcdfCxx4(AutotoolsPackage):
             # correct path to <mpi.h>. For example, <mpi.h> of a MacPorts-built
             # MPICH might reside in /opt/local/include/mpich-gcc10, which Spack
             # does not know about and cannot inject with its compiler wrapper.
-            config_args.append('CC=%s' % self.spec['mpi'].mpicc)
-
-        if '+static' in self.spec:
-            config_args.append('--enable-static')
-        else:
-            config_args.append('--disable-static')
-
-        if '+shared' in self.spec:
-            config_args.append('--enable-shared')
-        else:
-            config_args.append('--disable-shared')
-
-        if '+pic' in self.spec:
-            config_args.append('--with-pic')
-        else:
-            config_args.append('--without-pic')
-
-        if '+doc' in self.spec:
-            config_args.append('--enable-doxygen')
-        else:
-            config_args.append('--disable-doxygen')
+            config_args.append('CC={0}'.format(self.spec['mpi'].mpicc))
 
         return config_args

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -43,12 +43,11 @@ class NetcdfCxx4(AutotoolsPackage):
             flags.append(self.compiler.cxx_pic_flag)
         elif name == 'cppflags':
             flags.append('-I' + self.spec['netcdf-c'].prefix.include)
-        elif name == 'ldflags':
-            # On macOS, we need to explicitly add the linker flags
-            # for the netcdf-c library.
-            if self.spec.satisfies("platform=darwin"):
-                flags = [self.spec['netcdf-c'].libs.search_flags,
-                         self.spec['netcdf-c'].libs.link_flags] + flags
+        elif name == 'ldlibs':
+            # Address the underlinking problem reported in
+            # https://github.com/Unidata/netcdf-cxx4/issues/86, which also
+            # results into a linking error on macOS:
+            flags.append(self.spec['netcdf-c'].libs.link_flags)
 
         # Note that cflags and cxxflags should be added by the compiler wrapper
         # and not on the command line to avoid overriding the default

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -77,3 +77,7 @@ class NetcdfCxx4(AutotoolsPackage):
             config_args.append('CC={0}'.format(self.spec['mpi'].mpicc))
 
         return config_args
+
+    def check(self):
+        with working_dir(self.build_directory):
+            make('check', parallel=False)

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -22,8 +22,6 @@ class NetcdfCxx4(AutotoolsPackage):
     version('4.3.0', sha256='e34fbc6aba243ec82c23e9ee99db2430555ada849c54c1f3ab081b0ddd0f5f30')
 
     variant('shared', default=True, description='Enable shared library')
-    # Usually the configure automatically inserts the pic flags, but we can
-    # force its usage with this variant.
     variant('pic', default=True, description='Produce position-independent code (for shared libs)')
     variant('doc', default=False, description='Enable doxygen docs')
 
@@ -127,9 +125,10 @@ class NetcdfCxx4(AutotoolsPackage):
         # autoreconf and introduce additional dependencies. We do not generate a
         # patch for the configure script because the patched string contains the
         # version and we would need a patch file for each supported version of
-        # the library. We do not do implement a patch method because writing a
-        # robust regexp seems to be more difficult that simply renaming the file
-        # if exists.
+        # the library. We do not implement the patching with filter_file in the
+        # patch method because writing a robust regexp seems to be more
+        # difficult that simply renaming the file if exists. It also looks like
+        # we can simply remove the file since it is not used anywhere.
         if not self.spec.satisfies('@:4.3.1 platform=darwin'):
             return
 

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -52,10 +52,29 @@ class NetcdfCxx4(AutotoolsPackage):
 
     @property
     def libs(self):
-        shared = True
-        return find_libraries(
-            'libnetcdf_c++4', root=self.prefix, shared=shared, recursive=True
+        libraries = ['libnetcdf_c++4']
+
+        query_parameters = self.spec.last_query.extra_parameters
+
+        if 'shared' in query_parameters:
+            shared = True
+        elif 'static' in query_parameters:
+            shared = False
+        else:
+            shared = '+shared' in self.spec
+
+        libs = find_libraries(
+            libraries, root=self.prefix, shared=shared, recursive=True
         )
+
+        if libs:
+            return libs
+
+        msg = 'Unable to recursively locate {0} {1} libraries in {2}'
+        raise spack.error.NoLibrariesError(
+            msg.format('shared' if shared else 'static',
+                       self.spec.name,
+                       self.spec.prefix))
 
     @when('@4.3.1:+shared')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -49,7 +49,11 @@ class NetcdfCxx4(AutotoolsPackage):
             if self.spec.satisfies("platform=darwin"):
                 flags = [self.spec['netcdf-c'].libs.search_flags,
                          self.spec['netcdf-c'].libs.link_flags] + flags
-        return (None, None, flags)
+
+        # Note that cflags and cxxflags should be added by the compiler wrapper
+        # and not on the command line to avoid overriding the default
+        # compilation flags set by the configure script:
+        return flags, None, None
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -19,7 +19,6 @@ class NetcdfCxx4(AutotoolsPackage):
     version('4.3.1', sha256='6a1189a181eed043b5859e15d5c080c30d0e107406fbb212c8fb9814e90f3445')
     version('4.3.0', sha256='e34fbc6aba243ec82c23e9ee99db2430555ada849c54c1f3ab081b0ddd0f5f30')
 
-    variant('static', default=True, description='Enable building static libraries')
     variant('shared', default=True, description='Enable shared library')
     # Usually the configure automatically inserts the pic flags, but we can
     # force its usage with this variant.
@@ -29,8 +28,6 @@ class NetcdfCxx4(AutotoolsPackage):
     depends_on('netcdf-c')
 
     depends_on('doxygen', when='+doc', type='build')
-
-    conflicts('~shared', when='~static')
 
     # See https://github.com/Unidata/netcdf-cxx4/issues/109
     patch('https://github.com/Unidata/netcdf-cxx4/commit/e7cc5bab02cf089dc79616456a0a951fee979fe9.patch',
@@ -61,8 +58,7 @@ class NetcdfCxx4(AutotoolsPackage):
         )
 
     def configure_args(self):
-        config_args = self.enable_or_disable('static')
-        config_args += self.enable_or_disable('shared')
+        config_args = self.enable_or_disable('shared')
         config_args += self.with_or_without('pic')
 
         if '+doc' in self.spec:

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -19,10 +19,10 @@ class NetcdfCxx4(AutotoolsPackage):
     version('4.3.1', sha256='6a1189a181eed043b5859e15d5c080c30d0e107406fbb212c8fb9814e90f3445')
     version('4.3.0', sha256='e34fbc6aba243ec82c23e9ee99db2430555ada849c54c1f3ab081b0ddd0f5f30')
 
-    # Usually the configure automatically inserts the pic flags, but we can
-    # force its usage with this variant.
     variant('static', default=True, description='Enable building static libraries')
     variant('shared', default=True, description='Enable shared library')
+    # Usually the configure automatically inserts the pic flags, but we can
+    # force its usage with this variant.
     variant('pic', default=True, description='Produce position-independent code (for shared libs)')
     variant('doc', default=False, description='Enable doxygen docs')
 
@@ -32,6 +32,7 @@ class NetcdfCxx4(AutotoolsPackage):
 
     conflicts('~shared', when='~static')
 
+    # See https://github.com/Unidata/netcdf-cxx4/issues/109
     patch('https://github.com/Unidata/netcdf-cxx4/commit/e7cc5bab02cf089dc79616456a0a951fee979fe9.patch',
           sha256='4ddf6db9dc0c5f754cb3d68b1dbef8c385cf499f6e5df8fbccae3749336ba84a',
           when='@:4.3.1 platform=darwin')

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -41,8 +41,6 @@ class NetcdfCxx4(AutotoolsPackage):
             flags.append(self.compiler.cc_pic_flag)
         if name == 'cxxflags' and '+pic' in self.spec:
             flags.append(self.compiler.cxx_pic_flag)
-        elif name == 'cppflags':
-            flags.append('-I' + self.spec['netcdf-c'].prefix.include)
         elif name == 'ldlibs':
             # Address the underlinking problem reported in
             # https://github.com/Unidata/netcdf-cxx4/issues/86, which also

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -51,7 +51,7 @@ class NetcdfCxx4(AutotoolsPackage):
             # On macOS, we need to explicitly add the linker flags
             # for the netcdf-c library.
             if self.spec.satisfies("platform=darwin"):
-                flags = [self.spec['netcdf-c'].libs.search_flags, 
+                flags = [self.spec['netcdf-c'].libs.search_flags,
                          self.spec['netcdf-c'].libs.link_flags] + flags
         return (None, None, flags)
 

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -62,7 +62,6 @@ class NetcdfFortran(AutotoolsPackage):
     patch('no_parallel_build.patch', when='@4.5.2')
 
     def flag_handler(self, name, flags):
-
         if name == 'cflags':
             if '+pic' in self.spec:
                 flags.append(self.compiler.cc_pic_flag)
@@ -81,7 +80,10 @@ class NetcdfFortran(AutotoolsPackage):
                 # files with lowercase names.
                 flags.append('-ef')
 
-        return (None, None, flags)
+        # Note that cflags and fflags should be added by the compiler wrapper
+        # and not on the command line to avoid overriding the default
+        # compilation flags set by the configure script:
+        return flags, None, None
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -62,7 +62,6 @@ class NetcdfFortran(AutotoolsPackage):
     patch('no_parallel_build.patch', when='@4.5.2')
 
     def flag_handler(self, name, flags):
-        config_flags = None
 
         if name == 'cflags':
             if '+pic' in self.spec:

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -84,7 +84,7 @@ class NetcdfFortran(AutotoolsPackage):
         elif name == 'ldflags':
             # We need to specify LDFLAGS to get correct dependency_libs
             # in libnetcdff.la, so packages that use libtool for linking
-            # could correctly link to all the dependencies even when the
+            # can correctly link to all the dependencies even when the
             # building takes place outside of Spack environment, i.e.
             # without Spack's compiler wrappers.
             config_flags = [self.spec['netcdf-c'].libs.search_flags]

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -81,15 +81,8 @@ class NetcdfFortran(AutotoolsPackage):
                 # The following flag forces the compiler to produce module
                 # files with lowercase names.
                 flags.append('-ef')
-        elif name == 'ldflags':
-            # We need to specify LDFLAGS to get correct dependency_libs
-            # in libnetcdff.la, so packages that use libtool for linking
-            # can correctly link to all the dependencies even when the
-            # building takes place outside of Spack environment, i.e.
-            # without Spack's compiler wrappers.
-            config_flags = [self.spec['netcdf-c'].libs.search_flags]
 
-        return flags, None, config_flags
+        return (None, None, flags)
 
     @property
     def libs(self):


### PR DESCRIPTION
Updates to several packages.

The ESMF updates are also here (same commit hash): https://github.com/spack/spack/pull/29193

Changes to netcdf-cxx4/package.py and netcdf-fortran/package.py are identical to what is in https://github.com/spack/spack/pull/29246 (additional updates from the code review process) - same commit hashes.

@kgerheiser This is ready for merge, any additional updates/bugfixes to netcdf-c and parallel-netcdf to solve the problems on orion will come in via a follow-up PR.