### PR TITLE
Minor documentation updates to JCSDA-EMC spack library

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack.py
@@ -7,7 +7,7 @@ from spack.extensions.stack.cmd.stack_cmds.create import setup_create_parser, st
 from spack.extensions.stack.cmd.stack_cmds.setup_meta_modules import setup_meta_modules_parser, stack_setup_meta_modules
 
 description = "Create spack-stack environment"
-section = "spack-stack-env"
+section = "spack-stack"
 level = "long"
 
 
@@ -21,7 +21,7 @@ container_path = os.path.join(stack_path(), 'configs' 'containers')
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='stack_command')
     create_parser = sp.add_parser('create',
-                                  help='Create spack-stack env or container.')
+                                  help='Create spack-stack environment or container.')
     meta_modules_parser = sp.add_parser('setup-meta-modules', help='Create lmod/lua or tcl/tk meta-modules')
     setup_create_parser(create_parser)
     setup_meta_modules_parser(meta_modules_parser)

--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
@@ -8,8 +8,8 @@ import shutil
 import llnl.util.tty as tty
 import spack.util.spack_yaml as syaml
 
-description = "Create spack-stack environment (env or container)"
-section = "spack-stack-env"
+description = "Create spack-stack environment (environment or container)"
+section = "spack-stack"
 level = "long"
 
 default_env_name = 'default'
@@ -51,7 +51,7 @@ def spec_help():
 
 
 def setup_common_parser_args(subparser):
-    """Shared CLI args for container and env subcommands"""
+    """Shared CLI args for container and environment subcommands"""
     subparser.add_argument(
         '--app', type=str, required=False, dest='app', default='empty',
         help=app_help()
@@ -83,6 +83,7 @@ def setup_common_parser_args(subparser):
 
 
 def setup_container_parser(subparser):
+    """ create container-specific parsing options"""
     subparser.add_argument(
         'container', help=container_config_help())
 
@@ -90,7 +91,7 @@ def setup_container_parser(subparser):
 
 
 def setup_env_parser(subparser):
-    """ create env specific parsing options"""
+    """ create environment-specific parsing options"""
     setup_common_parser_args(subparser)
     subparser.add_argument(
         '--site', type=str, required=False, default='default',
@@ -166,13 +167,13 @@ def env_create(args):
     env_dir = stack_env.env_dir()
     if os.path.exists(env_dir):
         if args.overwrite:
-            tty.msg('Env {} exists. Overwriting...'.format(env_dir))
+            tty.msg('Environment {} exists. Overwriting...'.format(env_dir))
             shutil.rmtree(env_dir)
         else:
-            raise Exception('Env: {} already exists'.format(env_dir))
+            raise Exception('Environment: {} already exists'.format(env_dir))
 
     if args.envs_file:
-        logging.debug('Creating envs from envs_file')
+        logging.debug('Creating environment from envs_file')
         with open(args.envs_file, 'r') as f:
             site_envs = syaml.load_config(stream=f)
 
@@ -181,10 +182,10 @@ def env_create(args):
             stack_env = StackEnv(**env['env'])
             stack_env.write()
     else:
-        logging.debug('Creating envs from command-line args')
+        logging.debug('Creating environment from command-line args')
         stack_env = StackEnv(**stack_settings)
         stack_env.write()
-        tty.msg('Created env {}'.format(env_dir))
+        tty.msg('Created environment {}'.format(env_dir))
 
 
 def stack_create(parser, args):

--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/setup_meta_modules.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/setup_meta_modules.py
@@ -5,7 +5,7 @@ from spack.extensions.stack.meta_modules import setup_meta_modules
 import llnl.util.tty as tty
 
 description = "Create meta-modules"
-section = "spack-stack-env"
+section = "spack-stack"
 level = "long"
 
 

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -66,18 +66,18 @@ def spack_hash():
 
 class StackEnv(object):
     """ Represents a spack.yaml environment based on different
-    configurations of sites and specs. Can be created through an envs.yaml or
-    through the command line. Uses Spack's library
-    to maintain an internal state that represents the yaml and can be
-    written out with write().
-    The output is a pure Spack environment.
+    configurations of sites and specs. Can be created through
+    an envs.yaml orthrough the command line. Uses the Spack
+    library to maintain an internal state that represents the
+    yaml and can be written out with write(). The output is a
+    pure Spack environment.
     """
 
     def __init__(self, **kwargs):
         """
-        Construct properties directly from kwargs so they can be passed in
-        through a dictionary (input file), or named args
-        for command-line usage.
+        Construct properties directly from kwargs so they can
+        be passed in through a dictionary (input file), or named
+        args for command-line usage.
         """
 
         self.dir = kwargs.get('dir')


### PR DESCRIPTION
Minor documentation updates to JCSDA-EMC spack library, such as spelling out `environment` in several of the comments, adjusting the line wrapping etc. I decided not to change `spack stack create env` to `spack stack create environment`. 

Works on my Mac.