### PR TITLE
Add package configs for bufr-11.6.0, fms-2022.01, netcdf-fortran-4.5.4

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -22,10 +22,11 @@ class Bufr(CMakePackage):
     maintainers = ['t-brown', 'kgerheiser', 'edwardhartnett', 'Hang-Lei-NOAA',
                    'jbathegit']
 
+    version('11.6.0', sha256='af4c04e0b394aa9b5f411ec5c8055888619c724768b3094727e8bb7d3ea34a54')
     version('11.5.0', sha256='d154839e29ef1fe82e58cf20232e9f8a4f0610f0e8b6a394b7ca052e58f97f43')
 
     # Patch to not add '-c' to ranlib flags when using llvm-ranlib on Apple systems
-    patch('cmakelists-apple-llvm-ranlib.patch', when='@:11.5.0')
+    patch('cmakelists-apple-llvm-ranlib.patch', when='@:11.6.0')
 
     variant('python', default=False, description='Enable Python interface?')
     extends('python', when='+python')
@@ -59,7 +60,7 @@ class Bufr(CMakePackage):
                     flags.append('-fno-common')
 
         # Bufr inserts a path into source code which may be longer than 132
-        if fc == 'gfortran':
+        if name == 'fflags' and 'gfortran' in fc:
             flags.append('-ffree-line-length-none')
 
         # Inject flags into CMake build

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -24,6 +24,7 @@ class Fms(CMakePackage):
     variant('pic', default=True, description='Generate position-independent code (PIC), useful '
                                              'for building static libraries')
 
+    version('2022.01', sha256='a1cba1f536923f5953c28729a28e5431e127b45d6bc2c15d230939f0c02daa9b')
     version('2021.03.01', sha256='1f70e2a57f0d01e80fceb9ca9ce9661f5c1565d0437ab67618c2c4dfea0da6e9')
 
     depends_on('netcdf-c')

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -17,10 +17,11 @@ class NetcdfFortran(AutotoolsPackage):
     distribution."""
 
     homepage = "https://www.unidata.ucar.edu/software/netcdf"
-    url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-fortran-4.5.3.tar.gz"
+    url      = "https://downloads.unidata.ucar.edu/netcdf-fortran/4.5.4/netcdf-fortran-4.5.4.tar.gz"
 
     maintainers = ['skosukhin', 'WardF']
 
+    version('4.5.4', sha256='0a19b26a2b6e29fab5d29d7d7e08c24e87712d09a5cafeea90e16e0a2ab86b81')
     version('4.5.3', sha256='123a5c6184336891e62cf2936b9f2d1c54e8dee299cfd9d2c1a1eb05dd668a74')
     version('4.5.2', sha256='b959937d7d9045184e9d2040a915d94a7f4d0185f4a9dceb8f08c94b0c3304aa')
     version('4.4.5', sha256='2467536ce29daea348c736476aa8e684c075d2f6cab12f3361885cb6905717b8')


### PR DESCRIPTION
As the title says - new package configs and tiny bugfixes for bufr-11.6.0, fms-2022.01, netcdf-fortran-4.5.4. A number of issues in https://github.com/noaa-emc/spack-stack will get resolved once the corresponding spack-stack updates are merged (PR to come, but this PR can go in as is - tested on macOS with llvm-clang+gfortran and mpich).