### PR TITLE
Fix the hardcoded include and library directories in py-pyhdf

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyhdf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyhdf/package.py
@@ -29,16 +29,14 @@ class PyPyhdf(PythonPackage):
     depends_on('jpeg', type=('build', 'run'))
 
     def setup_build_environment(self, env):
-        # DH* There should be direct attributes to use
-        import os
         inc_dirs = []
         lib_dirs = []
-        inc_dirs.append(os.path.join(self.spec['hdf'].prefix, 'include'))
-        inc_dirs.append(os.path.join(self.spec['jpeg'].prefix, 'include'))
-        lib_dirs.append(os.path.join(self.spec['hdf'].prefix, 'lib'))
-        lib_dirs.append(os.path.join(self.spec['jpeg'].prefix, 'lib'))
+        # Strip -I and -L from spec include_flags / search_flags
+        inc_dirs.append(self.spec['hdf'].headers.include_flags.lstrip('-I'))
+        inc_dirs.append(self.spec['jpeg'].headers.include_flags.lstrip('-I'))
+        lib_dirs.append(self.spec['hdf'].libs.search_flags.lstrip('-L'))
+        lib_dirs.append(self.spec['jpeg'].libs.search_flags.lstrip('-L'))
         env.set('INCLUDE_DIRS', ':'.join(inc_dirs))
         env.set('LIBRARY_DIRS', ':'.join(lib_dirs))
-        # *DH
         if self.spec['hdf'].satisfies('@:4.1'):
             env.set('NO_COMPRESS', '1')


### PR DESCRIPTION
As the title says. This was a leftover from a previous PR where I had hardcoded the library directories for the `hdf` and `jpeg` specs to be `lib`, and similar for `include`. Using the correct spack library paths solves this problem. Just need to strip the leading `-I` and `-L` flags. Tested on Stampede2 with Intel.