### PR TITLE
Updates for netcdf-fortran and ESMF to find netcdf-c (required on Discover with Intel OneAPI)

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -236,9 +236,12 @@ class Esmf(MakefilePackage):
                 # are archived together in the same library file.
                 os.environ['ESMF_NETCDF'] = 'standard'
 
-            # FIXME: determine whether or not we need to set these.
-            # ESMF_NETCDF_INCLUDE
-            # ESMF_NETCDF_LIBPATH
+            os.environ['ESMF_NETCDF_INCLUDE'] = '{}:{}'.format(
+                spec['netcdf-fortran'].prefix.include,
+                spec['netcdf-c'].prefix.include)
+            os.environ['ESMF_NETCDF_LIBPATH'] = '{}:{}'.format(
+                spec['netcdf-fortran'].libs.search_flags,
+                spec['netcdf-c'].libs.search_flags)
 
         ###################
         # Parallel-NetCDF #

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -225,23 +225,8 @@ class Esmf(MakefilePackage):
         if '+netcdf' in spec:
             # ESMF provides the ability to read Grid and Mesh data in
             # NetCDF format.
-            if spec.satisfies('^netcdf-c@4.2:'):
-                # ESMF_NETCDF_LIBS will be set to "-lnetcdff -lnetcdf".
-                # This option is useful for systems which have the Fortran
-                # and C bindings archived in seperate library files.
-                os.environ['ESMF_NETCDF'] = 'split'
-            else:
-                # ESMF_NETCDF_LIBS will be set to "-lnetcdf".
-                # This option is useful when the Fortran and C bindings
-                # are archived together in the same library file.
-                os.environ['ESMF_NETCDF'] = 'standard'
-
-            os.environ['ESMF_NETCDF_INCLUDE'] = '{}:{}'.format(
-                spec['netcdf-fortran'].prefix.include,
-                spec['netcdf-c'].prefix.include)
-            os.environ['ESMF_NETCDF_LIBPATH'] = '{}:{}'.format(
-                spec['netcdf-fortran'].libs.search_flags,
-                spec['netcdf-c'].libs.search_flags)
+            os.environ['ESMF_NETCDF'] = 'nc-config'
+            os.environ['ESMF_NFCONFIG'] = 'nf-config'
 
         ###################
         # Parallel-NetCDF #

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -115,10 +115,17 @@ class NetcdfFortran(AutotoolsPackage):
         config_args = self.enable_or_disable('shared')
         config_args.append('--enable-static')
 
+        netcdf_c_spec = self.spec['netcdf-c']
+
+        # Fix a bug on some systems using Intel OneAPI where the netCDF-c
+        # headers and libraries are not found. This doesn't hurt on other systems.
+        config_args.append('CPPFLAGS=-I%s' % netcdf_c_spec.prefix.include)
+        config_args.append('LDLFAGS=%s' % netcdf_c_spec.libs.search_flags)
+        config_args.append('LIBS=%s' % netcdf_c_spec.libs.link_flags)
+
         # We need to build with MPI wrappers if either of the parallel I/O
         # features is enabled in netcdf-c:
         # https://www.unidata.ucar.edu/software/netcdf/docs/building_netcdf_fortran.html
-        netcdf_c_spec = self.spec['netcdf-c']
         if '+mpi' in netcdf_c_spec or '+parallel-netcdf' in netcdf_c_spec:
             config_args.append('CC=%s' % self.spec['mpi'].mpicc)
             config_args.append('FC=%s' % self.spec['mpi'].mpifc)


### PR DESCRIPTION
Yet another weird problem. On Discover with the Intel OneAPI installation provided as a module by the sysadmins, several packages need to be told explicitly where to find netCDF-c. This wasn't needed when I installed Intel OneAPI myself, but using the default Intel OneAPI means not having the HPC customizations in the IMPI module (specific settings for slurm, topography, ...).

These updates don't hurt on any of the other system so they shouldn't be a problem.

Fixes https://github.com/NOAA-EMC/spack/issues/37.