### PR TITLE
Bug fix in gdal's package.py: append correct library path for json-c library to LDFLAGS

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -237,6 +237,7 @@ class Gdal(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         libs = []
+        ldflags = []
 
         # Required dependencies
         args = [
@@ -245,6 +246,11 @@ class Gdal(AutotoolsPackage):
             '--with-geotiff={0}'.format(spec['libgeotiff'].prefix),
             '--with-libjson-c={0}'.format(spec['json-c'].prefix),
         ]
+        # Fix for gdal always using suffix 'lib', even though libraries
+        # like json-c might get installed in 'lib64'
+        #ldflags.append(self.spec['libtiff'].libs.search_flags)
+        #ldflags.append(self.spec['libgeotiff'].libs.search_flags)
+        ldflags.append(self.spec['json-c'].libs.search_flags)
 
         # Optional dependencies
         if spec.satisfies('@3:'):
@@ -576,6 +582,8 @@ class Gdal(AutotoolsPackage):
         if libs:
             args.append('LIBS=' + ' '.join(libs))
 
+        if ldflags:
+            args.append('LDFLAGS=' + ' '.join(ldflags))
         return args
 
     # https://trac.osgeo.org/gdal/wiki/GdalOgrInJavaBuildInstructionsUnix


### PR DESCRIPTION
The `gdal` `configure` script hardcodes the library path to some of its dependencies to `lib`, but depending on the system it should be `lib64`. On Stampede2, this is the case for `json-c`.

Patching `configure` is unnecessarily complicated, the easiest way around is to add the correct library path to the `LDFLAGS` argument that gets passed to `configure` alongside with `LIBS`.

I only activated this for `json-c` but left the placholders for other dependencies in there in case those become necessary in the future/on other systems. Happy to remove if that is preferred.

Tested to work on Stampede2.
