### PR TITLE
Bugfix for parallelio <= 2.5.6 with mpich-4.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -22,6 +22,8 @@ class Parallelio(CMakePackage):
     variant('pnetcdf', default=False, description='enable pnetcdf')
     variant('timing', default=False, description='enable GPTL timing')
 
+    patch('remove_redefinition_of_mpi_offset.patch', when='@:2.5.6')
+
     depends_on('mpi')
     depends_on('netcdf-c +mpi', type='link')
     depends_on('netcdf-fortran', type='link')

--- a/var/spack/repos/builtin/packages/parallelio/remove_redefinition_of_mpi_offset.patch
+++ b/var/spack/repos/builtin/packages/parallelio/remove_redefinition_of_mpi_offset.patch
@@ -1,0 +1,35 @@
+--- a/src/clib/pio_internal.h
++++ b/src/clib/pio_internal.h
+@@ -30,12 +30,12 @@
+ #include <mpe.h>
+ #endif /* USE_MPE */
+ 
+-#ifndef MPI_OFFSET
++//#ifndef MPI_OFFSET
+ /** MPI_OFFSET is an integer type of size sufficient to represent the
+  * size (in bytes) of the largest file supported by MPI. In some MPI
+  * implementations MPI_OFFSET is not properly defined.  */
+-#define MPI_OFFSET  MPI_LONG_LONG
+-#endif
++//#define MPI_OFFSET  MPI_LONG_LONG
++//#endif
+ 
+ /* These are the sizes of types in netCDF files. Do not replace these
+  * constants with sizeof() calls for C types. They are not the
+@@ -57,10 +57,10 @@
+ #define MPI_OFFSET OMPI_OFFSET_DATATYPE
+ #endif
+ #endif
+-#ifndef MPI_Offset
++//#ifndef MPI_Offset
+ /** This is the type used for PIO_Offset. */
+-#define MPI_Offset long long
+-#endif
++//#define MPI_Offset long long
++//#endif
+ 
+ /** Some MPI implementations do not allow passing MPI_DATATYPE_NULL to
+  * comm functions even though the send or recv length is 0, in these
+-- 
+2.34.1
+


### PR DESCRIPTION
Bug fix for parallelio <= 2.5.6 with mpich-4.0.1. The bug fix commit to the official PIO github repository was made after 2.5.6 was released, thus it is reasonable to assume that any later version will have it included.