### PR TITLE
Fix crtm-fix 2.4.0_emc download

### DIFF
--- a/var/spack/repos/jcsda-emc/packages/crtm-fix/package.py
+++ b/var/spack/repos/jcsda-emc/packages/crtm-fix/package.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 from spack import *
+import os
 
 
 class CrtmFix(Package):
@@ -20,10 +20,12 @@ class CrtmFix(Package):
     version('2.3.0_emc', sha256='fde73bb41c3c00666ab0eb8c40895e02d36fa8d7b0896c276375214a1ddaab8f')
 
     variant('big_endian', default=True, description='Install big_endian fix files')
-    variant('little_endian', default=False, description='Install little endian fix files')
+    variant('little_endian', default=False,
+            description='Install little endian fix files')
     variant('netcdf', default=True, description='Install netcdf fix files')
 
-    conflicts('+big_endian', when='+little_endian', msg='big_endian and little_endian conflict')
+    conflicts('+big_endian', when='+little_endian',
+              msg='big_endian and little_endian conflict')
 
     def url_for_version(self, version):
         url = 'ftp://ftp.ucar.edu/pub/cpaess/bjohns/fix_REL-{}.tgz'
@@ -31,6 +33,7 @@ class CrtmFix(Package):
 
     def install(self, spec, prefix):
         spec = self.spec
+        mkdir(self.prefix.fix)
 
         endian_dirs = []
         if '+big_endian' in spec:
@@ -49,19 +52,17 @@ class CrtmFix(Package):
         # Little_Endian amsua_metop-c_v2.SpcCoeff.bin is what it's supposed to be
         # Remove the incorrect file, and install it as noACC, and install the correct file.
         if '+big_endian' in spec and spec.version == Version('2.4.0_emc'):
-            fix_files.remove(
-                join_path(cwd, 'SpcCoeff', 'Big_Endian', 'amsua_metop-c.SpcCoeff.bin'))
+            remove_path = join_path(os.getcwd(), 'fix', 'SpcCoeff',
+                                    'Big_Endian', 'amsua_metop-c.SpcCoeff.bin')
+            fix_files.remove(remove_path)
 
             # This file is incorrect, install it as a different name.
-            install(join_path('SpcCoeff', 'Big_Endian', 'amsua_metop-c.SpcCoeff.bin'),
-                        join_path(self.prefix.fix, 'amsua_metop-c.SpcCoeff.noACC.bin'))
-                        
-            # This "Little_Endian" file is actually the correct one.
-            install(join_path('SpcCoeff', 'Little_Endian', 'amsua_metop-c_v2.SpcCoeff.bin'),
-                        join_path(self.prefix.fix, 'amsua_metop-c.SpcCoeff.bin'))
+            install(join_path('fix', 'SpcCoeff', 'Big_Endian', 'amsua_metop-c.SpcCoeff.bin'),
+                    join_path(self.prefix.fix, 'amsua_metop-c.SpcCoeff.noACC.bin'))
 
-        mkdir(self.prefix.fix)
-        cwd = pwd()
+            # This "Little_Endian" file is actually the correct one.
+            install(join_path('fix', 'SpcCoeff', 'Little_Endian', 'amsua_metop-c_v2.SpcCoeff.bin'),
+                    join_path(self.prefix.fix, 'amsua_metop-c.SpcCoeff.bin'))
 
         for f in fix_files:
             install(f, self.prefix.fix)

--- a/var/spack/repos/jcsda-emc/packages/crtm-fix/package.py
+++ b/var/spack/repos/jcsda-emc/packages/crtm-fix/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
+
+from spack import *
 
 
 class CrtmFix(Package):
@@ -49,19 +50,22 @@ class CrtmFix(Package):
             fix_files = fix_files + find('.', '*/{}/*'.format(d))
 
         # Big_Endian amsua_metop-c.SpcCoeff.bin is incorrect
-        # Little_Endian amsua_metop-c_v2.SpcCoeff.bin is what it's supposed to be
-        # Remove the incorrect file, and install it as noACC, and install the correct file.
+        # Little_Endian amsua_metop-c_v2.SpcCoeff.bin is what it's supposed to be.
+        # Remove the incorrect file, and install it as noACC,, then install
+        # correct file under new name.
         if '+big_endian' in spec and spec.version == Version('2.4.0_emc'):
             remove_path = join_path(os.getcwd(), 'fix', 'SpcCoeff',
                                     'Big_Endian', 'amsua_metop-c.SpcCoeff.bin')
             fix_files.remove(remove_path)
 
             # This file is incorrect, install it as a different name.
-            install(join_path('fix', 'SpcCoeff', 'Big_Endian', 'amsua_metop-c.SpcCoeff.bin'),
+            install(join_path('fix', 'SpcCoeff', 'Big_Endian',
+                              'amsua_metop-c.SpcCoeff.bin'),
                     join_path(self.prefix.fix, 'amsua_metop-c.SpcCoeff.noACC.bin'))
 
             # This "Little_Endian" file is actually the correct one.
-            install(join_path('fix', 'SpcCoeff', 'Little_Endian', 'amsua_metop-c_v2.SpcCoeff.bin'),
+            install(join_path('fix', 'SpcCoeff', 'Little_Endian',
+                              'amsua_metop-c_v2.SpcCoeff.bin'),
                     join_path(self.prefix.fix, 'amsua_metop-c.SpcCoeff.bin'))
 
         for f in fix_files:


### PR DESCRIPTION
The format in the file changed. 'fix' is a subdirectory instead of being top-level (I think by accident) of something like crtm-release-2.4.0_emc