### PR TITLE
bug fix for py-scipy: apply patch for macOS with gcc+gfortran

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -87,6 +87,15 @@ class PyScipy(PythonPackage):
 
     patch('scipy-clang.patch', when='@1.5.0:1.6.3 %clang')
 
+    # On macOS with GNU gcc instead of Apple/LLVM clang:
+    # build/src.macosx-12-x86_64-3.9/scipy/integrate/vodemodule.c:94:10:
+    #   fatal error: threads.h: No such file or directory
+    #      94 | #include <threads.h>
+    #         |          ^~~~~~~~~~~
+    #   compilation terminated.
+    # See also: https://github.com/macports/macports-ports/commit/d45376ea224ffa9184c6a0ecbcbdf024ee447f12
+    patch('use_stdc_no_threads.patch', when='platform=darwin %gcc')
+
     def setup_build_environment(self, env):
         # https://github.com/scipy/scipy/issues/9080
         env.set('F90', spack_fc)

--- a/var/spack/repos/builtin/packages/py-scipy/use_stdc_no_threads.patch
+++ b/var/spack/repos/builtin/packages/py-scipy/use_stdc_no_threads.patch
@@ -1,0 +1,54 @@
+--- a/scipy/integrate/setup.py
++++ b/scipy/integrate/setup.py
+@@ -37,9 +37,9 @@
+     config.add_library('mach', sources=mach_src, config_fc={'noopt': (__file__, 1)},
+                        _pre_build_hook=pre_build_hook)
+     config.add_library('quadpack', sources=quadpack_src, _pre_build_hook=pre_build_hook)
+-    config.add_library('lsoda', sources=lsoda_src, _pre_build_hook=pre_build_hook)
+-    config.add_library('vode', sources=vode_src, _pre_build_hook=pre_build_hook)
+-    config.add_library('dop', sources=dop_src, _pre_build_hook=pre_build_hook)
++    config.add_library('lsoda', sources=lsoda_src, _pre_build_hook=pre_build_hook, macros=[('__STDC_NO_THREADS__',1)])
++    config.add_library('vode', sources=vode_src, _pre_build_hook=pre_build_hook, macros=[('__STDC_NO_THREADS__',1)])
++    config.add_library('dop', sources=dop_src, _pre_build_hook=pre_build_hook, macros=[('__STDC_NO_THREADS__',1)])
+
+     # Extensions
+     # quadpack:
+--- a/scipy/linalg/setup.py
++++ b/scipy/linalg/setup.py
+@@ -59,7 +59,8 @@
+     config.add_extension('_flapack',
+                          sources=sources,
+                          depends=depends,
+-                         extra_info=lapack_opt
++                         extra_info=lapack_opt,
++                         define_macros=[('__STDC_NO_THREADS__',1)]
+                          )
+
+     if uses_blas64():
+@@ -96,7 +97,8 @@
+     ext = config.add_extension('_interpolative',
+                                sources=[join('src', 'id_dist', 'src', '*.f'),
+                                         "interpolative.pyf"],
+-                               extra_info=lapack_opt
++                               extra_info=lapack_opt,
++                               define_macros=[('__STDC_NO_THREADS__',1)]
+                                )
+     ext._pre_build_hook = gfortran_legacy_flag_hook
+
+--- a/scipy/optimize/setup.py
++++ b/scipy/optimize/setup.py
+@@ -78,10 +78,13 @@
+                          depends=[join('tnc', 'tnc.h')],
+                          **numpy_nodepr_api)
+
++    local_macros = numpy_nodepr_api
++    local_macros['define_macros'].append(('__STDC_NO_THREADS__',1))
++
+     config.add_extension('_cobyla',
+                          sources=[join('cobyla', x) for x in [
+                              'cobyla.pyf', 'cobyla2.f', 'trstlp.f']],
+-                         **numpy_nodepr_api)
++                         **local_macros)
+
+     sources = ['minpack2.pyf', 'dcsrch.f', 'dcstep.f']
+     config.add_extension('minpack2',


### PR DESCRIPTION
As the title says. 

The error is:
```
build/src.macosx-12-x86_64-3.9/scipy/integrate/vodemodule.c:94:10:
   fatal error: threads.h: No such file or directory
      94 | #include <threads.h>
         |          ^~~~~~~~~~~
   compilation terminated.
```

The solution is taken from here: https://github.com/macports/macports-ports/commit/d45376ea224ffa9184c6a0ecbcbdf024ee447f12
