### PR TITLE
Bug fix in var/spack/repos/builtin/packages/glib/package.py when 'gettext' list is empty

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -282,10 +282,11 @@ class Glib(Package):
         # appropriate -L path.
         spec = self.spec
         if spec.satisfies('@2.0:2'):
-            pattern = 'Libs:'
-            repl = 'Libs: -L{0} -Wl,-rpath={0} '.format(
-                   spec['gettext'].libs.directories[0])
-            myfile = join_path(
-                self.spec['glib'].libs.directories[0],
-                'pkgconfig', 'glib-2.0.pc')
-            filter_file(pattern, repl, myfile, backup=False)
+            if spec['gettext'].libs.directories:
+                pattern = 'Libs:'
+                repl = 'Libs: -L{0} -Wl,-rpath={0} '.format(
+                       spec['gettext'].libs.directories[0])
+                myfile = join_path(
+                    self.spec['glib'].libs.directories[0],
+                    'pkgconfig', 'glib-2.0.pc')
+                filter_file(pattern, repl, myfile, backup=False)


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/spack/issues/39.