### PR TITLE
Create py-f90nml package

### DIFF
--- a/var/spack/repos/jcsda-emc/packages/py-f90nml/package.py
+++ b/var/spack/repos/jcsda-emc/packages/py-f90nml/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyF90nml(PythonPackage):
+    """A Python module and command line tool for parsing Fortran namelist files"""
+
+    homepage = "https://www.example.com"
+    pypi     = "f90nml/f90nml-1.4.2.tar.gz"
+
+    maintainers = ['kgerheiser', 'Hang-Lei-NOAA']
+
+    version('1.4.2', sha256='becacc8bed78efa3873438027f898fdd42f3b447c94cd29ae3033d6ff88ab9bb')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
This package is used for reading, writing, and editing Fortran namelist files as well as converting between a Python dict, JSON, and YAML.