### PR TITLE
Feature/openmpi two level namespace

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -45,9 +45,6 @@ else:
     class HTMLParseError(Exception):
         pass
 
-# Timeout in seconds for web requests
-_timeout = 10
-
 
 class LinkParser(HTMLParser):
     """This parser just takes an HTML page and strips out the hrefs on the
@@ -96,6 +93,9 @@ def read_from_url(url, accept_content_type=None):
 
     verify_ssl = spack.config.get('config:verify_ssl')
 
+    # Timeout in seconds for web requests
+    timeout = spack.config.get('config:connect_timeout', 10)
+
     # Don't even bother with a context unless the URL scheme is one that uses
     # SSL certs.
     if uses_ssl(url):
@@ -127,7 +127,7 @@ def read_from_url(url, accept_content_type=None):
         # one round-trip.  However, most servers seem to ignore the header
         # if you ask for a tarball with Accept: text/html.
         req.get_method = lambda: "HEAD"
-        resp = _urlopen(req, timeout=_timeout, context=context)
+        resp = _urlopen(req, timeout=timeout, context=context)
 
         content_type = get_header(resp.headers, 'Content-type')
 
@@ -135,7 +135,7 @@ def read_from_url(url, accept_content_type=None):
     req.get_method = lambda: "GET"
 
     try:
-        response = _urlopen(req, timeout=_timeout, context=context)
+        response = _urlopen(req, timeout=timeout, context=context)
     except URLError as err:
         raise SpackWebError('Download failed: {ERROR}'.format(
             ERROR=str(err)))

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -68,7 +68,7 @@ class Hdf(AutotoolsPackage):
     # TODO: '@:4.2.14 ~external-xdr' and the fact that we compile for 64 bit
     #  architecture should be in conflict
 
-    #https://github.com/knedlsepp/nixpkgs/commit/c1a2918c849a5bc766c6d55d96bc6cf85c9d27f4
+    # https://github.com/knedlsepp/nixpkgs/commit/c1a2918c849a5bc766c6d55d96bc6cf85c9d27f4
     patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-ppc.patch?full_index=1',
           sha256='5434f29a87856aa05124c7a9409b3ec3106c30b1ad722720773623190f6bfda8',
           when='@4.2.15:')

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -68,6 +68,23 @@ class Hdf(AutotoolsPackage):
     # TODO: '@:4.2.14 ~external-xdr' and the fact that we compile for 64 bit
     #  architecture should be in conflict
 
+    #https://github.com/knedlsepp/nixpkgs/commit/c1a2918c849a5bc766c6d55d96bc6cf85c9d27f4
+    patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-ppc.patch?full_index=1',
+          sha256='5434f29a87856aa05124c7a9409b3ec3106c30b1ad722720773623190f6bfda8',
+          when='@4.2.15:')
+    patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-4.2.4-sparc.patch?full_index=1',
+          sha256='ce75518cccbeb80ab976b299225ea6104c3eec1ec13c09e2289913279fcf1b39',
+          when='@4.2.15:')
+    patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-s390.patch?full_index=1',
+          sha256='f7d67e8c3d0dad8bfca308936c6ac917cc0b63222c6339a29efdce14e8be6475',
+          when='@4.2.15:')
+    patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-arm.patch?full_index=1',
+          sha256='d54592df281c92e7e655b8312d18bef9ed096848de9430510e0699e98246ccd3',
+          when='@4.2.15:')
+    patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-aarch64.patch?full_index=1',
+          sha256='49733dd6143be7b30a28d386701df64a72507974274f7e4c0a9e74205510ea72',
+          when='@4.2.15:')
+
     @property
     def libs(self):
         """HDF can be queried for the following parameters:

--- a/var/spack/repos/builtin/packages/py-pyhdf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyhdf/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPyhdf(PythonPackage):
+    """pyhdf is a python wrapper around the NCSA HDF version 4 library.
+    The SD (Scientific Dataset), VS (Vdata) and V (Vgroup) API’s are
+    currently implemented. NetCDF files can also be read and modified."""
+
+    homepage = "https://github.com/fhs/pyhdf"
+    pypi     = "pyhdf/pyhdf-0.10.4.tar.gz"
+    git      = "https://github.com/fhs/pyhdf.git"
+    #maintainers = []
+
+    version('master', branch='master')
+    version('0.10.4', sha256='ea09b2bdafc9be0f7f43d72ff122d8efbde61881f4da3a659b33be5e29215f93')
+
+    # Python versions
+    depends_on('python@3.2:', type=('build', 'run'))
+
+    # Dependencies
+    depends_on('zlib', type=('build', 'run'))
+    depends_on('hdf', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('jpeg', type=('build', 'run'))
+
+    def setup_build_environment(self, env):
+        # DH* There should be direct attributes to use
+        import os
+        inc_dirs = []
+        lib_dirs = []
+        inc_dirs.append(os.path.join(self.spec['hdf'].prefix, 'include'))
+        inc_dirs.append(os.path.join(self.spec['jpeg'].prefix, 'include'))
+        lib_dirs.append(os.path.join(self.spec['hdf'].prefix, 'lib'))
+        lib_dirs.append(os.path.join(self.spec['jpeg'].prefix, 'lib'))
+        env.set('INCLUDE_DIRS', ':'.join(inc_dirs))
+        env.set('LIBRARY_DIRS', ':'.join(lib_dirs))
+        # *DH
+        if self.spec['hdf'].satisfies('@:4.1'):
+            env.set('NO_COMPRESS', '1')

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -24,6 +24,7 @@ class JediBaseEnv(BundlePackage):
     depends_on('bison', type='run')
     depends_on('flex', type='run')
 
+    depends_on('hdf', type='run')
     depends_on('netcdf-cxx4', type='run')
 
     depends_on('ecbuild', type='run')
@@ -48,6 +49,7 @@ class JediBaseEnv(BundlePackage):
     depends_on('py-pandas', type='run')
     depends_on('py-scipy', type='run')
     depends_on('py-pybind11', type='run')
+    depends_on('py-pyhdf', type='run')
     depends_on('py-h5py', type='run')
     depends_on('py-netcdf4',  type='run')
     depends_on('py-pycodestyle', type='run')

--- a/var/spack/repos/jcsda-emc-bundles/packages/nceplibs-bundle-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/nceplibs-bundle-env/package.py
@@ -3,27 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install nceplibs-bundle
-#
-# You can edit this file again by typing:
-#
-#     spack edit nceplibs-bundle
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 
 
-class NceplibsBundle(BundlePackage):
+class NceplibsBundleEnv(BundlePackage):
     """
     This is a collection of libraries commonly known as NCEPLIBS that are required 
     for several NCEP applications e.g. UFS, GSI, UPP, etc. 


### PR DESCRIPTION
This PR does the following:
- Add option to compile `openmpi` without flat namespace (aka two-level namespaces) - corresponding flags borrowed from `mpich`
- Rename `nceplibs-bundle` to `nceplibs-bundle-env`
- Add new package `py-pyhdf`, add it to `jedi-base-env`
- Bug fix for building `hdf` on Ubuntu 20.04 aarch64 - see also https://github.com/spack/spack/pull/30522
- Get timeout for web requests with `urllib` from spack config, same as for `curl` (see corresponding PR for the authoritative spack repo https://github.com/spack/spack/pull/30468)

See https://github.com/NOAA-EMC/spack-stack/pull/131 for the corresponding changes in `spack-stack` and for testing.