### PR TITLE
Add guard to prevent static eckit and building with cmake 3.20 and 3.21 / bug fix in py-numpy for detecting gcc version on cray

### DIFF
--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -26,6 +26,7 @@ class Eckit(CMakePackage):
 
     version('1.16.0', sha256='9e09161ea6955df693d3c9ac70131985eaf7cf24a9fa4d6263661c6814ebbaf1')
 
+    variant('shared', default=True, description='Build shared libraries')
     variant('tools', default=True, description='Build the command line tools')
     variant('mpi', default=True, description='Enable MPI support')
     variant('admin', default=True,
@@ -50,7 +51,8 @@ class Eckit(CMakePackage):
                         'parsers')
     variant('aio', default=True, description='Enable asynchronous IO')
 
-    depends_on('cmake@3.12:', type='build')
+    # Build issues with cmake 3.20, not sure about 3.21
+    depends_on('cmake@3.12:3.19,3.22:', type='build')
     depends_on('ecbuild@3.5:', type='build')
 
     depends_on('mpi', when='+mpi')
@@ -136,6 +138,12 @@ class Eckit(CMakePackage):
             # Disable "prototyping code that may never see the light of day":
             self.define('ENABLE_SANDBOX', False)
         ]
+
+        # Static build of eckit not working, many places in eckit's build
+        # system have SHARED hardcoded (in several CMakeLists.txt files).
+        if '~shared' in self.spec:
+            #args.append('-DBUILD_SHARED_LIBS=OFF')
+            raise InstrallError("eckit static build not supported")
 
         if '+mpi' in self.spec:
             args += [

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -146,7 +146,13 @@ class PyNumpy(PythonPackage):
         # This will essentially check the system gcc compiler unless a gcc
         # module is already loaded.
         if self.spec.satisfies('%intel') and name == 'cflags':
-            if "platform=cray" in self.spec:
+            # Note that the compiler environment variables and modules
+            # aren't loaded for the flag_handler phase ... 
+            # See https://github.com/spack/spack/issues/2056
+            #
+            # Newer/other flavors of Cray systems using the Intel compilers directly
+            # (icc, ...), therefore use this workaround only if 'cc' is used.
+            if self.compiler.cc == 'cc':
                 gcc_version = Version(spack.compiler.get_compiler_version_output('gcc', '-dumpversion'))
                 # Note that this only returns the major versions on some systems,
                 # to be on the safe side add a guard here to prevent versions <6


### PR DESCRIPTION
### eckit

eckit doesn't build static libraries, because in many of its `CMakeLists.txt` files SHARED is hardcoded. This PR adds a guard to prevent users from attempting a static build.

eckit also doesn't build with cmake 3.20, not sure about 3.21. It builds fine with versions up to 3.19 (incl) and with 3.22+. The official spack repo had a strict dependency on 3.19, @kgerheiser took that out, but many of our systems have a cmake 3.20 that gets found by `spack external find`. This PR excludes 3.20 and 3.21 for building eckit, removing the need to manually remove cmake 3.20 from the externals found by spack.

Fixes https://github.com/NOAA-EMC/spack-stack/issues/44.

### py-numpy

The second change is a bug fix for detecting the `gcc` version when the Intel compiler is used in `py-numpy`. The issue is that on Cray systems using `cc` (e.g. gaea), the original logic (`icc -v` --> parse output `icc version 2021.5.0 (gcc version 4.8.5 compatibility)`) didn't work. So I added the workaround to run `gcc` directly, which cannot detect minor version numbers if `gcc < 6`. On hera, this doesn't work, because of the issue mentioned in the note (https://github.com/spack/spack/issues/2056) - it therefore calls the default OS `gcc` with version `4.8.5`. The "workaround" is to check if the C compiler is `cc` instead of if the platform is `cray`.

I think that the entire block is still not really correct, because either way it finds the default/OS `gcc` and adds the modules/env variables in the compiler spec, but it "works" because the flags that get added (C99 std) work with any gcc compiler 4.8.5+. 