### PR TITLE
Bug fix in var/spack/repos/builtin/packages/mpich/package.py: version…

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -337,11 +337,14 @@ with '-Wl,-commons,use_dylibs' and without
         # https://bugzilla.redhat.com/show_bug.cgi?id=1795817
         if self.spec.satisfies('%gcc@10:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
+            env.set('FCFLAGS', '-fallow-argument-mismatch')
         # Same fix but for macOS - avoids issue #17934
         if self.spec.satisfies('%apple-clang@11:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
+            env.set('FCFLAGS', '-fallow-argument-mismatch')
         if self.spec.satisfies('%clang@11:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
+            env.set('FCFLAGS', '-fallow-argument-mismatch')
 
         if 'pmi=cray' in self.spec:
             env.set(

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -335,16 +335,13 @@ with '-Wl,-commons,use_dylibs' and without
         env.unset('F90FLAGS')
 
         # https://bugzilla.redhat.com/show_bug.cgi?id=1795817
-        if self.spec.satisfies('%gcc@10:'):
-            env.set('FFLAGS', '-fallow-argument-mismatch')
-            env.set('FCFLAGS', '-fallow-argument-mismatch')
         # Same fix but for macOS - avoids issue #17934
-        if self.spec.satisfies('%apple-clang@11:'):
-            env.set('FFLAGS', '-fallow-argument-mismatch')
-            env.set('FCFLAGS', '-fallow-argument-mismatch')
-        if self.spec.satisfies('%clang@11:'):
-            env.set('FFLAGS', '-fallow-argument-mismatch')
-            env.set('FCFLAGS', '-fallow-argument-mismatch')
+        if 'gfortran' in self.compiler.fc:
+            gfortran_major_version = int(spack.compiler.get_compiler_version_output(
+                self.compiler.fc, '-dumpversion').split('.')[0])
+            if gfortran_major_version >= 10:
+                env.set('FFLAGS', '-fallow-argument-mismatch')
+                env.set('FCFLAGS', '-fallow-argument-mismatch')
 
         if 'pmi=cray' in self.spec:
             env.set(

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 from spack import *
 
 
@@ -51,6 +52,17 @@ class Wget(AutotoolsPackage, GNUMirrorPackage):
     depends_on('valgrind', type='test')
 
     build_directory = 'spack-build'
+
+    # For spack external find
+    executables = ['^wget$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        regex = re.compile('^GNU Wget (.*) built on .*')
+        output = Executable(exe)('--version', output=str, error=str).strip()
+        match = regex.match(output)
+        version = match.group(1)
+        return version
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
This PR contains:
- Bug fix in `var/spack/repos/builtin/packages/mpich/package.py`: version 4.x.y also needs `FCFLAGS` set correctly for `gfortran@10:`, not just `FFLAGS`
- `var/spack/repos/builtin/packages/wget/package.py`: Make `wget` detectable by spack (`spack external find`)

Both tested to work on macOS.

Note. I have not tested if setting `FCFLAGS` in addition to `FFLAGS` causes problems for earlier versions of `mpich` - I believe not.
