### PR TITLE
Move spack-stack repos into Spack builtin

### DIFF
--- a/etc/spack/defaults/repos.yaml
+++ b/etc/spack/defaults/repos.yaml
@@ -12,3 +12,4 @@
 # -------------------------------------------------------------------------
 repos:
   - $spack/var/spack/repos/builtin
+  - $spack/var/spack/repos/jcsda-emc-bundles

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class CrtmFix(Package):
+    """CRTM coeffecient files"""
+
+    homepage = "https://github.com/NOAA-EMC/crtm"
+    url      = "ftp://ftp.ucar.edu/pub/cpaess/bjohns/fix_REL-2.3.0_emc.tgz"
+
+    maintainers = ['kgerheiser']
+
+    version('2.4.0', sha256='7924285b8aa25b0b864643f03e7f281ca1816958e24c76aa9531b3ca902bf6e9')
+    version('2.4.0_emc', sha256='84b176ee16cce0897377696cc4f621ef5a55cae7ea8280a0acd5ff70d4435995')
+    version('2.3.0_emc', sha256='fde73bb41c3c00666ab0eb8c40895e02d36fa8d7b0896c276375214a1ddaab8f')
+
+    variant('big_endian', default=True, description='Install big_endian fix files')
+    variant('little_endian', default=False, description='Install little endian fix files')
+    variant('netcdf', default=True, description='Install netcdf fix files')
+
+    conflicts('+big_endian', when='+little_endian', msg='big_endian and little_endian conflict')
+
+    def url_for_version(self, version):
+        url = 'ftp://ftp.ucar.edu/pub/cpaess/bjohns/fix_REL-{}.tgz'
+        return url.format(version)
+
+    def install(self, spec, prefix):
+        spec = self.spec
+        
+        endian_dirs = []
+        if '+big_endian' in spec:
+            endian_dirs.append('Big_Endian')
+        elif '+little_endian' in spec:
+            endian_dirs.append('Little_Endian')
+
+        if '+netcdf' in spec:
+            endian_dirs.extend(['netcdf', 'netCDF'])
+
+        fix_files = []
+        for d in endian_dirs:
+            fix_files = fix_files + find('.', '*/{}/*'.format(d))
+
+        mkdir(self.prefix.fix)
+        cwd = pwd()
+
+        for f in fix_files:
+            install(f, self.prefix.fix)
+
+    def setup_run_environment(self, env):
+        env.set('CRTM_FIX', self.prefix.fix)

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/clang_include_array.patch
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/clang_include_array.patch
@@ -1,0 +1,11 @@
+--- a/src/atlas/grid/detail/partitioner/CubedSpherePartitioner.h	2022-01-12 08:44:07.000000000 -0700
++++ b/src/atlas/grid/detail/partitioner/CubedSpherePartitioner.h	2022-01-12 08:44:11.000000000 -0700
+@@ -11,7 +11,7 @@
+ #pragma once
+ 
+ #include <vector>
+-
++#include <array>
+ #include "atlas/grid/detail/partitioner/Partitioner.h"
+ 
+ namespace atlas {

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -1,0 +1,61 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from spack import *
+
+class EcmwfAtlas(CMakePackage):
+    """A library for numerical weather prediction and climate modelling."""
+
+    homepage = "https://software.ecmwf.int/wiki/display/atlas"
+    git = "https://github.com/ecmwf/atlas.git"
+    url = "https://github.com/ecmwf/atlas/archive/0.22.1.tar.gz"
+
+    maintainers = ['climbfuji', 'rhoneyager']
+
+    version('master', branch='master')
+    version('develop', branch='develop')
+    version('0.27.0', commit='d825fad7ab415558a81415914a0fc60da1d0295a', preferred=True)
+    version('0.26.0', commit='3ae6184a598a00fbc6b1a77c3c9d5d808f1c65ea')
+    version('0.25.0', commit='3c74adda4960723f237db936132888e3fd380154')
+    version('0.24.1', commit='36772b5a72f91e99b30756808d8cff6edb415b8f')
+    version('0.24.0', commit='071bbb18c1fe3eac9d19557cc4490995e0af5184')
+    version('0.23.0', commit='7e0a1251685e07a5dcccc84f4d9251d5a066e2ee')
+    version('0.22.1', commit='e55e9c72883d24e3ed4d4eaaae330825a2d77dd3')
+    version('0.22.0', commit='a70030278541d4c4e18ebf92b683951749d60049')
+    version('0.21.0', commit='b7728bb798b9891ce62e1034fa21c0bc33a30cab')
+
+    depends_on('ecbuild', type=('build'))
+    depends_on('eckit')
+    depends_on('boost cxxstd=14 visibility=hidden', when='@0.26.0:', type=('build', 'run'))
+    variant('fckit', default=True)
+    depends_on('fckit', when='+fckit')
+    depends_on('python')
+
+    patch('clang_include_array.patch', when='%apple-clang')
+    patch('clang_include_array.patch', when='%clang')
+
+    variant('shared', default=True)
+
+    variant('trans', default=False)
+    depends_on('ectrans', when='+trans')
+    #variant('cgal', default=False)
+    #depends_on('cgal', when='+cgal')
+    variant('eigen', default=True)
+    depends_on('eigen', when='+eigen')
+    variant('fftw', default=True)
+    depends_on('fftw-api', when='+fftw')
+
+    def cmake_args(self):
+        res = [
+                self.define_from_variant('ENABLE_FCKIT', 'fckit'),
+                self.define_from_variant('ENABLE_TRANS', 'trans'),
+                self.define_from_variant('ENABLE_EIGEN', 'eigen'),
+                self.define_from_variant('ENABLE_FFTW',  'fftw'),
+                "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec['python'].command.path,
+                ] 
+        if '~shared' in self.spec:
+            res.append('-DBUILD_SHARED_LIBS=OFF')
+        return res

--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Ectrans(CMakePackage):
+    """Ectrans is the global spherical Harmonics transforms library, extracted from the IFS.
+    It is using a hybrid of MPI and OpenMP parallelisation strategies. The package contains
+    both single- and double precision Fortran libraries (trans_sp, trans_dp), as well as a
+    C interface to the double-precision version (transi_dp)."""
+
+    homepage = "https://github.com/ecmwf-ifs/ectrans"
+    git = "https://github.com/ecmwf-ifs/ectrans.git"
+
+    maintainers = ['climbfuji']
+
+    version('develop', branch='develop', no_cache=True, preferred=True)
+    version('main', branch='main', no_cache=True, preferred=False)
+
+    variant('mpi', default=True, description='Use MPI?')
+    variant('openmp', default=True, description='Use OpenMP?')
+
+    #variant('double_precision', default=True, description='Support for double precision?')
+    #variant('single_precision', default=True, description='Support for single precision?')
+
+    variant('mkl',  default=False, description='Use MKL?')
+    variant('fftw', default=True, description='Use FFTW?')
+
+    #variant('transi', default=True, description='Compile TransI C-interface to trans?')
+
+    depends_on('ecbuild', type=('build'))
+    depends_on('mpi',  when='+mpi')
+    depends_on('blas')
+    depends_on('lapack')
+    depends_on('fftw-api', when='+fftw')
+    depends_on('mkl', when='+mkl')
+
+    depends_on('fiat~mpi',  when='~mpi')
+    depends_on('fiat+mpi',  when='+mpi')
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant('ENABLE_MPI', 'mpi'),
+            self.define_from_variant('ENABLE_OMP', 'openmp'),
+            #self.define_from_variant('ENABLE_DOUBLE_PRECISION', 'double_precision'),
+            #self.define_from_variant('ENABLE_SINGLE_PRECISION', 'single_precision'),
+            self.define_from_variant('ENABLE_FFTW', 'fftw'),
+            self.define_from_variant('ENABLE_MKL', 'mkl')
+            #self.define_from_variant('ENABLE_TRANSI', 'transi')
+        ]
+
+        return args

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -1,0 +1,59 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from spack import *
+
+class Fckit(CMakePackage):
+    """A Fortran toolkit for interoperating Fortran with C/C++."""
+
+    homepage = "https://software.ecmwf.int/wiki/display/fckit"
+    git = "https://github.com/ecmwf/fckit.git"
+    url = "https://github.com/ecmwf/fckit/archive/0.9.0.tar.gz"
+
+    maintainers = ['rhoneyager', 'climbfuji']
+
+    version('master', branch='master')
+    version('develop', branch='develop')
+    version('0.9.5', commit='7ec9cf8ad8b619a8319199e834171c11e111c888', preferred=True)
+    version('0.9.4', commit='a83cfe6d4ed22c954548dd7c31e1fbad3cd2f908')
+    version('0.9.3', commit='3f612e107682c61c0b6806ea3fc12e9509a90664')
+    version('0.9.2', commit='26439f09a421b29d745f4c4810d7d40f2820f5ec')
+    version('0.9.1', commit='0b2c04d29ff141d1963e21da2add2e70f01163ce')
+    version('0.9.0', commit='9cd993a524264e079ae260dbc89faea599e270fc')
+    version('0.8.0', commit='4cd749f1eeac64eece00adb50abd072ea14fa2b1')
+    version('0.7.0', commit='5a9ad884c087ae4c188a5937acf078514519778f')
+
+    depends_on('mpi')
+    depends_on('python')
+    depends_on('ecbuild', type=('build'))
+
+    variant('eckit', default=True)
+    depends_on('eckit+mpi', when='+eckit')
+
+    variant('shared', default=True)
+
+    def cmake_args(self):
+        res = [
+                self.define_from_variant('ENABLE_ECKIT', 'eckit'),
+                '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
+                '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
+                '-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc,
+                "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec['python'].command.path,
+                '-DFYPP_NO_LINE_NUMBERING=ON'
+                ]
+        if '~shared' in self.spec:
+            res.append('-DBUILD_SHARED_LIBS=OFF')
+
+        if self.spec.satisfies('%intel') or self.spec.satisfies('%gcc'):
+            cxxlib = 'stdc++'
+        elif self.spec.satisfies('%clang') or self.spec.satisfies('%apple-clang'):
+            cxxlib = 'c++'
+        else:
+            raise InstallError("C++ library not configured for compiler")
+        res.append('-DECBUILD_CXX_IMPLICIT_LINK_LIBRARIES={}'.format(cxxlib))
+
+        return res
+

--- a/var/spack/repos/builtin/packages/fiat/package.py
+++ b/var/spack/repos/builtin/packages/fiat/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Fiat(CMakePackage):
+    """FIAT (Fortran IFS and Arpege Toolkit) is a collection of selected
+    Fortran utility libraries, extracted from the IFS/Arpege model."""
+
+    homepage = "https://github.com/ecmwf-ifs/fiat"
+    git = "https://github.com/ecmwf-ifs/fiat.git"
+
+    maintainers = ['climbfuji']
+
+    version('develop', branch='develop', no_cache=True, preferred=True)
+    version('main', branch='main', no_cache=True, preferred=False)
+
+    variant('mpi', default=True, description='Use MPI?')
+    variant('openmp', default=True, description='Use OpenMP?')
+    variant('fckit', default=True, description='Use fckit?')
+    #variant('dr_hook_multi_precision_handles', default=False,
+    #    description='Use deprecated single precision handles for DR_HOOK?')
+    #variant('warnings', default=True, description='Enable compiler warnings')
+
+    depends_on('ecbuild', type=('build'))
+    depends_on('mpi', when='+mpi')
+    depends_on('eckit', when='+fckit')
+    depends_on('fckit', when='+fckit')
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant('ENABLE_OMP', 'openmp'),
+            self.define_from_variant('ENABLE_MPI', 'mpi'),
+            self.define_from_variant('ENABLE_FCKIT', 'fckit')
+            #self.define_from_variant('ENABLE_DR_HOOK_MULTI_PRECISION_HANDLES',
+            #   'dr_hook_multi_precision_handles')
+            #self.define_from_variant('ENABLE_WARNINGS, 'warnings')
+        ]
+
+        return args

--- a/var/spack/repos/builtin/packages/fms-jcsda/package.py
+++ b/var/spack/repos/builtin/packages/fms-jcsda/package.py
@@ -1,0 +1,69 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class FmsJcsda(CMakePackage):
+    """GFDL's Flexible Modeling System (FMS) is a software environment
+    that supports the efficient development, construction, execution,
+    and scientific interpretation of atmospheric, oceanic, and climate
+    system models.
+    This version has been adapated by JCSDA and is only meant to be
+    used temporarily, until the JCSDA changes have found their way
+    back into the official repository."""
+
+    #homepage = "https://github.com/jcsda/fms"
+    #git = "https://github.com/jcsda/fms.git"
+    homepage = "https://github.com/climbfuji/fms"
+    git = "https://github.com/climbfuji/fms.git"
+
+    maintainers = ['climbfuji']
+
+    version('release-stable', branch='feature/no-openmp-option_default_on', no_cache=True, preferred=True)
+    version('dev-jcsda',      branch='dev/jcsda',      no_cache=True)
+
+    variant('64bit',                 default=True,  description='64 bit?')
+    variant('gfs_phys',              default=True,  description='Use GFS Physics?')
+    variant('openmp',                default=True,  description='Use OpenMP?')
+    variant('enable_quad_precision', default=True,  description='Enable quad precision?')
+    variant('pic',                   default=True,  description='Generate position-independent code (PIC), useful '
+                                                               'for building static libraries')
+    depends_on('mpi')
+    depends_on('netcdf-c')
+    depends_on('netcdf-fortran')
+    depends_on('ecbuild', type=('build'), when='@release-stable')
+    depends_on('jedi-cmake', type=('build'), when='@release-stable')
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant('64BIT'),
+            self.define_from_variant('GFS_PHYS'),
+            self.define_from_variant('OPENMP'),
+            self.define_from_variant('ENABLE_QUAD_PRECISION')
+        ]
+
+        args.append(self.define('CMAKE_C_COMPILER', self.spec['mpi'].mpicc))
+        args.append(self.define('CMAKE_CXX_COMPILER', self.spec['mpi'].mpicxx))
+        args.append(self.define('CMAKE_Fortran_COMPILER', self.spec['mpi'].mpifc))
+
+        cflags = []
+        fflags = []
+
+        if self.compiler.name in ['gcc', 'clang', 'apple-clang']:
+            gfortran_major_version = int(spack.compiler.get_compiler_version_output(self.compiler.fc, '-dumpversion').split('.')[0])
+            if gfortran_major_version>=10:
+                fflags.append('-fallow-argument-mismatch')
+
+        if '+pic' in self.spec:
+            cflags.append(self.compiler.cc_pic_flag)
+            fflags.append(self.compiler.fc_pic_flag)
+
+        if cflags:
+            args.append(self.define('CMAKE_C_FLAGS', ' '.join(cflags)))
+        if fflags:
+            args.append(self.define('CMAKE_Fortran_FLAGS', ' '.join(fflags)))
+
+        return args

--- a/var/spack/repos/builtin/packages/gftl-shared/package.py
+++ b/var/spack/repos/builtin/packages/gftl-shared/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class GftlShared(CMakePackage):
+    """
+    Provides common gFTL containers of Fortran intrinsic types that
+    are encountered frequently.
+    """
+
+    homepage = "https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared"
+    url = "https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared/releases/download/v1.4.1/gFTL-shared-1.4.1.tar"
+
+    maintainers = ['kgerheiser', 'edwardhartnett', 'Hang-Lei-NOAA']
+
+    depends_on('m4', type=('build', 'run'))
+
+    version('1.4.1', 
+        sha256='78a1c20fe75430df0e2abc5d324905cf52ad22346080b66925bca514d90ff94a',
+        url='https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared/releases/download/v1.4.1/gFTL-shared-1.4.1.tar')
+
+    version('1.3.6', 
+        sha256='6a6d618581b0d15213b2700b15102921f557340b73c7710405525641824e8703',
+        url='https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared/releases/download/v1.3.6/gFTL-shared-v1.3.6.tar')
+    
+    version('1.3.0', 
+        sha256='c9e8090fb74900bbfd6cc9a0f75626180062be18d8671d48bb46dd087880e6b2',
+        url='https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared/releases/download/v1.3.0/gFTL-shared-v1.3.0.tar')

--- a/var/spack/repos/builtin/packages/gsl-lite/package.py
+++ b/var/spack/repos/builtin/packages/gsl-lite/package.py
@@ -1,0 +1,67 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install gsl-lite
+#
+# You can edit this file again by typing:
+#
+#     spack edit gsl-lite
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class GslLite(CMakePackage):
+    """gsl-lite – A single-file header-only version of ISO C++ Guidelines Support Library (GSL) for C++98, C++11, and later"""
+
+    homepage = "https://github.com/gsl-lite/gsl-lite"
+    git = "https://github.com/gsl-lite/gsl-lite.git"
+    url      = "https://github.com/gsl-lite/gsl-lite/archive/refs/tags/v0.38.1.tar.gz"
+
+    maintainers = ['kgerheiser', 'edwardhartnett', 'Hang-Lei-NOAA']
+
+    version('0.40.0', commit='d6c8af99a1d95b3db36f26b4f22dc3bad89952de')
+    version('0.39.0', commit='d0903fa87ff579c30f608bc363582e6563570342')
+    version('0.38.1', sha256='c2fa2315fff312f3897958903ed4d4e027f73fa44235459ecb467ad7b7d62b18')
+    version('0.38.0', sha256='5d25fcd31ea66dac9e14da1cad501d95450ccfcb2768fffcd1a4170258fcbc81')
+    version('0.37.0', sha256='a31d51b73742bb234acab8d2411223cf299e760ed713f0840ffed0dabe57ca38')
+    version('0.36.0', sha256='c052cc4547b33cedee6f000393a7005915c45c6c06b35518d203db117f75c71c')
+    version('0.34.0', sha256='a7d5b2672b78704ca03df9ef65bc274d8f8cacad3ca950365eef9e25b50324c5')
+
+    depends_on('cmake')
+
+    variant('tests', default=False)
+    variant('cuda_tests', default=False)
+    variant('examples', default=False)
+    variant('static_analysis_demos', default=False)
+    variant('cmake_export_package_registry', default=False)
+    variant('compat_header', default=False)
+    variant('legacy_headers', default=False)
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant('GSL_LITE_OPT_BUILD_TESTS', 'tests'),
+            self.define_from_variant('GSL_LITE_OPT_BUILD_CUDA_TESTS', 'cuda_tests'),
+            self.define_from_variant('GSL_LITE_OPT_BUILD_EXAMPLES', 'examples'),
+            self.define_from_variant('GSL_LITE_LOPT_BUILD_STATIC_ANALYSIS_DEMOS',
+                                     'static_analysis_demos'),
+            self.define_from_variant('CMAKE_EXPORT_PACKAGE_REGISTRY',
+                                     'cmake_export_package_registry'),
+            self.define_from_variant('GSL_LITE_OPT_INSTALL_COMPAT_HEADER',
+                                     'compat_header'),
+            self.define_from_variant('GSL_LITE_OPT_INSTALL_LEGACY_HEADERS',
+                                     'legacy_headers')
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/jedi-cmake/package.py
+++ b/var/spack/repos/builtin/packages/jedi-cmake/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from spack import *
+
+class JediCmake(CMakePackage):
+    """CMake/ecbuild toolchains to facilitate portability on different systems."""
+
+    homepage = "https://github.com/JCSDA/jedi-cmake"
+    git = "https://github.com/JCSDA/jedi-cmake.git"
+    url = "https://github.com/JCSDA/jedi-cmake/archive/refs/tags/1.3.0.tar.gz"
+
+    maintainers = ['climbfuji', 'rhoneyager']
+
+    version('master', branch='master', no_cache=True)
+    version('develop', branch='develop', no_cache=True)
+    version('1.3.0', sha256='b217e2250398f6c34f0da0a50a8efe500684af4d484adebaa87a9de630eee1b7', preferred=True)
+    version('1.2.0', sha256='eb9f1c403d1b43a90a5e774097382b183d56d5b40a1204b51af2da8db1559b21')
+    version('1.1.0', sha256='f1fe41eb5edd343bdf57eb76bea6d1b9f015878f0a9d0eb1e9dba18b903d3b35')
+    version('1.0.0', sha256='d773a800350e69372355b45e89160b593818cd438a86925b8a689c47996a0b9a')
+
+    depends_on('cmake @3.10:', type=('build'))
+

--- a/var/spack/repos/builtin/packages/mapl/esma_cmake_apple_m1.patch
+++ b/var/spack/repos/builtin/packages/mapl/esma_cmake_apple_m1.patch
@@ -1,0 +1,16 @@
+--- a/ESMA_cmake/GNU.cmake	2022-01-27 09:49:56.000000000 -0700
++++ b/ESMA_cmake/GNU.cmake	2022-01-27 09:51:54.000000000 -0700
+@@ -123,7 +123,13 @@
+    set (GNU_NATIVE_ARCH "native")
+    set (PREFER_AVX128 "-mprefer-avx128")
+    set (NO_FMA "-mno-fma")
++elseif (${proc_decription} MATCHES "Apple M1" AND ${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "x86_64")
++   # Rosetta 2 emulator of x86_64 architecture on Apple Silicon
++   set (GNU_TARGET_ARCH "westmere")
++   set (GNU_NATIVE_ARCH "native")
++   set (PREFER_AVX128 "-mprefer-avx128")
++   set (NO_FMA "-mno-fma")
+ else ()
+    message(FATAL_ERROR "Unknown processor. Contact Matt Thompson")
+ endif ()
+ 

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -1,0 +1,89 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack import *
+
+
+class Mapl(CMakePackage):
+    """
+    MAPL is a foundation layer of the GEOS architecture, whose
+    original purpose is to supplement the Earth System Modeling
+    Framework (ESMF).  MAPL fills in missing capabilities of ESMF,
+    provides higher-level interfaces for common boiler-plate logic,
+    and enforces various componentization conventions across ESMF
+    gridded components within GEOS.
+
+    """
+
+    homepage = "https://github.com/GEOS-ESM/MAPL"
+    url      = "https://github.com/GEOS-ESM/MAPL/archive/refs/tags/v2.8.1.tar.gz"
+
+    maintainers = ['kgerheiser', 'edwardhartnett', 'Hang-Lei-NOAA']
+
+    version('2.8.1', sha256='a7657d4c52a66c3a6663e436d2c2dd4dbb81addd747e1ace68f59843665eb739')
+    version('2.8.0', sha256='6da60a21ab77ecebc80575f25b756c398ef48f635ab0b9c96932a1d4ebd8b4a0')
+    version('2.7.3', sha256='e8cdc0816471bb4c42673c2fa66d9d749f5a18944cd31580a2d6fd6d961ba163')
+    version('2.7.2', sha256='8f123352c665c434a18ff87304a71a61fb3342919adcccfea2a40729992d9f93')
+    version('2.7.1', sha256='8239fdbebd2caa47a232c24927f7a91196704e35c8b7909e1bbbefccf0647ea6')
+
+    resource(
+        name='esma_cmake',
+        git='https://github.com/GEOS-ESM/ESMA_cmake.git',
+        tag='v3.4.3')
+
+    resource(
+        name='CMakeModules',
+        git='https://github.com/NOAA-EMC/CMakeModules.git',
+        tag='v1.2.0')
+
+    # Patch to configure Apple M1 chip in x86_64 Rosetta 2 emulator mode
+    patch('esma_cmake_apple_m1.patch', when='@:2.8.1')
+
+    variant('flap', default=False)
+    variant('pflogger', default=False)
+    variant('esma_gfe_namespace', default=True)
+    variant('shared', default=True)
+    variant('debug', default=False, description='Make a debuggable version of the library')
+
+    depends_on('mpi')
+    depends_on('hdf5')
+    depends_on('netcdf-c')
+    depends_on('esmf~debug', when='~debug')
+    depends_on('esmf+debug', when='+debug')
+    depends_on('yafyaml')
+    depends_on('gftl-shared')
+    depends_on('ecbuild')
+
+    def cmake_args(self):
+        dir = os.getcwd()
+        ecbuild_prefix = self.spec["ecbuild"].prefix
+        long_arg = ('-DCMAKE_MODULE_PATH={pwd}/ESMA_cmake;{pwd}/CMakeModules/Modules;' +
+                    '{ecbuild_prefix}/share/ecbuild/cmake')
+        args = [
+            self.define_from_variant('BUILD_WITH_FLAP', 'flap'),
+            self.define_from_variant('BUILD_WITH_PFLOGGER', 'pflogger'),
+            self.define_from_variant('ESMA_USE_GFE_NAMESPACE', 'esma_gfe_namespace'),
+            self.define_from_variant('BUILD_SHARED_MAPL', 'shared'),
+            long_arg.format(pwd=dir, ecbuild_prefix=ecbuild_prefix),
+            '-DCMAKE_Fortran_FLAGS=-ffree-line-length-none',
+            '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
+            '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
+            '-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc
+        ]
+
+        # Compatibility flags for gfortran
+        fflags = []
+        if self.compiler.name in ['gcc', 'clang', 'apple-clang']:
+            fflags.append('-ffree-line-length-none')
+            gfortran_major_version = int(spack.compiler.get_compiler_version_output(self.compiler.fc, '-dumpversion').split('.')[0])
+            if gfortran_major_version>=10:
+                fflags.append('-fallow-invalid-boz')
+                fflags.append('-fallow-argument-mismatch')
+        if fflags:
+            args.append(self.define('CMAKE_Fortran_FLAGS', ' '.join(fflags)))
+
+        return args

--- a/var/spack/repos/builtin/packages/met/openmp_shape_patch.patch
+++ b/var/spack/repos/builtin/packages/met/openmp_shape_patch.patch
@@ -1,0 +1,11 @@
+--- a/src/basic/vx_util/data_plane_util.cc	2022-03-18 22:29:42.000000000 -0400
++++ b/src/basic/vx_util/data_plane_util.cc	2022-03-18 22:30:44.000000000 -0400
+@@ -253,7 +253,7 @@
+ 
+ #pragma omp parallel default(none)                 \
+    shared(mlog, dp, frac_dp, width, wrap_lon, t)   \
+-   shared(use_climo, cmn, csd, vld_t, bad)         \
++   shared(use_climo, cmn, csd, vld_t, bad, shape)  \
+    private(x, y, n_vld, n_thr, gp, v)
+    {
+ 

--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -1,0 +1,156 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Met(AutotoolsPackage):
+    """
+    Statistical tool that matches up grids with either gridded analyses or point observations and applies configurable methods to compute statistics and diagnostics
+    """
+
+    homepage = "https://dtcenter.org/community-code/model-evaluation-tools-met"
+    url      = "https://github.com/dtcenter/MET/releases/download/v10.1.0/met-10.1.0.20220314.tar.gz"
+
+    maintainers = ['kgerheiser']
+
+    version('10.1.0', sha256='8d4c1fb2311d8481ffd24e30e407a1b1bc72a6add9658d76b9c323f1733db336')
+    version('10.0.1', sha256='8e965bb0eb8353229a730af511c5fa62bad9744606ab6a218d741d29eb5f3acd')
+    version('10.0.0', sha256='92f37c8bd83c951d86026cce294a16e4d3aa6dd41905629d0a729fa1bebe668a')
+    version('9.1.3', sha256='7356a5ad79ca961fd965cadd93a7bf6c73b3aa5fb1a01a932580b94e66d0d0c8')    
+
+    variant('openmp', default=True, description='Use OpenMP multithreading')
+    variant('grib2', default=False,
+            description='Enable compilation of utilities using GRIB2')
+    variant('python', default=False, description='Enable python embedding')
+    variant('lidar2nc', default=False,
+            description='Enable compilation of lidar2nc')
+    variant('modis', default=False, description='Enable compilation of modis')
+    variant('graphics', default=False,
+            description='Enable compilation of mode_graphics')
+    
+    depends_on('gsl')
+    depends_on('bufr')
+    depends_on('zlib')
+    depends_on('netcdf-c')
+    depends_on('netcdf-cxx4')
+    depends_on('g2c', when='+grib2')
+
+    depends_on('hdf-eos2', when='+modis')
+    depends_on('hdf-eos2', when='+lidar2nc')
+    depends_on('hdf', when='+modis')
+    depends_on('hdf', when='+lidar2nc')
+
+    depends_on('cairo', when='+graphics')
+    depends_on('freetype', when='+graphics')
+
+    depends_on('python@3.6.3:', when='+python', type=('build', 'run'))
+    depends_on('py-netcdf4', when='+python', type=('run'))
+    depends_on('py-numpy', when='+python', type=('run'))
+    depends_on('py-xarray', when='+python', type=('run'))
+    depends_on('py-pandas', when='+python', type=('run'))
+    depends_on('py-cartopy', when='+python', type=('run'))
+    depends_on('py-matplotlib', when='+python', type=('run'))
+    depends_on('py-python-dateutil', when='+python', type=('run'))
+    
+    patch('openmp_shape_patch.patch', when='@10.1.0')
+
+    def url_for_version(self, version):
+        release_date = {
+            '10.1.0': '20220314',
+            '10.0.1': '20211201',
+            '10.0.0': '20210510',
+            '9.1.3':  '20210319'
+        }
+        url = "https://github.com/dtcenter/MET/releases/download/v{0}/met-{0}.{1}.tar.gz"
+        return url.format(version, release_date[str(version)])
+
+    def setup_build_environment(self, env):
+        spec = self.spec
+        cppflags = []
+        ldflags = []
+        libs = []
+
+        gsl = spec['gsl']
+        env.set('MET_GSL', gsl.prefix)
+
+        netcdfc = spec['netcdf-c']
+        netcdfcxx = spec['netcdf-cxx4']
+        zlib = spec['zlib']
+
+        cppflags.append('-I' + netcdfc.prefix.include)
+        cppflags.append('-I' + netcdfcxx.prefix.include)
+        cppflags.append('-D__64BIT__')
+
+        ldflags.append('-L' + netcdfc.prefix.lib)
+        ldflags.append('-L' + netcdfcxx.prefix.lib)
+        ldflags.append('-L' + zlib.prefix.lib)
+
+        libs.append('-lnetcdf')
+        libs.append('-lnetcdf_c++4')
+        libs.append('-lz')
+
+        bufr = spec['bufr']
+        bufr_libdir = find_libraries('libbufr_4', root=bufr.prefix, 
+            shared=False, recursive=True).directories[0]
+        env.set('BUFRLIB_NAME', '-lbufr_4')
+        env.set('MET_BUFRLIB', bufr_libdir)
+        
+        if '+grib2' in spec:
+            g2c = spec['g2c']
+            g2c_libdir = find_libraries('libg2c', root=g2c.prefix,
+                                        shared=False, recursive=True).directories[0]
+            env.set('MET_GRIB2CLIB', g2c_libdir)
+            env.set('GRIB2CLIB_NAME', '-lg2c')
+
+        if '+python' in spec:
+            python = spec['python']
+            env.set('MET_PYTHON', python.command.path)
+            env.set('MET_PYTHON_CC', '-I' + python.headers.directories[0])
+            env.set('MET_PYTHON_LD', python.libs.ld_flags)
+
+        if '+lidar2nc' in spec or '+modis' in spec:
+            hdf = spec['hdf']
+            hdfeos = spec['hdf-eos2']
+            env.set('MET_HDF5', hdf.prefix)
+            env.set('MET_HDFEOS', hdfeos.prefix)
+
+        if '+graphics' in spec:
+            cairo = spec['cairo']
+            freetype = spec['freetype']
+            env.set('MET_CAIRO', cairo.prefix)
+            cppflags.append('-I' + cairo.prefix.include.cairo)
+            env.set('MET_FREETYPE', freetype.prefix)
+
+        env.set('CPPFLAGS', ' '.join(cppflags))
+        env.set('LIBS', ' '.join(libs))
+        env.set('LDFLAGS', ' '.join(ldflags))
+
+    def configure_args(self):
+        args = []
+        spec = self.spec
+
+        if '+grib2' in spec:
+            args.append('--enable-grib2')
+
+        if '+python' in spec:
+            args.append('--enable-python')
+
+        if '~openmp' in spec:
+            args.append('--disable-openmp')
+
+        if '+lidar2nc' in spec:
+            args.append('--enable-lidar2nc')
+
+        if '+modis' in spec:
+            args.append('--enable-modis')
+        
+        if '+graphics' in spec:
+            args.append('--enable-mode_graphics')
+
+        return args
+
+    def setup_run_environment(self, env):
+        env.set('MET_BASE', self.prefix)

--- a/var/spack/repos/builtin/packages/metplus/package.py
+++ b/var/spack/repos/builtin/packages/metplus/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import os
+
+
+class Metplus(Package):
+    """
+    METplus is a verification framework that spans a wide range of temporal 
+    (warn-on-forecast to climate) and spatial (storm to global) scales.
+    """
+
+    homepage = "https://dtcenter.org/community-code/metplus"
+    url = "https://github.com/dtcenter/METplus/archive/refs/tags/v4.1.0.tar.gz"
+
+    maintainers = ['kgerheiser']
+
+    version('4.1.0', sha256='4e4d74be64c9c57b910824ebefff42eb3a9bb7e8e325d86b7a3f7fdd59d3e45d')
+    version('4.0.0', sha256='650c65b0cf1f1993209e69e469903c83fb4ae3c693060d8392fc1dece52493e2')
+    version('3.1.1', sha256='d137420c56b2736b09ab713300f25c16e1d6fe523d3f3e4d811471aed83b0d85')
+
+    depends_on('met+python', type=('run'))
+
+    def install(self, spec, prefix):
+        if spec.satisfies('@4.0.0:'):
+            conf = 'defaults.conf'
+        else:
+            conf = 'metplus_system.conf'
+
+        metplus_config = FileFilter(
+            join_path('parm', 'metplus_config', conf))
+
+        met_prefix = spec['met'].prefix
+        metplus_config.filter(r'MET_INSTALL_DIR = /path/to',
+                              'MET_INSTALL_DIR = {}'.format(met_prefix))
+
+        install_tree(self.stage.source_path, prefix)
+
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', self.prefix.ush)

--- a/var/spack/repos/builtin/packages/py-pygrib/package.py
+++ b/var/spack/repos/builtin/packages/py-pygrib/package.py
@@ -1,0 +1,45 @@
+# Copyright 2010 Jeffrey Whitaker
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy of 
+# this software and associated documentation files (the "Software"), to deal in the 
+# Software without restriction, including without limitation the rights to use, 
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the 
+# Software, and to permit persons to whom the Software is furnished to do so, 
+# subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all 
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN 
+# AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from spack import *
+
+
+class PyPygrib(PythonPackage):
+    """A high-level interface to the ECWMF ECCODES C library for reading GRIB files."""
+
+    homepage = "https://github.com/jswhit/pygrib"
+    pypi = "pygrib/pygrib-2.1.4.tar.gz"
+
+    version('2.1.4', sha256='951a409eb3233dd95839dd77c0dbe4d8cbed8f21a4015b1047dec9edec65f545')
+
+    depends_on('eccodes', type=('build', 'run'))
+
+    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-cython', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-proj', type=('run'))
+    
+    #depends_on('python@2.6:2.8,3.2:', type=('build', 'run'), when='@0.9.0')
+    #depends_on('python@2.6:2.8,3.3:', type=('build', 'run'), when='@0.10.0')
+    #depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@0.13.3')
+    #depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@0.17.2')
+    #depends_on('python@3.6:', type=('build', 'run'), when='@0.18.0')
+
+
+

--- a/var/spack/repos/builtin/packages/shumlib/package.py
+++ b/var/spack/repos/builtin/packages/shumlib/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+from spack import *
+
+
+class Shumlib(MakefilePackage):
+    """shumlib - set of libraries which are used by the UK Met Office's Unified Model, that may
+    be of use to external tools or applications where identical functionality is desired"""
+
+    homepage = "https://github.com/metomi/shumlib"
+    #git = "https://github.com/metomi/shumlib.git"
+    git = "https://github.com/climbfuji/shumlib.git"
+    url = "https://github.com/metomi/shumlib/archive/refs/tags/2021.10.1.zip"
+
+    maintainers = [ 'matthewrmshin', 'climbfuji' ]
+
+    version('macos_clang_port', commit='e5e5c9f23ce2656aacd75a884c26b01a5380752e')
+    #version('2021.10.1', commit='545874fba961deadf4b2758926be7c26f4c8dcb9')
+    #version('2021.07.1', commit='a4ea525ad3bf04684ef39b0241991a350e2b7241')
+    #version('2021.03.1', commit='58f599ce9cfb4bd47197125548a44039695fa7f1')
+    #version('2020.11.1', commit='58f599ce9cfb4bd47197125548a44039695fa7f1')
+
+    def edit(self, spec, prefix):
+        env['LIBDIR_OUT'] = os.path.join(os.path.join(self.build_directory, 'spack-build')) # '/Users/heinzell/scratch/tmp-shumlib-inst' # prefix
+        #env['LIBDIR_ROOT'] = self.build_directory
+
+    def build(self, spec, prefix):
+        # DH* TODO: SWITCH FOR DIFFERENT ARCHITECTURES
+        if spec.satisfies('%clang') or spec.satisfies('%apple-clang'):
+            os.system('make -f make/vm-x86-gfortran-clang.mk')
+        #elif spec.satisfies('%gcc'):
+        else:
+            os.system('make -f make/vm-x86-gfortran-gcc.mk')
+
+    def install(self, spec, prefix):
+        install_tree(os.path.join(os.getenv('LIBDIR_OUT'), 'include'), prefix.include)
+        install_tree(os.path.join(os.getenv('LIBDIR_OUT'), 'lib'), prefix.lib)

--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -3,27 +3,185 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install wgrib
+#
+# You can edit this file again by typing:
+#
+#     spack edit wgrib
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+import os
+import sys
+import re
+
 from spack import *
 
 
-class Wgrib2(CMakePackage):
-    """The wgrib2 package functionality for interacting with, reading,
-    writing, and manipulating GRIB2 files."""
+class Wgrib2(MakefilePackage):
+    """Utility for interacting with grib2 files"""
 
     homepage = "https://www.cpc.ncep.noaa.gov/products/wesley/wgrib2"
-    url      = "https://github.com/NOAA-EMC/NCEPLIBS-wgrib2/archive/refs/tags/v2.0.8-cmake-v6.tar.gz"
+    url = "https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz.v2.0.8"
 
-    maintainers = ['t-brown', 'kgerheiser', 'Hang-Lei-NOAA', 'edwardhartnett']
+    maintainers = ['kgerheiser', 'Hang-Lei-NOAA']
 
-    version('2.0.8-cmake-v6', sha256='745cd008b4ce0245ea44247733e57e2b9ec6c5205d171d457e18d0ff8f87172d')
+    version('2.0.7', sha256='d7f1a4f9872922c62b3c7818c022465532cca1f5666b75d3ac5735f0b2747793', extension='tar.gz')
+    version('2.0.8', sha256='5e6a0d6807591aa2a190d35401606f7e903d5485719655aea1c4866cc2828160', extension='tar.gz')
+    version('3.1.0', sha256='5757ef9016b19ae87491918e0853dce2d3616b14f8c42efe3b2f41219c16b78f', extension='tar.gz')
+    version('3.1.1', sha256='9236f6afddad76d868c2cfdf5c4227f5bdda5e85ae40c18bafb37218e49bc04a', extension='tar.gz')
 
-    depends_on('ip2')
-    depends_on('jasper')
-    depends_on('libpng')
-    depends_on('netcdf-c')
-    depends_on('netcdf-fortran')
-    depends_on('sp')
+    variant('netcdf3', default=True,
+            description='Link in netcdf3 library to write netcdf3 files')
+    variant('netcdf4', default=False,
+            description='Link in netcdf4 library to write netcdf3/4 files')
+    variant('ipolates', default='3',
+            description='Link in IPOLATES library to interpolate to new grids (0=OFF, 1=ip, 3=ip2)',
+            values=('0', '1', '3'))
+    variant('spectral', default=False,
+            description='Spectral interpolation in -new_grid')
+    variant('fortran_api', default=True,
+            description='Make wgrib2api which allows fortran code to read/write grib2')
+    variant('mysql', default=False,
+            description='Link in interface to MySQL to write to mysql database')
+    variant('udf', default=False,
+            description='Add commands for user-defined functions and shell commands')
+    variant('regex', default=True,
+            description='Use regular expression library (POSIX-2')
+    variant('tigge', default=True,
+            description='Ability for TIGGE-like variable names')
+    variant('proj4', default=False,
+            description='The proj4 library is used to confirm that the gctpc code is working correctly')
+    variant('aec', default=True,
+            description='Enable use of the libaec library for packing with GRIB2 template')
+    variant('g2c', default=False,
+            description='include NCEP g2clib (mainly for testing purposes)')
+    variant('disable_timezone', default=False,
+            description='Some machines do not support timezones')
+    variant('disable_alarm', default=False,
+            description='Some machines do not support alarm(..) (not POSIX-1, IEEE Std 1003.1) use the alarm to terminate wgrib2 after N seconds')
+    variant('png', default=True, description='PNG encoding')
+    variant('jasper', default=True, description='JPEG compression using Jasper')
+    variant('openmp', default=True, description='OpenMP parallelization')
+    variant('wmo_validation', default=False, description='WMO validation')
 
-    def cmake_args(self):
-        args = ['-DUSE_IPOLATES=3', '-DUSE_SPECTRAL=BOOL:ON']
-        return args
+    conflicts('+openmp', when='%apple-clang')
+
+    variant_map = {
+        'netcdf3': 'USE_NETCDF3',
+        'netcdf4': 'USE_NETCDF4',
+        'spectral': 'USE_SPECTRAL',
+        'mysql': 'USE_MYSQL',
+        'udf': 'USE_UDF',
+        'regex': 'USE_REGEX',
+        'tigge': 'USE_TIGGE',
+        'proj4': 'USE_PROJ4',
+        'aec': 'USE_AEC',
+        'g2c': 'USE_G2CLIB',
+        'png': 'USE_PNG',
+        'jasper': 'USE_JASPER',
+        'openmp': 'USE_OPENMP',
+        'wmo_validation': 'USE_WMO_VALIDATION',
+        'ipolates': 'USE_IPOLATES',
+        'disable_timezone': 'DISABLE_TIMEZONE',
+        'disable_alarm': 'DISABLE_ALARM',
+        'fortran_api': 'MAKE_FTN_API'
+    }
+
+    # Disable parallel build
+    parallel = False
+
+    # Use Spack compiler wrapper flags
+    def inject_flags(self, name, flags):
+        if name == 'cflags':
+            if self.spec.compiler.name == 'apple-clang':
+                flags.append('-Wno-error=implicit-function-declaration')
+
+            # When mixing Clang/gfortran need to link to -lgfortran
+            # Find this by searching for gfortran/../lib
+            if self.spec.compiler.name in ['apple-clang', 'clang']:
+                if 'gfortran' in self.compiler.fc:
+                    output = Executable(self.compiler.fc)('-###', output=str, error=str)
+                    libdir = re.search('--libdir=(.+?) ', output).group(1)
+                    flags.append('-L{}'.format(libdir))
+    
+        return (flags, None, None)
+
+    flag_handler = inject_flags
+
+    def url_for_version(self, version):
+        url = "https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz.v{}"
+        return url.format(version)
+
+    def edit(self, spec, prefix):
+        makefile = FileFilter('makefile')
+
+        # ifort no longer accepts -openmp
+        makefile.filter(r'-openmp', '-qopenmp')
+        makefile.filter(r'-Wall', ' ')
+        makefile.filter(r'-Werror=format-security', ' ')
+
+        # clang doesn't understand --fast-math
+        if spec.satisfies('%clang') or spec.satisfies('%apple-clang'):
+            makefile.filter(r'--fast-math', '-ffast-math')
+
+        for variant_name, makefile_option in self.variant_map.items():
+            value = int(spec.variants[variant_name].value)
+            makefile.filter(r'^%s=.*' % makefile_option,
+                            '{}={}'.format(makefile_option, value))
+
+    def setup_build_environment(self, env):
+
+        if self.spec.compiler.name in 'intel':
+            comp_sys = 'intel_linux'
+        elif self.spec.compiler.name in ['gcc', 'clang', 'apple-clang']:
+            comp_sys = 'gnu_linux'
+
+        env.set('COMP_SYS', comp_sys)
+
+    def build(self, spec, prefix):
+        make()
+
+        # Move wgrib2 executable to a tempoary directory
+        mkdir('install')
+        mkdir(join_path('install', 'bin'))
+        move(join_path('wgrib2', 'wgrib2'), join_path('install', 'bin'))
+
+        # Build wgrib2 library by disabling all options
+        # and enabling only MAKE_FTN_API=1
+        if '+fortran_api' in spec:
+            make('clean')
+            make('deep-clean')
+            makefile = FileFilter('makefile')
+
+            # Disable all options
+            for variant_name, makefile_option in self.variant_map.items():
+                value = 0
+                makefile.filter(r'^%s=.*' % makefile_option,
+                                '{}={}'.format(makefile_option, value))
+
+            # Enable MAKE_FTN_API to build library and USE_REGEX (there is a bug when off)
+            makefile.filter(r'^MAKE_FTN_API=.*', 'MAKE_FTN_API=1')
+            makefile.filter(r'^USE_REGEX=.*', 'USE_REGEX=1')
+            make('lib')
+            mkdir(join_path('install', 'lib'))
+            mkdir(join_path('install', 'include'))
+
+            move(join_path('lib', 'libwgrib2.a'),
+                 join_path('install', 'lib'))
+            move(join_path('lib', 'wgrib2api.mod'),
+                 join_path('install', 'include'))
+            move(join_path('lib', 'wgrib2lowapi.mod'),
+                 join_path('install', 'include'))
+
+    def install(self, spec, prefix):
+        install_tree('install/', prefix)

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Yafyaml(CMakePackage):
+    """
+    yet another Fortran (implementation of) YAML
+
+    The rationale for this one is simply to be compatible with the
+    containers in gFTL.  It is not intended to be a complete YAML
+    parser, just the subset needed by my own projects.
+
+    """
+
+    homepage = "https://github.com/Goddard-Fortran-Ecosystem/yaFyaml"
+    url      = "https://github.com/Goddard-Fortran-Ecosystem/yaFyaml/archive/refs/tags/v0.5.1.tar.gz"
+
+    maintainers = ['kgerheiser', 'edwardhartnett', 'Hang-Lei-NOAA']
+
+    version('0.5.1', sha256='7019460314e388b2d556db75d5eb734237a18494f79b921613addb96b7b7ce2f')
+    version('0.5.0', sha256='8ac5d41b1020e9311ac87f50dbd61b9f3e3188f3599ce463ad59650208fdb8ad')
+
+    depends_on('gftl-shared')
+
+    def cmake_args(self):
+        # FIXME: Add arguments other than
+        # FIXME: CMAKE_INSTALL_PREFIX and CMAKE_BUILD_TYPE
+        # FIXME: If not needed delete this function
+        args = []
+        return args

--- a/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class BaseEnv(BundlePackage):
+    """Basic development environment used by other environments"""
+
+    homepage = "https://github.com/noaa-emc/spack-stack"
+    git      = "https://github.com/noaa-emc/spack-stack.git"
+
+    maintainers = ['climbfuji', 'kgerheiser', 'rhoneyager']
+
+    version('main', branch='main')
+
+    # Basic utilities
+    if sys.platform == 'darwin':
+        depends_on('libbacktrace', type='run')
+    depends_on('cmake', type='run')
+    depends_on('git', type='run')
+    depends_on('wget', type='run')
+    depends_on('curl', type='run')
+
+    # I/O
+    depends_on('zlib', type='run')
+    depends_on('szip', type='run')
+    depends_on('hdf5', type='run')
+    depends_on('netcdf-c', type='run')
+    depends_on('netcdf-fortran', type='run')
+    depends_on('parallel-netcdf', type='run')
+    depends_on('parallelio', type='run')
+    depends_on('nccmp', type='run')
+
+    # Python
+    depends_on('python@3.7:')

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -40,7 +40,7 @@ class JediBaseEnv(BundlePackage):
     depends_on('blas',  type='run')
     depends_on('eckit', type='run')
     depends_on('fckit', type='run')
-    depends_on('atlas', type='run')
+    depends_on('ecmwf-atlas', type='run')
     depends_on('nlohmann-json', type='run')
     depends_on('nlohmann-json-schema-validator', type='run')
 

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -1,0 +1,60 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class JediBaseEnv(BundlePackage):
+    """Basic development environment for JEDI applications"""
+
+    # Todo: update URL
+    homepage = "https://github.com/JCSDA-internal/jedi-stack"
+    git      = "https://github.com/JCSDA-internal/jedi-stack.git"
+
+    maintainers = ['climbfuji', 'rhoneyager']
+
+    version('main', branch='main')
+
+    depends_on('base-env', type='run')
+
+    depends_on('bison', type='run')
+    depends_on('flex', type='run')
+
+    depends_on('netcdf-cxx4', type='run')
+
+    depends_on('ecbuild', type='run')
+    depends_on('jedi-cmake', type='run')
+
+    depends_on('git-lfs', type='run')
+
+    depends_on('eigen', type='run')
+    depends_on('fftw-api', type='run')
+    depends_on('gsl-lite', type='run')
+    depends_on('udunits', type='run')
+
+    depends_on('boost', type='run')
+    depends_on('blas',  type='run')
+    depends_on('eckit', type='run')
+    depends_on('fckit', type='run')
+    depends_on('atlas', type='run')
+    depends_on('nlohmann-json', type='run')
+    depends_on('nlohmann-json-schema-validator', type='run')
+
+    # Todo: check where all of this needs to be - jedi-base-env or one of the bundles?
+    depends_on('py-pandas', type='run')
+    depends_on('py-scipy', type='run')
+    depends_on('py-pybind11', type='run')
+    depends_on('py-h5py', type='run')
+    depends_on('py-netcdf4',  type='run')
+    depends_on('py-pycodestyle', type='run')
+    depends_on('py-pyyaml', type='run')
+    depends_on('py-python-dateutil', type='run')
+
+    depends_on('eccodes', type='run')
+    depends_on('py-eccodes', type='run')
+
+    depends_on('bufr', type='run')

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ewok-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ewok-env/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class JediEwokEnv(BundlePackage):
+    """Development environment for ewok"""
+
+    # DH* TODO UPDATE
+    homepage = "https://github.com/JCSDA-internal/ewok"
+    git      = "https://github.com/JCSDA-internal/ewok.git"
+
+    maintainers = ['climbfuji', '@ericlingerfelt']
+
+    version('main', branch='main')
+
+    depends_on('base-env', type='run')
+    depends_on('jedi-base-env', type='run')
+
+    depends_on('py-boto3', type='run')
+    depends_on('py-cartopy', type='run')
+    depends_on('py-jinja2', type='run')
+    depends_on('py-ruamel-yaml', type='run')
+    depends_on('py-ruamel-yaml-clib', type='run')
+
+    depends_on('ecflow', type='run')
+
+    conflicts('%gcc platform=darwin', msg='jedi-ewok-env does ' + \
+        'not build with gcc (11?) on macOS (12), use apple-clang')

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-fv3-bundle-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-fv3-bundle-env/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class JediFv3BundleEnv(BundlePackage):
+    """Development environment for fv3-bundle"""
+
+    homepage = "https://github.com/JCSDA-internal/fv3-bundle"
+    git      = "https://github.com/JCSDA-internal/fv3-bundle.git"
+
+    maintainers = ['climbfuji', 'rhoneyager']
+
+    version('main', branch='main')
+
+    depends_on('base-env', type='run')
+    depends_on('jedi-base-env', type='run')
+
+    depends_on('fms-jcsda@release-stable')

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class JediToolsEnv(BundlePackage):
+    """Development environment for jedi-tools"""
+
+    homepage = "https://github.com/JCSDA-internal/jedi-tools"
+    git      = "https://github.com/JCSDA-internal/jedi-tools.git"
+
+    maintainers = ['climbfuji', 'rhoneyager']
+
+    version('main', branch='main')
+
+    depends_on('py-click', type='run')
+    depends_on('py-pandas', type='run')
+    depends_on('py-pygithub', type='run')
+    depends_on('py-openpyxl', type='run')
+
+    conflicts('%intel', msg='jedi-tools-env does not build with Intel')

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-bundle-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-bundle-env/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class JediUfsBundleEnv(BundlePackage):
+    """Development environment for fv3-bundle"""
+
+    # DH* TODO - we should rename this to just ufs-bundle to match the other bundles
+    homepage = "https://github.com/JCSDA/ufs-jedi-bundle"
+    git      = "https://github.com/JCSDA/ufs-jedi-bundle.git"
+
+    maintainers = ['climbfuji', 'mark-a-potts']
+
+    version('main', branch='main')
+
+    depends_on('base-env', type='run')
+    depends_on('jedi-base-env', type='run')
+
+    depends_on('ufs-weather-model-env', type='run')

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-um-bundle-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-um-bundle-env/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class JediUmBundleEnv(BundlePackage):
+    """Development environment for um-bundle"""
+
+    # DH* TODO UPDATE
+    homepage = "https://github.com/JCSDA-internal/um-bundle"
+    git      = "https://github.com/JCSDA-internal/um-bundle.git"
+
+    maintainers = ['climbfuji', 'rhoneyager']
+
+    version('main', branch='main')
+
+    depends_on('base-env', type='run')
+    depends_on('jedi-base-env', type='run')
+
+    depends_on('shumlib', type='run')
+    depends_on('fiat', type='run')
+    depends_on('ectrans', type='run')

--- a/var/spack/repos/jcsda-emc-bundles/packages/nceplibs-bundle/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/nceplibs-bundle/package.py
@@ -1,0 +1,58 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install nceplibs-bundle
+#
+# You can edit this file again by typing:
+#
+#     spack edit nceplibs-bundle
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class NceplibsBundle(BundlePackage):
+    """
+    This is a collection of libraries commonly known as NCEPLIBS that are required 
+    for several NCEP applications e.g. UFS, GSI, UPP, etc. 
+    """
+
+    homepage = "https://github.com/NOAA-EMC/NCEPLIBS"
+    # There is no URL since there is no code to download.
+
+    maintainers = ['kgerheiser', 'Hang-Lei-NOAA']
+
+    version('1.0.0')
+
+    depends_on('bacio')
+    depends_on('bufr')
+    depends_on('crtm')
+    depends_on('g2')
+    depends_on('g2c')
+    depends_on('g2tmpl')
+    depends_on('gfsio')
+    depends_on('ip')
+    depends_on('landsfcutil')
+    depends_on('ncio')
+    depends_on('nemsio')
+    depends_on('sfcio')
+    depends_on('sigio')
+    depends_on('sp')
+    depends_on('w3emc')
+    depends_on('w3nco')
+    depends_on('wrf-io')
+    depends_on('wgrib2')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/soca-bundle-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/soca-bundle-env/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class SocaBundleEnv(BundlePackage):
+    """Development environment for soca-bundle"""
+
+    # DH* TODO UPDATE
+    homepage = "https://github.com/JCSDA-internal/soca"
+    git      = "https://github.com/JCSDA-internal/soca.git"
+
+    maintainers = ['climbfuji', 'travissluka' ]
+
+    version('main', branch='main')
+
+    depends_on('base-env', type='run')
+    depends_on('jedi-base-env', type='run')
+
+    depends_on('nco', type='run')

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-debug-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-debug-env/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class UfsWeatherModelDebugEnv(BundlePackage):
+    """Development environment for ufs-weathermodel-bundle"""
+
+    homepage = "https://github.com/ufs-community/ufs-weather-model"
+    git      = "https://github.com/ufs-community/ufs-weather-model.git"
+
+    maintainers = ['kgerheiser', 'climbfuji']
+
+    version('main', branch='main')
+
+    depends_on('esmf+debug', type='run')
+    depends_on('mapl+debug', type='run')

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from spack import *
+
+class UfsWeatherModelEnv(BundlePackage):
+    """Development environment for ufs-weathermodel-bundle"""
+
+    homepage = "https://github.com/ufs-community/ufs-weather-model"
+    git      = "https://github.com/ufs-community/ufs-weather-model.git"
+
+    maintainers = ['kgerheiser', 'climbfuji']
+
+    version('main', branch='main')
+
+    depends_on('base-env', type='run')
+
+    depends_on('esmf~debug', type='run')
+    depends_on('fms', type='run')
+
+    depends_on('bacio', type='run')
+    depends_on('crtm', type='run')
+    depends_on('g2', type='run')
+    depends_on('g2tmpl', type='run')
+    depends_on('ip', type='run')
+    depends_on('sp', type='run')
+    depends_on('w3nco', type='run')
+
+    depends_on('mapl~debug', type='run')

--- a/var/spack/repos/jcsda-emc-bundles/repo.yaml
+++ b/var/spack/repos/jcsda-emc-bundles/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: jcsda-emc-bundles


### PR DESCRIPTION
This makes it easier to use containers because the repo is included with Spack, and many of these packages should be moved into Spack officially at some point.

* Add a new `jcsda-emc-bundle` repo that's part of the default repositories. These are kept separate because the bundles aren't real packages.

* The EMCWF `atlas` package was changed to `ecmwf-atlas` to avoid a name conflict with a builtin linear algebra library also called atlas.

* This overwrites the CMake NCEPLIBS wgrib2 package for the official wgrib2 releases which contains more variants and versions.