### PR TITLE
Bug fix (patch) for nco-5.0.1+ with Intel

### DIFF
--- a/var/spack/repos/builtin/packages/nco/nco-5_0_1-intel-omp.patch
+++ b/var/spack/repos/builtin/packages/nco/nco-5_0_1-intel-omp.patch
@@ -1,0 +1,11 @@
+--- a/src/nco/nco_rgr.c	2022-03-22 17:14:58.000000000 -0600
++++ b/src/nco/nco_rgr.c	2022-03-22 17:18:03.000000000 -0600
+@@ -4847,7 +4847,7 @@
+ # endif /* 900 */
+ #endif /* !__GNUC__ */
+ #if defined( __INTEL_COMPILER)
+-# pragma omp parallel for default(none) firstprivate(dmn_cnt_in,dmn_cnt_out,dmn_srt,dmn_id_in,dmn_id_out,tally,var_val_dbl_in,var_val_dbl_out,wgt_vld_out) private(dmn_idx,dmn_nbr_in,dmn_nbr_out,dmn_nbr_max,dst_idx,has_mss_val,idx,idx_in,idx_out,idx_tbl,in_id,lnk_idx,lvl_idx,lvl_nbr,mss_val_dbl,rcd,thr_idx,trv,val_in_fst,val_out_fst,var_id_in,var_id_out,var_nm,var_sz_in,var_sz_out,var_typ_out,var_typ_rgr,var_val_crr) shared(col_src_adr,dmn_nbr_hrz_crd,flg_add_fll,flg_frc_nrm,flg_msk_apl,flg_msk_out,flg_rnr,fnc_nm,frc_out,lnk_nbr,out_id,row_dst_adr,sgs_frc_nm,sgs_frc_in,sgs_frc_out,sgs_msk_nm,wgt_raw,wgt_vld_thr)
++# pragma omp parallel for default(none) firstprivate(dmn_cnt_in,dmn_cnt_out,dmn_srt,dmn_id_in,dmn_id_out,tally,var_val_dbl_in,var_val_dbl_out,wgt_vld_out) private(dmn_idx,dmn_nbr_in,dmn_nbr_out,dmn_nbr_max,dst_idx,has_mss_val,idx,idx_in,idx_out,idx_tbl,in_id,lnk_idx,lvl_idx,lvl_nbr,mss_val_dbl,rcd,thr_idx,trv,val_in_fst,val_out_fst,var_id_in,var_id_out,var_nm,var_sz_in,var_sz_out,var_typ_out,var_typ_rgr,var_val_crr) shared(col_src_adr,dmn_nbr_hrz_crd,flg_add_fll,flg_frc_nrm,flg_msk_apl,flg_msk_out,flg_rnr,fnc_nm,frc_out,lnk_nbr,out_id,row_dst_adr,sgs_frc_nm,sgs_frc_in,sgs_frc_out,sgs_msk_nm,wgt_raw,wgt_vld_thr,msk_out)
+ #else /* !__INTEL_COMPILER */
+ # ifdef GXX_OLD_OPENMP_SHARED_TREATMENT
+ #  pragma omp parallel for default(none) firstprivate(dmn_cnt_in,dmn_cnt_out,dmn_srt,dmn_id_in,dmn_id_out,tally,var_val_dbl_in,var_val_dbl_out,wgt_vld_out) private(dmn_idx,dmn_nbr_in,dmn_nbr_out,dmn_nbr_max,dst_idx,has_mss_val,idx,idx_in,idx_out,idx_tbl,in_id,lnk_idx,lvl_idx,lvl_nbr,mss_val_dbl,rcd,thr_idx,trv,val_in_fst,val_out_fst,var_id_in,var_id_out,var_nm,var_sz_in,var_sz_out,var_typ_out,var_typ_rgr,var_val_crr) shared(col_src_adr,dmn_nbr_hrz_crd,flg_add_fll,flg_frc_nrm,flg_msk_apl,flg_msk_out,flg_rnr,fnc_nm,frc_out,lnk_nbr,out_id,row_dst_adr,sgs_frc_nm,sgs_frc_in,sgs_frc_out,sgs_msk_nm,wgt_raw)

--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -13,6 +13,7 @@ class Nco(AutotoolsPackage):
     homepage = "http://nco.sourceforge.net/"
     url      = "https://github.com/nco/nco/archive/5.0.1.tar.gz"
 
+    version('5.0.6', sha256='37d11ffe582aa0ee89f77a7b9a176b41e41900e9ab709e780ec0caf52ad60c4b')
     version('5.0.1', sha256='37d11ffe582aa0ee89f77a7b9a176b41e41900e9ab709e780ec0caf52ad60c4b')
     version('4.9.3', sha256='eade5b79f3814b11ae3f52c34159567e76a73f05f0ab141eccaac68f0ca94aee')
     version('4.9.2', sha256='1a98c37c946c00232fa7319d00d1d80f77603adda7c9239d10d68a8a3545a4d5')
@@ -32,6 +33,9 @@ class Nco(AutotoolsPackage):
 
     # https://github.com/nco/nco/issues/43
     patch('NUL-0-NULL.patch', when='@:4.6.7')
+
+    # https://githubhot.com/repo/nco/nco/issues/244
+    patch('nco-5_0_1-intel-omp.patch', when='@5.0.1: %intel')
 
     variant('doc', default=False, description='Build/install NCO TexInfo-based documentation')
 


### PR DESCRIPTION
Issue: https://githubhot.com/repo/nco/nco/issues/244

This patch fixes the problem that variable `msk_out` needs to be in the `shared` OMP directive to avoid a compiler error with Intel.

Note: According to the above issue page, it should have been fixed in 5.0.2. I checked the code in 5.0.6 and the bug was still there.