### PR TITLE
Add variant 64bitIO to gdal, default is on (doesn't work on NOAA's Gaea machine)

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -96,6 +96,7 @@ class Gdal(AutotoolsPackage):
     variant('cryptopp',  default=False, description='Include cryptopp support')
     variant('crypto',    default=False, description='Include crypto (from openssl) support')
     variant('grib',      default=False, description='Include GRIB support')
+    variant('64bitIO',   default=True,  description='Enable 64-bit file I/O')
 
     # FIXME: Allow packages to extend multiple packages
     # See https://github.com/spack/spack/issues/987
@@ -491,6 +492,11 @@ class Gdal(AutotoolsPackage):
                 spec['armadillo'].prefix))
         else:
             args.append('--with-armadillo=no')
+
+        if '+64bitIO' in spec:
+            args.append('--with-unix-stdio-64=yes')
+        else:
+            args.append('--with-unix-stdio-64=no')
 
         # TODO: add packages for these dependencies
         args.extend([

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -96,7 +96,7 @@ class Gdal(AutotoolsPackage):
     variant('cryptopp',  default=False, description='Include cryptopp support')
     variant('crypto',    default=False, description='Include crypto (from openssl) support')
     variant('grib',      default=False, description='Include GRIB support')
-    variant('unix_stdio_64', default=True, description='Enable 64-bit file I/O')
+    variant('unix_stdio_64', default=True, description='Utilize 64 stdio api')
 
     # FIXME: Allow packages to extend multiple packages
     # See https://github.com/spack/spack/issues/987

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -96,7 +96,7 @@ class Gdal(AutotoolsPackage):
     variant('cryptopp',  default=False, description='Include cryptopp support')
     variant('crypto',    default=False, description='Include crypto (from openssl) support')
     variant('grib',      default=False, description='Include GRIB support')
-    variant('64bitIO',   default=True,  description='Enable 64-bit file I/O')
+    variant('unix_stdio_64', default=True, description='Enable 64-bit file I/O')
 
     # FIXME: Allow packages to extend multiple packages
     # See https://github.com/spack/spack/issues/987
@@ -249,8 +249,8 @@ class Gdal(AutotoolsPackage):
         ]
         # Fix for gdal always using suffix 'lib', even though libraries
         # like json-c might get installed in 'lib64'
-        #ldflags.append(self.spec['libtiff'].libs.search_flags)
-        #ldflags.append(self.spec['libgeotiff'].libs.search_flags)
+        # ldflags.append(self.spec['libtiff'].libs.search_flags)
+        # ldflags.append(self.spec['libgeotiff'].libs.search_flags)
         ldflags.append(self.spec['json-c'].libs.search_flags)
 
         # Optional dependencies
@@ -493,7 +493,7 @@ class Gdal(AutotoolsPackage):
         else:
             args.append('--with-armadillo=no')
 
-        if '+64bitIO' in spec:
+        if '+unix_stdio_64' in spec:
             args.append('--with-unix-stdio-64=yes')
         else:
             args.append('--with-unix-stdio-64=no')


### PR DESCRIPTION
Add variant unix_stdio_64 to gdal, default is on. Doesn't work on NOAA's Gaea machine, therefore turning it off there.

Fixes https://github.com/NOAA-EMC/spack/issues/72