### PR TITLE
Add option to compile shumlib with Intel

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -27,7 +27,7 @@ class Esmf(MakefilePackage):
     version('8.1.1',  sha256='58c2e739356f21a1b32673aa17a713d3c4af9d45d572f4ba9168c357d586dc75')
     version('8.0.1',  sha256='9172fb73f3fe95c8188d889ee72fdadb4f978b1d969e1d8e401e8d106def1d84')
     version('8.0.0',  sha256='051dca45f9803d7e415c0ea146df15ce487fb55f0fce18ca61d96d4dba0c8774')
-    version('7.1.0r', sha256='ae9a5edb8d40ae97a35cbd4bd00b77061f995c77c43d36334dbb95c18b00a889')    
+    version('7.1.0r', sha256='ae9a5edb8d40ae97a35cbd4bd00b77061f995c77c43d36334dbb95c18b00a889')
 
     variant('mpi',     default=True,  description='Build with MPI support')
     variant('external-lapack', default=False, description='Build with external LAPACK support')

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -22,11 +22,12 @@ class Esmf(MakefilePackage):
     maintainers = ['climbfuji']
 
     version('8.3.0',  sha256='0ff43ede83d1ac6beabd3d5e2a646f7574174b28a48d1b9f2c318a054ba268fd')
+    version('8.3.0b09', commit='5b7e546c4b')
     version('8.2.0',  sha256='3693987aba2c8ae8af67a0e222bea4099a48afe09b8d3d334106f9d7fc311485')
     version('8.1.1',  sha256='58c2e739356f21a1b32673aa17a713d3c4af9d45d572f4ba9168c357d586dc75')
     version('8.0.1',  sha256='9172fb73f3fe95c8188d889ee72fdadb4f978b1d969e1d8e401e8d106def1d84')
     version('8.0.0',  sha256='051dca45f9803d7e415c0ea146df15ce487fb55f0fce18ca61d96d4dba0c8774')
-    version('7.1.0r', sha256='ae9a5edb8d40ae97a35cbd4bd00b77061f995c77c43d36334dbb95c18b00a889')
+    version('7.1.0r', sha256='ae9a5edb8d40ae97a35cbd4bd00b77061f995c77c43d36334dbb95c18b00a889')    
 
     variant('mpi',     default=True,  description='Build with MPI support')
     variant('external-lapack', default=False, description='Build with external LAPACK support')

--- a/var/spack/repos/jcsda-emc/packages/shumlib/package.py
+++ b/var/spack/repos/jcsda-emc/packages/shumlib/package.py
@@ -18,6 +18,7 @@ class Shumlib(MakefilePackage):
 
     maintainers = [ 'matthewrmshin', 'climbfuji' ]
 
+    version('macos_clang_linux_intel_port', commit='84770606669463a54b51f9b8ed65a1d31f105fe9')
     version('macos_clang_port', commit='e5e5c9f23ce2656aacd75a884c26b01a5380752e')
     #version('2021.10.1', commit='545874fba961deadf4b2758926be7c26f4c8dcb9')
     #version('2021.07.1', commit='a4ea525ad3bf04684ef39b0241991a350e2b7241')
@@ -25,16 +26,18 @@ class Shumlib(MakefilePackage):
     #version('2020.11.1', commit='58f599ce9cfb4bd47197125548a44039695fa7f1')
 
     def edit(self, spec, prefix):
-        env['LIBDIR_OUT'] = os.path.join(os.path.join(self.build_directory, 'spack-build')) # '/Users/heinzell/scratch/tmp-shumlib-inst' # prefix
+        env['LIBDIR_OUT'] = os.path.join(os.path.join(self.build_directory, 'spack-build'))
         #env['LIBDIR_ROOT'] = self.build_directory
 
     def build(self, spec, prefix):
-        # DH* TODO: SWITCH FOR DIFFERENT ARCHITECTURES
         if spec.satisfies('%clang') or spec.satisfies('%apple-clang'):
             os.system('make -f make/vm-x86-gfortran-clang.mk')
-        #elif spec.satisfies('%gcc'):
-        else:
+        elif spec.satisfies('%gcc'):
             os.system('make -f make/vm-x86-gfortran-gcc.mk')
+        elif spec.satisfies('%intel'):
+            os.system('make -f make/vm-x86-ifort-icc.mk')
+        else:
+            raise InstallError('No shumlib make config for this compiler')
 
     def install(self, spec, prefix):
         install_tree(os.path.join(os.getenv('LIBDIR_OUT'), 'include'), prefix.include)


### PR DESCRIPTION
So far, `shumlib` is either using `clang` or `gcc`, even if the spack compiler is `intel`. This PR adds support for `intel` and fails for unsupported compilers (instead of silently falling back to `gcc`).

https://github.com/NOAA-EMC/spack-stack/pull/210