### PR TITLE
Add atlas@0.29.0 and enable all build options (variants) for ectrans

### DIFF
--- a/var/spack/repos/jcsda-emc/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/jcsda-emc/packages/ecmwf-atlas/package.py
@@ -17,7 +17,8 @@ class EcmwfAtlas(CMakePackage):
 
     version('master', branch='master')
     version('develop', branch='develop')
-    version('0.27.0', commit='d825fad7ab415558a81415914a0fc60da1d0295a', preferred=True)
+    version('0.29.0', commit='b2558897fa22b18164d4481089423e7b443436f9', preferred=True)
+    version('0.27.0', commit='d825fad7ab415558a81415914a0fc60da1d0295a')
     version('0.26.0', commit='3ae6184a598a00fbc6b1a77c3c9d5d808f1c65ea')
     version('0.25.0', commit='3c74adda4960723f237db936132888e3fd380154')
     version('0.24.1', commit='36772b5a72f91e99b30756808d8cff6edb415b8f')

--- a/var/spack/repos/jcsda-emc/packages/ectrans/package.py
+++ b/var/spack/repos/jcsda-emc/packages/ectrans/package.py
@@ -23,15 +23,16 @@ class Ectrans(CMakePackage):
     variant('mpi', default=True, description='Use MPI?')
     variant('openmp', default=True, description='Use OpenMP?')
 
-    #variant('double_precision', default=True, description='Support for double precision?')
-    #variant('single_precision', default=True, description='Support for single precision?')
+    variant('double_precision', default=True, description='Support for double precision?')
+    variant('single_precision', default=True, description='Support for single precision?')
 
     variant('mkl',  default=False, description='Use MKL?')
     variant('fftw', default=True, description='Use FFTW?')
 
-    #variant('transi', default=True, description='Compile TransI C-interface to trans?')
+    variant('transi', default=True, description='Compile TransI C-interface to trans?')
 
     depends_on('ecbuild', type=('build'))
+    #depends_on('ecbuild')
     depends_on('mpi',  when='+mpi')
     depends_on('blas')
     depends_on('lapack')
@@ -45,11 +46,11 @@ class Ectrans(CMakePackage):
         args = [
             self.define_from_variant('ENABLE_MPI', 'mpi'),
             self.define_from_variant('ENABLE_OMP', 'openmp'),
-            #self.define_from_variant('ENABLE_DOUBLE_PRECISION', 'double_precision'),
-            #self.define_from_variant('ENABLE_SINGLE_PRECISION', 'single_precision'),
+            self.define_from_variant('ENABLE_DOUBLE_PRECISION', 'double_precision'),
+            self.define_from_variant('ENABLE_SINGLE_PRECISION', 'single_precision'),
             self.define_from_variant('ENABLE_FFTW', 'fftw'),
-            self.define_from_variant('ENABLE_MKL', 'mkl')
-            #self.define_from_variant('ENABLE_TRANSI', 'transi')
+            self.define_from_variant('ENABLE_MKL', 'mkl'),
+            self.define_from_variant('ENABLE_TRANSI', 'transi')
         ]
 
         return args


### PR DESCRIPTION
As the title says: Add atlas@0.29.0 and enable all build options (variants) for ectrans.

Issues and testing: see https://github.com/NOAA-EMC/spack-stack/pull/140