### PR TITLE
Work in progress: Bug fix for building cmake 3.20+ on macOS with GNU gcc

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/include_memory_dot_h.patch
+++ b/var/spack/repos/builtin/packages/cmake/include_memory_dot_h.patch
@@ -1,0 +1,10 @@
+--- a/Source/cmMachO.h	2022-03-22 21:13:23.000000000 -0600
++++ b/Source/cmMachO.h	2022-03-22 21:13:15.000000000 -0600
+@@ -5,6 +5,7 @@
+ #include "cmConfigure.h" // IWYU pragma: keep
+ 
+ #include <iosfwd>
++#include <memory>
+ #include <string>
+ 
+ #if !defined(CMake_USE_MACH_PARSER)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -141,6 +141,9 @@ class Cmake(Package):
     # https://gitlab.kitware.com/cmake/cmake/merge_requests/4075
     patch('fix-xlf-ninja-mr-4075.patch', sha256="42d8b2163a2f37a745800ec13a96c08a3a20d5e67af51031e51f63313d0dedd1", when="@3.15.5")
 
+    # Add missing '#include <memory>' to Source/cmMachO.h - fixed for 3.23+
+    patch('include_memory_dot_h.patch', when='@:3.22.9')
+
     # We default ownlibs to true because it greatly speeds up the CMake
     # build, and CMake is built frequently. Also, CMake is almost always
     # a build dependency, and its libs will not interfere with others in


### PR DESCRIPTION
This PR so far contains the first of ? bug fixes required to build cmake 3.20+ on macOS with GNU gcc. Since cmake can easily be installed with homebrew and since it doesn't need to be installed in a consistent way with the same compiler as the rest of spack-stack, this may be moot. But for now I wanted to keep the work that I did on this.