### PR TITLE
Add py-ruamel-yaml-clib@0.2.4 and set Python dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-ruamel-yaml-clib/package.py
+++ b/var/spack/repos/builtin/packages/py-ruamel-yaml-clib/package.py
@@ -11,7 +11,10 @@ class PyRuamelYamlClib(PythonPackage):
     homepage = "https://sourceforge.net/p/ruamel-yaml-clib/code/ci/default/tree/"
     pypi = "ruamel.yaml.clib/ruamel.yaml.clib-0.2.0.tar.gz"
 
+    version('0.2.4', sha256='f997f13fd94e37e8b7d7dbe759088bb428adc6570da06b64a913d932d891ac8d')
     version('0.2.0', sha256='b66832ea8077d9b3f6e311c4a53d06273db5dc2db6e8a908550f3c14d67e718c')
 
-    depends_on('python@2.7:2.8,3.5:', type=('build', 'link', 'run'))
+    # https://sourceforge.net/p/ruamel-yaml-clib/tickets/5
+    depends_on('python@2.7:2.8,3.5:3.9', when='@:0.2.1', type=('build', 'link', 'run'))
+    depends_on('python@3.5:',            when='@0.2.4:', type=('build', 'link', 'run'))
     depends_on('py-setuptools@28.7.0:', type='build')


### PR DESCRIPTION
py-ruamel-yaml-clib older than 0.2.4 doesn't build with Python 3.10, see `https://sourceforge.net/p/ruamel-yaml-clib/tickets/5`. Add version 0.2.4 and set Python dependencies.

I tested this on Ubuntu 22.04 with Python 3.10 and it worked, but then I gave up trying to fix many other errors ... this PR is still ok to go in, though.