### PR TITLE
Bring back common config in environments, set JCSDA-EMC bundle versions to 1.0.0

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
@@ -15,7 +15,6 @@ level = "long"
 
 default_env_name = 'default'
 default_env_path = stack_path('envs')
-default_packages = stack_path('configs', 'common', 'packages.yaml')
 
 
 def default_site():
@@ -97,9 +96,8 @@ def setup_common_parser_args(subparser):
     )
 
     subparser.add_argument(
-        '--packages', type=str, required=False, default=default_packages,
-        help='Base packages.yaml.'
-        ' Defaults to {}'.format(default_packages)
+        '--packages', type=str, required=False, default=None,
+        help='Base packages.yaml, use to override common packages.yaml.'
     )
 
 

--- a/lib/jcsda-emc/spack-stack/stack/container_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/container_env.py
@@ -1,7 +1,7 @@
 import os
 import spack
 import spack.util.spack_yaml as syaml
-from spack.extensions.stack.stack_paths import stack_path, container_path, template_path
+from spack.extensions.stack.stack_paths import stack_path, container_path, template_path, common_path
 import copy
 
 
@@ -34,7 +34,10 @@ class StackContainer():
 
         self.dir = dir
         self.env_dir = os.path.join(self.dir, self.name)
-        self.base_packages = base_packages
+        if base_packages:
+            self.base_packages = base_packages
+        else:
+            self.base_packages = os.path.join(common_path, 'packages.yaml')
 
     def write(self):
         """Merge base packages and app's spack.yaml into

--- a/lib/jcsda-emc/spack-stack/stack/stack_paths.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_paths.py
@@ -17,7 +17,7 @@ def stack_path(*paths):
 
     return os.path.join(stack_dir, *paths)
 
-
+common_path = stack_path('configs', 'common')
 site_path = stack_path('configs', 'sites')
 container_path = stack_path('configs', 'containers')
 template_path = stack_path('configs', 'templates')

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -33,12 +33,12 @@ class Fms(CMakePackage):
     # These versions were adapated by JCSDA and are only meant to be
     # used temporarily, until the JCSDA changes have found their way
     # back into the official repository.
-    # The following commit corresponds to branch='feature/no-openmp-option_default_on'
-    version('release-jcsda', commit="6ed89b23e3dc7b8d74191f92760a9487de93a85b", no_cache=True)
+    # The following commit corresponds to branch='release-stable' in the JCSDA public fork
+    version('release-jcsda', commit="1f739141ef8b000a0bd75ae8bebfadea340299ba", no_cache=True)
     #version('dev-jcsda', branch='dev/jcsda', no_cache=True)
 
     with when('@release-jcsda'):
-        git      = "https://github.com/climbfuji/fms.git"
+        git      = "https://github.com/JCSDA/fms.git"
     # *DH 20220602
 
     variant('64bit', default=True, description='Build a version of the library with default 64 bit reals')

--- a/var/spack/repos/builtin/packages/py-ruamel-yaml-clib/package.py
+++ b/var/spack/repos/builtin/packages/py-ruamel-yaml-clib/package.py
@@ -11,7 +11,10 @@ class PyRuamelYamlClib(PythonPackage):
     homepage = "https://sourceforge.net/p/ruamel-yaml-clib/code/ci/default/tree/"
     pypi = "ruamel.yaml.clib/ruamel.yaml.clib-0.2.0.tar.gz"
 
+    version('0.2.4', sha256='f997f13fd94e37e8b7d7dbe759088bb428adc6570da06b64a913d932d891ac8d')
     version('0.2.0', sha256='b66832ea8077d9b3f6e311c4a53d06273db5dc2db6e8a908550f3c14d67e718c')
 
-    depends_on('python@2.7:2.8,3.5:', type=('build', 'link', 'run'))
+    # https://sourceforge.net/p/ruamel-yaml-clib/tickets/5
+    depends_on('python@2.7:2.8,3.5:3.9', when='@:0.2.1', type=('build', 'link', 'run'))
+    depends_on('python@3.5:',            when='@0.2.4:', type=('build', 'link', 'run'))
     depends_on('py-setuptools@28.7.0:', type='build')

--- a/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
@@ -16,7 +16,7 @@ class BaseEnv(BundlePackage):
 
     maintainers = ['climbfuji', 'kgerheiser']
 
-    version('main', branch='main')
+    version('1.0.0')
 
     # Basic utilities
     if sys.platform == 'darwin':
@@ -38,3 +38,5 @@ class BaseEnv(BundlePackage):
 
     # Python
     depends_on('python@3.7:')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/emc-gfs-wafs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/emc-gfs-wafs-env/package.py
@@ -27,3 +27,5 @@ class EmcGfsWafsEnv(BundlePackage):
     depends_on('ip')
     depends_on('g2')
     depends_on('bufr')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/emc-verif-global-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/emc-verif-global-env/package.py
@@ -16,7 +16,7 @@ class EmcVerifGlobalEnv(BundlePackage):
 
     maintainers = ['kgerheiser']
 
-    version('develop', branch='develop')
+    version('1.0.0')
 
     depends_on('python')
     depends_on('netcdf-c')
@@ -31,3 +31,5 @@ class EmcVerifGlobalEnv(BundlePackage):
     depends_on('prod-util')
     depends_on('met')
     depends_on('metplus')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/gldas-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/gldas-env/package.py
@@ -16,7 +16,7 @@ class GldasEnv(BundlePackage):
 
     maintainers = ['kgerheiser']
 
-    version('develop', branch='develop')
+    version('1.0.0')
 
     depends_on('netcdf-c')
     depends_on('netcdf-fortran')
@@ -26,3 +26,5 @@ class GldasEnv(BundlePackage):
     depends_on('nemsio')
     depends_on('bacio')
     depends_on('sp')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/global-workflow-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/global-workflow-env/package.py
@@ -16,7 +16,7 @@ class GlobalWorkflowEnv(BundlePackage):
 
     maintainers = ['kgerheiser']
 
-    version('develop', branch='develop')
+    version('1.0.0')
 
     depends_on('prod-util')
     depends_on('nco')
@@ -40,3 +40,5 @@ class GlobalWorkflowEnv(BundlePackage):
     depends_on('met')
     depends_on('metplus')
     depends_on('gw-pyenv')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/gsi-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/gsi-env/package.py
@@ -16,7 +16,7 @@ class GsiEnv(BundlePackage):
 
     maintainers = ['kgerheiser']
 
-    version('develop', branch='develop')
+    version('1.0.0')
 
     depends_on('netcdf-c')
     depends_on('netcdf-fortran')
@@ -31,3 +31,5 @@ class GsiEnv(BundlePackage):
     depends_on('wrf-io')
     depends_on('crtm')
     depends_on('ncio')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/gw-pyenv/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/gw-pyenv/package.py
@@ -26,3 +26,5 @@ class GwPyenv(BundlePackage):
     depends_on('py-pandas')
     depends_on('py-python-dateutil')
     depends_on('py-netcdf4')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -16,7 +16,7 @@ class JediBaseEnv(BundlePackage):
 
     maintainers = ['climbfuji', 'rhoneyager']
 
-    version('main', branch='main')
+    version('1.0.0')
 
     depends_on('base-env',                       type='run')
     depends_on('bison',                          type='run')
@@ -50,3 +50,4 @@ class JediBaseEnv(BundlePackage):
     depends_on('py-scipy',                       type='run')
     depends_on('udunits',                        type='run')
 
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ewok-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ewok-env/package.py
@@ -17,7 +17,7 @@ class JediEwokEnv(BundlePackage):
 
     maintainers = ['climbfuji', 'ericlingerfelt']
 
-    version('main', branch='main')
+    version('1.0.0')
 
     # Variants defining repositories that are not yet publicly available
     variant('solo', default=False, description='Build solo (general tools for Python programmers)')
@@ -39,3 +39,5 @@ class JediEwokEnv(BundlePackage):
 
     conflicts('%gcc platform=darwin', msg='jedi-ewok-env does ' + \
         'not build with gcc (11?) on macOS (12), use apple-clang')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-fv3-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-fv3-env/package.py
@@ -16,9 +16,10 @@ class JediFv3Env(BundlePackage):
 
     maintainers = ['climbfuji', 'rhoneyager']
 
-    version('main', branch='main')
+    version('1.0.0')
 
     depends_on('base-env',          type='run')
     depends_on('fms@release-jcsda', type='run')
     depends_on('jedi-base-env',     type='run')
 
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-mpas-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-mpas-env/package.py
@@ -16,9 +16,11 @@ class JediMpasEnv(BundlePackage):
 
     maintainers = ['climbfuji', 'rhoneyager']
 
-    version('main')
+    version('1.0.0')
 
     depends_on('base-env',          type='run')
     depends_on('jedi-base-env',     type='run')
 
     # Anything missing?
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
@@ -17,7 +17,7 @@ class JediToolsEnv(BundlePackage):
 
     maintainers = ['climbfuji', 'rhoneyager']
 
-    version('main', branch='main')
+    version('1.0.0')
 
     variant('latex',
             default=False,
@@ -32,3 +32,5 @@ class JediToolsEnv(BundlePackage):
     depends_on('texlive', when='+latex',                 type='run')
 
     conflicts('%intel', msg='jedi-tools-env does not build with Intel')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
@@ -17,9 +17,10 @@ class JediUfsEnv(BundlePackage):
 
     maintainers = ['climbfuji', 'mark-a-potts']
 
-    version('main', branch='main')
+    version('1.0.0')
 
     depends_on('base-env',                    type='run')
     depends_on('jedi-base-env',               type='run')
     depends_on('ufs-weather-model-env',       type='run')
 
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-um-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-um-env/package.py
@@ -18,7 +18,7 @@ class JediUmEnv(BundlePackage):
 
     maintainers = ['climbfuji', 'rhoneyager']
 
-    version('main', branch='main')
+    version('1.0.0')
 
     depends_on('base-env',      type='run')
     depends_on('ectrans',       type='run')
@@ -26,3 +26,4 @@ class JediUmEnv(BundlePackage):
     depends_on('jedi-base-env', type='run')
     depends_on('shumlib',       type='run')
 
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/soca-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/soca-env/package.py
@@ -16,9 +16,10 @@ class SocaEnv(BundlePackage):
 
     maintainers = ['climbfuji', 'travissluka']
 
-    version('main', branch='main')
+    version('1.0.0')
 
     depends_on('base-env',      type='run')
     depends_on('jedi-base-env', type='run')
     depends_on('nco',           type='run')
 
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-utils-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-utils-env/package.py
@@ -17,7 +17,7 @@ class UfsUtilsEnv(BundlePackage):
 
     maintainers = ['kgerheiser', 'Hang-Lei-NOAA']
 
-    version('develop')
+    version('1.0.0')
 
     depends_on('netcdf-c')
     depends_on('netcdf-fortran')

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
@@ -16,13 +16,13 @@ class UfsWeatherModelEnv(BundlePackage):
 
     maintainers = ['kgerheiser', 'climbfuji']
 
-    version('main', branch='main')
+    version('1.0.0')
 
     variant('debug', default=False, description='Build a debug version of certain dependencies (ESMF, MAPL)')
 
     depends_on('base-env', type='run')
 
-    depends_on('fms@2022.01', type='run')
+    depends_on('fms',         type='run')
     depends_on('bacio',       type='run')
     depends_on('crtm',        type='run')
     depends_on('g2',          type='run')
@@ -36,3 +36,4 @@ class UfsWeatherModelEnv(BundlePackage):
     depends_on('mapl~debug', type='run', when='~debug')
     depends_on('mapl+debug', type='run', when='+debug')
 
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufswm-pyenv/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufswm-pyenv/package.py
@@ -26,3 +26,5 @@ class UfswmPyenv(BundlePackage):
     depends_on('py-pandas')
     depends_on('py-python-dateutil')
     depends_on('py-netcdf4')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/upp-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/upp-env/package.py
@@ -16,7 +16,7 @@ class UppEnv(BundlePackage):
 
     maintainers = ['kgerheiser']
 
-    version('develop', branch='develop')
+    version('1.0.0')
 
     depends_on('netcdf-fortran')
     depends_on('bacio')
@@ -30,3 +30,5 @@ class UppEnv(BundlePackage):
     depends_on('w3nco')
     depends_on('w3emc')
     depends_on('wrf-io')
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/ww3-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ww3-env/package.py
@@ -16,7 +16,7 @@ class Ww3Env(BundlePackage):
 
     maintainers = ['kgerheiser', 'Hang-Lei-NOAA']
 
-    version('develop')
+    version('1.0.0')
 
     variant('grib2', default=True, description='Build with g2 library for GRIB2 I/O.')
     variant('netcdf', default=True, description='Build with NetCDF I/O.')


### PR DESCRIPTION
Two sets of changes:

1. Spack extension updates: Bring back common config in environments, and make `--packages` an option to overwrite the common `packages.yaml`. This makes more sense to me, because users may want to adapt the other config files as well (i.e. the common `modules.yaml`). It is also more consistent and less confusing in my opinion
2. Package updates:
    - Set versions of JCSDA-EMC bundles to 1.0.0 throughout. Most of the EMC bundles already had that, but not all, and none of the JCSDA bundles had it.
    - Point JCSDA release-stable version of FMS back to JCSDA public repo, @climbfuji's changes were merged.
    - py-ruamel-yaml-clib older than 0.2.4 doesn't build with Python 3.10, see `https://sourceforge.net/p/ruamel-yaml-clib/tickets/5`. Add version 0.2.4 and set Python dependencies. I tested this on Ubuntu 22.04 with Python 3.10 and it worked.

Tested successfully on my macOS with the skylab-1.0.0 template (build almost everything that we have in spack-stack).