### PR TITLE
Add --specs and --template option

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/stack_paths.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_paths.py
@@ -19,5 +19,5 @@ def stack_path(*paths):
 
 
 site_path = stack_path('configs', 'sites')
-app_path = stack_path('configs', 'apps')
 container_path = stack_path('configs', 'containers')
+template_path = stack_path('configs', 'templates')

--- a/lib/jcsda-emc/spack-stack/tests/test_setup_meta_modules.py
+++ b/lib/jcsda-emc/spack-stack/tests/test_setup_meta_modules.py
@@ -27,7 +27,7 @@ def test_setup_meta_modules():
 
     env_dir = os.path.join(test_dir)
     create_output = stack_create('create', 'env', '--dir', env_dir,
-                                 '--app', 'empty', '--site', 'default', '--overwrite')
+                                 '--site', 'default', '--overwrite')
 
     # Create empty env
     env_dir = os.path.join(env_dir, 'empty.default')
@@ -47,6 +47,7 @@ def test_setup_meta_modules():
     scope = env.env_file_config_scope_name()
     spack.config.add('packages:all:compiler:[{}]'.format(comp), scope=scope)
     spack.config.add('packages:all:providers:mpi:[{}]'.format(mpi), scope=scope)
+    spack.config.add('packages:openmpi:version:[{}]'.format(mpi_ver))
     spack.main.SpackCommand('stack')
     os.makedirs(compiler_module_path)
     os.makedirs(mpi_module_path)

--- a/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
+++ b/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
@@ -20,9 +20,9 @@ def stack_path(*paths):
 test_dir = stack_path('envs', 'unit-tests', 'stack-create')
 
 
-def all_apps():
-    _, apps, _ = next(os.walk(stack_path('configs', 'apps')))
-    return list(apps)
+def all_templates():
+    _, templates, _ = next(os.walk(stack_path('configs', 'templates')))
+    return list(templates)
 
 
 def all_sites():
@@ -32,15 +32,21 @@ def all_sites():
 
 def all_containers():
     _, _, containers = next(os.walk(stack_path('configs', 'containers')))
-    print(containers)
     return containers
 
 
+def all_specs():
+    bundles_dir = os.path.join(spack.paths.var_path, 'repos',
+                               'jcsda-emc-bundles', 'packages')
+    _, bundle_envs, _ = next(os.walk(bundles_dir))
+    return bundle_envs
+
+
 @pytest.mark.extension('stack')
-@pytest.mark.parametrize('app', all_apps())
+@pytest.mark.parametrize('template', all_templates())
 @pytest.mark.filterwarnings('ignore::UserWarning')
-def test_apps(app):
-    output = stack_create('create', 'env', '--app', app,
+def test_apps(template):
+    output = stack_create('create', 'env', '--template', template,
                           '--dir', test_dir, '--overwrite')
 
 
@@ -53,9 +59,17 @@ def test_sites(site):
 
 
 @pytest.mark.extension('stack')
+@pytest.mark.parametrize('spec', all_specs())
+@pytest.mark.filterwarnings('ignore::UserWarning')
+def test_specs(spec):
+    output = stack_create('create', 'env', '--specs', spec,
+                          '--dir', test_dir, '--overwrite')
+
+
+@pytest.mark.extension('stack')
 @pytest.mark.parametrize('container', all_containers())
 @pytest.mark.filterwarnings('ignore::UserWarning')
 def test_containers(container):
     container_wo_ext = os.path.splitext(container)[0]
-    output = stack_create('create', 'container', container_wo_ext, '--app', 'empty',
+    output = stack_create('create', 'container', container_wo_ext,
                           '--dir', test_dir, '--overwrite')

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-fv3-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-fv3-env/package.py
@@ -8,18 +8,17 @@ import sys
 
 from spack import *
 
-class SocaBundleEnv(BundlePackage):
-    """Development environment for soca-bundle"""
+class JediFv3Env(BundlePackage):
+    """Development environment for fv3-bundle"""
 
-    # DH* TODO UPDATE
-    homepage = "https://github.com/JCSDA-internal/soca"
-    git      = "https://github.com/JCSDA-internal/soca.git"
+    homepage = "https://github.com/JCSDA-internal/fv3-bundle"
+    git      = "https://github.com/JCSDA-internal/fv3-bundle.git"
 
-    maintainers = ['climbfuji', 'travissluka' ]
+    maintainers = ['climbfuji', 'rhoneyager']
 
     version('main', branch='main')
 
     depends_on('base-env', type='run')
     depends_on('jedi-base-env', type='run')
 
-    depends_on('nco', type='run')
+    depends_on('fms-jcsda@release-stable')

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
@@ -8,7 +8,7 @@ import sys
 
 from spack import *
 
-class JediUfsBundleEnv(BundlePackage):
+class JediUfsEnv(BundlePackage):
     """Development environment for fv3-bundle"""
 
     # DH* TODO - we should rename this to just ufs-bundle to match the other bundles

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-um-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-um-env/package.py
@@ -8,7 +8,7 @@ import sys
 
 from spack import *
 
-class JediUmBundleEnv(BundlePackage):
+class JediUmEnv(BundlePackage):
     """Development environment for um-bundle"""
 
     # DH* TODO UPDATE

--- a/var/spack/repos/jcsda-emc-bundles/packages/nceplibs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/nceplibs-env/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class NceplibsBundleEnv(BundlePackage):
+class NceplibsEnv(BundlePackage):
     """
     This is a collection of libraries commonly known as NCEPLIBS that are required 
     for several NCEP applications e.g. UFS, GSI, UPP, etc. 

--- a/var/spack/repos/jcsda-emc-bundles/packages/soca-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/soca-env/package.py
@@ -8,17 +8,18 @@ import sys
 
 from spack import *
 
-class JediFv3BundleEnv(BundlePackage):
-    """Development environment for fv3-bundle"""
+class SocaEnv(BundlePackage):
+    """Development environment for soca-bundle"""
 
-    homepage = "https://github.com/JCSDA-internal/fv3-bundle"
-    git      = "https://github.com/JCSDA-internal/fv3-bundle.git"
+    # DH* TODO UPDATE
+    homepage = "https://github.com/JCSDA-internal/soca"
+    git      = "https://github.com/JCSDA-internal/soca.git"
 
-    maintainers = ['climbfuji', 'rhoneyager']
+    maintainers = ['climbfuji', 'travissluka' ]
 
     version('main', branch='main')
 
     depends_on('base-env', type='run')
     depends_on('jedi-base-env', type='run')
 
-    depends_on('fms-jcsda@release-stable')
+    depends_on('nco', type='run')


### PR DESCRIPTION
* The number of apps was growing to be large, and all they did was specify a single spec. Add a `--specs` option to add specs to an environment. And then change the `apps` directory to `templates` to provide unique environments which can be used as a base for further site or spec configuration.

* The `--template` option specifies a base spack.yaml to use and it defaults to `empty` like the app previously did.

* Syncronize bundle names. Remove the bundle from the name and leave it at just `<name>-env`.