### PR TITLE
Add grib2 and netcdf variant to Grads along with v2.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -19,6 +19,7 @@ class G2c(CMakePackage):
     variant('png', default=True)
     variant('jasper', default=True)
     variant('openjpeg', default=False)
+    variant('pic', default=True, description='Build with position-independent-code')
 
     version('1.6.4', sha256='5129a772572a358296b05fbe846bd390c6a501254588c6a223623649aefacb9d')
     version('1.6.2', sha256='b5384b48e108293d7f764cdad458ac8ce436f26be330b02c69c2a75bb7eb9a2c')
@@ -26,6 +27,14 @@ class G2c(CMakePackage):
     depends_on('libpng', when='+png')
     depends_on('jasper', when='+jasper')
     depends_on('openjpeg', when='+openjpeg')
+
+    def cmake_args(self):
+        args = []
+
+        if '+pic' in self.spec:
+            args.append('-DCMAKE_POSITION_INDEPENDENT_CODE=ON')
+
+        return args
 
     def setup_run_environment(self, env):
         lib = find_libraries('libg2c', root=self.prefix, shared=False, recursive=True)

--- a/var/spack/repos/builtin/packages/grads/package.py
+++ b/var/spack/repos/builtin/packages/grads/package.py
@@ -17,35 +17,76 @@ class Grads(AutotoolsPackage):
     homepage = "http://cola.gmu.edu/grads/grads.php"
     url      = "ftp://cola.gmu.edu/grads/2.2/grads-2.2.1-src.tar.gz"
 
+    version('2.2.2', sha256='5b28c2674c538342132f1a557be72287850ddaf10f51b7161c6837cf833f2c8f')
     version('2.2.1', sha256='695e2066d7d131720d598bac0beb61ac3ae5578240a5437401dc0ffbbe516206')
 
     variant('geotiff', default=True, description="Enable GeoTIFF support")
     variant('shapefile', default=True, description="Enable Shapefile support")
+    variant('grib2', default=True, description='Enable GRIB2 support with the g2c library.')
+    variant('netcdf', default=True, description='Enable NetCDF support')
 
     """
     # FIXME: Fails with undeclared functions (tdefi, tdef, ...) in gauser.c
-    variant('hdf5', default=False, description="Enable HDF5 support")
     variant('hdf4', default=False, description="Enable HDF4 support")
-    variant('netcdf', default=False, description="Enable NetCDF support")
-    depends_on('hdf5', when='+hdf5')
     depends_on('hdf', when='+hdf4')
-    depends_on('netcdf-c', when='+netcdf')
     """
 
     depends_on('libgeotiff', when='+geotiff')
     depends_on('shapelib', when='+shapefile')
+    depends_on('g2c+pic', when='+grib2')
     depends_on('udunits')
     depends_on('libgd')
     depends_on('libxmu')
     depends_on('cairo +X +pdf +fc +ft')
     depends_on('readline')
     depends_on('pkgconfig', type='build')
+    depends_on('netcdf-c', when='+netcdf')
+    depends_on('hdf5', when='+netcdf')
+
+    # Grads does not supply #include <stdint.h> which Intel complains about
+    patch('stdint.patch')
 
     def setup_build_environment(self, env):
         env.set('SUPPLIBS', '/')
 
     def setup_run_environment(self, env):
         env.set('GADDIR', self.prefix.data)
+
+    # -lgrib2c is -lg2c
+    # and no reason to hardcode PNG version
+    def patch(self):
+        filter_file('-lgrib2c', '-lg2c', 'configure')
+        filter_file('-lpng15', '-lpng', 'configure')
+
+    def setup_build_environment(self, env):
+        spec = self.spec
+        libs = []
+
+        if '+grib2' in spec:
+            cppflags.append('-I' + spec['g2c'].prefix.include)
+            cppflags.append('-I' + spec['jasper'].prefix.include.jasper)
+        
+        # Grads is not compatible with HDF5 1.12.0
+        # which had an API change in h5_getinfo
+        if spec['hdf5'].satisfies('@1.12.0:'):
+            cppflags.append('-DH5_USE_110_API')
+
+        # Need to manually supply -ludunits2
+        libs.append('-ludunits2')
+        env.set('LIBS', ' '.join(libs))
+        env.set('CPPFLAGS', ' '.join(cppflags))
+
+    def configure_args(self):
+        args = []
+        spec = self.spec
+
+        args.extend(self.with_or_without('geotiff'))
+
+        # GCC on macOS complained about these directories not existing
+        mkdirp('bin')
+        mkdirp('lib')
+
+        return args
 
     @run_after('install')
     def copy_data(self):
@@ -58,8 +99,3 @@ class Grads(AutotoolsPackage):
                 self.prefix.lib,
                 self.prefix.data.udpt
             )
-
-    def configure_args(self):
-        args = []
-        args.extend(self.with_or_without('geotiff'))
-        return args

--- a/var/spack/repos/builtin/packages/grads/stdint.patch
+++ b/var/spack/repos/builtin/packages/grads/stdint.patch
@@ -1,0 +1,10 @@
+--- a/src/gagmap.c	2022-06-13 09:17:17.000000000 -0400
++++ b/src/gagmap.c	2022-06-13 09:22:37.000000000 -0400
+@@ -39,6 +39,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
++#include <stdint.h>
+ #include <string.h>
+ #include <unistd.h>
+ #include <sys/types.h>


### PR DESCRIPTION
* Create patch for Grads because it attempts to use `intmax_t` without using `<stdint.h>`
* Add grib2 variant to Grads which links to g2c and requires patching `configure` for correct library names
* Add netcdf variant
* Fix for HDF5 1.12+ by passing `-DH5_USE_110_API `
* Add v2.2.2 which works with Udunits2+
* Add pic variant to g2c which is required by Grads (also see https://github.com/NOAA-EMC/NCEPLIBS-g2c/issues/253)

I built this on WCOSS2-Acorn and was able to create an image using a grib2 GFS file.