### PR TITLE
Make qt discoverable by spack external find

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -191,6 +191,13 @@ class Qt(Package):
     depends_on("llvm", when='@5.11: +doc')
     depends_on("zstd@1.3:", when='@5.13:')
 
+    # For spack external find
+    executables = ['^qtplugininfo$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        return Executable(exe)('-v', output=str, error=str).lstrip('qplugininfo').strip()
+
     with when('+webkit'):
         patch(
             'https://src.fedoraproject.org/rpms/qt5-qtwebengine/raw/32062243e895612823b47c2ae9eeb873a98a3542/f/qtwebengine-gcc11.patch',


### PR DESCRIPTION
Make qt discoverable by spack external find. I followed the instructions in https://spack.readthedocs.io/en/latest/packaging_guide.html#make-package-findable and the example in the `gdal` package. Works on my macOS:
```
PATH=/usr/local/opt/qt5/bin:$PATH SPACK_SYSTEM_CONFIG_PATH=`pwd` spack external find --scope system qt
```
adds
```
  qt:
    externals:
    - spec: qt@5.15.3
      prefix: /usr/local/opt/qt5
```
to the `site.default`'s `packages.yaml` file.