### PR TITLE
Require git-lfs for CRTM

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -823,7 +823,7 @@ class GitFetchStrategy(VCSFetchStrategy):
     """
     url_attr = 'git'
     optional_attrs = ['tag', 'branch', 'commit', 'submodules',
-                      'get_full_repo', 'submodules_delete', 'skip_git_lfs']
+                      'get_full_repo', 'submodules_delete']
 
     git_version_re = r'git version (\S+)'
 
@@ -838,7 +838,6 @@ class GitFetchStrategy(VCSFetchStrategy):
         self.submodules = kwargs.get('submodules', False)
         self.submodules_delete = kwargs.get('submodules_delete', False)
         self.get_full_repo = kwargs.get('get_full_repo', False)
-        self.skip_git_lfs = kwargs.get('skip_git_lfs', False)
 
     @property
     def git_version(self):
@@ -868,10 +867,6 @@ class GitFetchStrategy(VCSFetchStrategy):
             # with git as well.
             if not spack.config.get('config:verify_ssl'):
                 self._git.add_default_env('GIT_SSL_NO_VERIFY', 'true')
-
-            # Don't attempt to download large files with git-lfs
-            if self.skip_git_lfs:
-                self._git.add_default_env('GIT_LFS_SKIP_SMUDGE', '1')
 
         return self._git
 

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -17,6 +17,7 @@ class Crtm(CMakePackage):
 
     maintainers = ['t-brown', 'edwardhartnett', 'kgerheiser', 'Hang-Lei-NOAA']
 
+    depends_on('git-lfs')
     depends_on('netcdf-fortran', when='@2.4.0:')
 
     # ecbuild release v2.4.0 is broken
@@ -24,6 +25,6 @@ class Crtm(CMakePackage):
     # depends_on('ecbuild', when='@2.4.0:', type=('build'))
 
     # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
-    version('2.4.0', commit='a831626', skip_git_lfs=True)
+    version('2.4.0', commit='a831626')
     # Uses the tip of REL-2.3.0_emc branch
-    version('2.3.0', commit='99760e6', skip_git_lfs=True)
+    version('2.3.0', commit='99760e6')


### PR DESCRIPTION
There doesn't seem to be a way to clone a git-lfs repo without having git-lfs installed.

GIT_LFS_SKIP_SMUDGE=1 only works when git-lfs is installed.

Fix https://github.com/NOAA-EMC/spack-stack/issues/207

