### PR TITLE
Updates for CRTM

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -823,7 +823,7 @@ class GitFetchStrategy(VCSFetchStrategy):
     """
     url_attr = 'git'
     optional_attrs = ['tag', 'branch', 'commit', 'submodules',
-                      'get_full_repo', 'submodules_delete']
+                      'get_full_repo', 'submodules_delete', 'skip_git_lfs']
 
     git_version_re = r'git version (\S+)'
 
@@ -838,6 +838,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         self.submodules = kwargs.get('submodules', False)
         self.submodules_delete = kwargs.get('submodules_delete', False)
         self.get_full_repo = kwargs.get('get_full_repo', False)
+        self.skip_git_lfs = kwargs.get('skip_git_lfs', False)
 
     @property
     def git_version(self):
@@ -867,6 +868,10 @@ class GitFetchStrategy(VCSFetchStrategy):
             # with git as well.
             if not spack.config.get('config:verify_ssl'):
                 self._git.add_default_env('GIT_SSL_NO_VERIFY', 'true')
+
+            # Don't attempt to download large files with git-lfs
+            if self.skip_git_lfs:
+                self._git.add_default_env('GIT_LFS_SKIP_SMUDGE', '1')
 
         return self._git
 

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -13,8 +13,17 @@ class Crtm(CMakePackage):
     scattering, and a solver for a radiative transfer."""
 
     homepage = "https://www.jcsda.org/jcsda-project-community-radiative-transfer-model"
-    url      = "https://github.com/NOAA-EMC/EMC_crtm/archive/refs/tags/v2.3.0.tar.gz"
+    git = 'https://github.com/JCSDA/crtm.git'
 
     maintainers = ['t-brown', 'edwardhartnett', 'kgerheiser', 'Hang-Lei-NOAA']
 
-    version('2.3.0', sha256='3e2c87ae5498c33dd98f9ede5c39e33ee7f298c7317b12adeb552e3a572700ce')
+    depends_on('netcdf-fortran', when='@2.4.0:')
+
+    # ecbuild release v2.4.0 is broken
+    # add ecbuild dependency for next release with fix
+    # depends_on('ecbuild', when='@2.4.0:', type=('build'))
+
+    # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
+    version('2.4.0', commit='a831626', skip_git_lfs=True)
+    # Uses the tip of REL-2.3.0_emc branch
+    version('2.3.0', commit='99760e6', skip_git_lfs=True)

--- a/var/spack/repos/builtin/packages/git-lfs/package.py
+++ b/var/spack/repos/builtin/packages/git-lfs/package.py
@@ -22,6 +22,8 @@ class GitLfs(MakefilePackage):
 
     maintainers = ['sethrj']
 
+    tags = ['build-tools']
+
     version('3.1.2', sha256='5c9bc449068d0104ea124c25f596af16da85e7b5bf256bc544d8ce5f4fe231f2')
     version('2.13.3', sha256='f8bd7a06e61e47417eb54c3a0db809ea864a9322629b5544b78661edab17b950')
     version('2.12.1', sha256='2b2e70f1233f7efe9a010771510391a07527ec7c0af721ecf8edabac5d60f62b')


### PR DESCRIPTION
* Update CRTM with JCSDA repo and version 2.4.0
* Add build-tool tag to git-lfs (going to make a PR to the main repo too)
* Add option to ignore git-lfs when cloning a repository to avoid the dependency when just trying to obtain the code.

Also @climbfuji the Spack submodule in spack-stack is pointing to your fork.