### PR TITLE
Fix NCO 5.0.1+ build with Intel again

### DIFF
--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -35,7 +35,7 @@ class Nco(AutotoolsPackage):
     patch('NUL-0-NULL.patch', when='@:4.6.7')
 
     # https://githubhot.com/repo/nco/nco/issues/244
-    patch('nco-5_0_1-intel-omp.patch', when='@5.0.1 %intel')
+    patch('nco-5_0_1-intel-omp.patch', when='@5.0.1: %intel')
 
     variant('doc', default=False, description='Build/install NCO TexInfo-based documentation')
 


### PR DESCRIPTION
See https://github.com/NOAA-EMC/spack-stack/issues/96 - the patch is still required for 5.0.6, apply it for all versions 5.0.1+.

Closes https://github.com/NOAA-EMC/spack-stack/issues/96