### PR TITLE
bugfix/py-cffi for macOS with gcc

### DIFF
--- a/var/spack/repos/builtin/packages/py-cffi/macos_gnu.patch
+++ b/var/spack/repos/builtin/packages/py-cffi/macos_gnu.patch
@@ -1,0 +1,16 @@
+--- a/setup.py	2022-03-18 19:23:11.000000000 -0600
++++ b/setup.py	2022-03-18 19:25:38.000000000 -0600
+@@ -148,9 +148,10 @@
+     ask_supports_thread()
+     ask_supports_sync_synchronize()
+ 
+-if 'darwin' in sys.platform:
+-    # priority is given to `pkg_config`, but always fall back on SDK's libffi.
+-    extra_compile_args += ['-iwithsysroot/usr/include/ffi']
++# Remove fallback to SDK's libffi when using GNU's gcc instead of clang
++#if 'darwin' in sys.platform:
++#    # priority is given to `pkg_config`, but always fall back on SDK's libffi.
++#    extra_compile_args += ['-iwithsysroot/usr/include/ffi']
+ 
+ if 'freebsd' in sys.platform:
+     include_dirs.append('/usr/local/include')

--- a/var/spack/repos/builtin/packages/py-cffi/package.py
+++ b/var/spack/repos/builtin/packages/py-cffi/package.py
@@ -28,6 +28,12 @@ class PyCffi(PythonPackage):
     depends_on('py-pycparser', type=('build', 'run'))
     depends_on('libffi')
 
+    # Fix a bug in setup.py: on macOS, extra compiler flags
+    #    extra_compile_args += ['-iwithsysroot/usr/include/ffi']
+    # are added as a fallback to SDK's libffi, but this only
+    # works with "gcc" being clang, not with gnu gcc
+    patch('macos_gnu.patch', when='platform=darwin %gcc')
+
     def setup_build_environment(self, env):
         # This sets the compiler (and flags) that distutils will use
         # to create the final shared library.  It will use the


### PR DESCRIPTION
Fixes #25 by patching `setup.py` when using `gcc` on macOS`.