### PR TITLE
By default, turn off variant unix_stdio_64 for gdal

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -96,7 +96,7 @@ class Gdal(AutotoolsPackage):
     variant('cryptopp',  default=False, description='Include cryptopp support')
     variant('crypto',    default=False, description='Include crypto (from openssl) support')
     variant('grib',      default=False, description='Include GRIB support')
-    variant('unix_stdio_64', default=True, description='Utilize 64 stdio api')
+    variant('unix_stdio_64', default=False, description='Utilize 64 stdio api')
 
     # FIXME: Allow packages to extend multiple packages
     # See https://github.com/spack/spack/issues/987


### PR DESCRIPTION
For more information on why this is needed refer to the discussion in https://github.com/spack/spack/pull/30809 and issue https://github.com/NOAA-EMC/spack-stack/issues/152. I tested this on macOS. Will run CI tests with this spack branch to confirm it fixes those, too.