### PR TITLE
Continue to use Cray wrappers for MPI in cray-mpich for WCOSS2

### DIFF
--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -59,17 +59,10 @@ class CrayMpich(Package):
                 return os.path.dirname(os.path.normpath(libdir))
 
     def setup_run_environment(self, env):
-        if(self.spec.satisfies('@:8.1.6')):
-            env.set('MPICC', spack_cc)
-            env.set('MPICXX', spack_cxx)
-            env.set('MPIF77', spack_fc)
-            env.set('MPIF90', spack_fc)
-        else:
-            # cray-mpich 8.1.7: features MPI compiler wrappers
-            env.set('MPICC', join_path(self.prefix.bin, 'mpicc'))
-            env.set('MPICXX', join_path(self.prefix.bin, 'mpicxx'))
-            env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
-            env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
+        env.set('MPICC', spack_cc)
+        env.set('MPICXX', spack_cxx)
+        env.set('MPIF77', spack_fc)
+        env.set('MPIF90', spack_fc)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_run_environment(env)

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -81,11 +81,10 @@ class CrayMpich(Package):
 
     def setup_dependent_package(self, module, dependent_spec):
         spec = self.spec
-        if(spec.satisfies('@:8.1.6')):
-            spec.mpicc = spack_cc
-            spec.mpicxx = spack_cxx
-            spec.mpifc = spack_fc
-            spec.mpif77 = spack_f77
+        spec.mpicc = spack_cc
+        spec.mpicxx = spack_cxx
+        spec.mpifc = spack_fc
+        spec.mpif77 = spack_f77
 
     def install(self, spec, prefix):
         raise InstallError(

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -86,12 +86,6 @@ class CrayMpich(Package):
             spec.mpicxx = spack_cxx
             spec.mpifc = spack_fc
             spec.mpif77 = spack_f77
-        else:
-            # cray-mpich 8.1.7: features MPI compiler wrappers
-            spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
-            spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
-            spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
-            spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
 
     def install(self, spec, prefix):
         raise InstallError(


### PR DESCRIPTION
This comment says `cray-mpich 8.1.7` and above should have the regular MPI wrappers, but on WCOSS2 with `cray-mpich/8.1.9` it doesn't. 

Only `CC`, `cc`, `ftn` are available.

