### PR TITLE
Bugfix: set correct path to MPI library in parallel-netcdf with intel-oneapi-mpi, follow-up on nco patch

### DIFF
--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -35,7 +35,7 @@ class Nco(AutotoolsPackage):
     patch('NUL-0-NULL.patch', when='@:4.6.7')
 
     # https://githubhot.com/repo/nco/nco/issues/244
-    patch('nco-5_0_1-intel-omp.patch', when='@5.0.1: %intel')
+    patch('nco-5_0_1-intel-omp.patch', when='@5.0.1 %intel')
 
     variant('doc', default=False, description='Build/install NCO TexInfo-based documentation')
 

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -131,13 +131,12 @@ class ParallelNetcdf(AutotoolsPackage):
             # the repository.
             autoreconf('-iv')
 
-    def setup_build_environment(self, env):
-        if self.spec['mpi'].satisfies('intel-oneapi-mpi'):
-            # fix I_MPI_SUBSTITUTE_INSTALLDIR problem by setting I_MPI_ROOT
-            env.set('I_MPI_ROOT', self.spec['mpi'].prefix)
-
     def configure_args(self):
-        args = ['--with-mpi=%s' % self.spec['mpi'].prefix,
+        if self.spec['mpi'].satisfies('intel-oneapi-mpi'):
+            prefix = os.path.join(self.spec['mpi'].prefix, 'mpi', str(self.spec['mpi'].version))
+        else:
+            prefix = self.spec['mpi'].prefix
+        args = ['--with-mpi=%s' % prefix,
                 'SEQ_CC=%s' % spack_cc]
 
         args += self.enable_or_disable('cxx')


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/spack/issues/34 by using a different (the correct) path to the intel-oneapi-mpi installation. Tested on NASA Discover.

Also included: follow-up on nco patch, only apply for version 5.0.1 because the problem was fixed in 5.0.6.