### PR TITLE
Some intel compilers require adding flag -std=c99 when building Jasper

### DIFF
--- a/var/spack/repos/builtin/packages/jasper/package.py
+++ b/var/spack/repos/builtin/packages/jasper/package.py
@@ -36,6 +36,7 @@ class Jasper(Package):
         spec = self.spec
         args = std_cmake_args
         args.append('-DJAS_ENABLE_DOC=false')
+        args.append('-DCMAKE_C_FLAGS=-std=c99')
 
         if '+jpeg' in spec:
             args.append('-DJAS_ENABLE_LIBJPEG=true')


### PR DESCRIPTION
Weird Cheyenne's Intel compilers (2021.2.0) want to have the flag `-std=c99` for compiling Jasper 2.0.20-2.0.32. This shouldn't do any harm for other versions or compilers. Tested to work on Gaea and Cheyenne.