### PR TITLE
Feature/updates for rc2

### DIFF
--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -35,9 +35,9 @@ class Ecflow(CMakePackage):
     extends('python')
 
     depends_on('python@3:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
-    depends_on('py-numpy', type='build')
-    depends_on('py-pip', type='build')
+    #depends_on('py-setuptools', type='build')
+    #depends_on('py-numpy', type='build')
+    #depends_on('py-pip', type='build')
 
     # v4: Boost-1.7X release not working well on serialization
     depends_on('boost@1.53:1.69+python', when='@:4')
@@ -55,8 +55,8 @@ class Ecflow(CMakePackage):
     depends_on('qt@5:', when='+ui')
     depends_on('cmake@2.12.11:', type='build')
 
-    def setup_build_environment(self, env):
-        env.prepend_path("OPENSSL_ROOT_DIR", self.spec['openssl'].prefix)
+    #def setup_build_environment(self, env):
+    #    env.prepend_path("OPENSSL_ROOT_DIR", self.spec['openssl'].prefix)
 
     def cmake_args(self):
         boost_lib = self.spec['boost'].prefix.lib

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -32,6 +32,13 @@ class Ecflow(CMakePackage):
 
     variant('ui', default=False, description='Enable ecflow_ui')
 
+    extends('python')
+
+    depends_on('python@3:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-numpy', type='build')
+    depends_on('py-pip', type='build')
+
     # v4: Boost-1.7X release not working well on serialization
     depends_on('boost@1.53:1.69+python', when='@:4')
     depends_on('boost@1.53:1.69+pic', when='@:4 +static_boost')

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -55,14 +55,17 @@ class Ecflow(CMakePackage):
     depends_on('qt@5:', when='+ui')
     depends_on('cmake@2.12.11:', type='build')
 
+    def setup_build_environment(self, env):
+        env.prepend_path("OPENSSL_ROOT_DIR", self.spec['openssl'].prefix)
+
     def cmake_args(self):
         boost_lib = self.spec['boost'].prefix.lib
         args = ['-DBoost_PYTHON_LIBRARY_RELEASE=' + boost_lib]
 
-        ecflow_ui = 'ON' if '+ui' in self.spec else 'OFF'
         # https://jira.ecmwf.int/browse/SUP-2641#comment-208943
         use_static_boost = 'ON' if '+static_boost' in self.spec else 'OFF'
         args.append('-DENABLE_STATIC_BOOST_LIBS=' + use_static_boost)
 
+        ecflow_ui = 'ON' if '+ui' in self.spec else 'OFF'
         args.extend(['-DENABLE_UI=' + ecflow_ui, '-DENABLE_GUI=' + ecflow_ui])
         return args

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -27,17 +27,18 @@ class Ecflow(CMakePackage):
     version('4.12.0', sha256='566b797e8d78e3eb93946b923ef540ac61f50d4a17c9203d263c4fd5c39ab1d1')
     version('4.11.1', sha256='b3bcc1255939f87b9ba18d802940e08c0cf6379ca6aeec1fef7bd169b0085d6c')
 
+    variant('ssl', default=True,
+            description='Enable SSL')
     variant('static_boost', default=False,
             description='Use also static boost libraries when compiling')
-
     variant('ui', default=False, description='Enable ecflow_ui')
 
     extends('python')
 
     depends_on('python@3:', type=('build', 'run'))
-    #depends_on('py-setuptools', type='build')
-    #depends_on('py-numpy', type='build')
-    #depends_on('py-pip', type='build')
+    depends_on('py-setuptools', type='build')
+    depends_on('py-numpy', type='build')
+    depends_on('py-pip', type='build')
 
     # v4: Boost-1.7X release not working well on serialization
     depends_on('boost@1.53:1.69+python', when='@:4')
@@ -55,9 +56,6 @@ class Ecflow(CMakePackage):
     depends_on('qt@5:', when='+ui')
     depends_on('cmake@2.12.11:', type='build')
 
-    #def setup_build_environment(self, env):
-    #    env.prepend_path("OPENSSL_ROOT_DIR", self.spec['openssl'].prefix)
-
     def cmake_args(self):
         boost_lib = self.spec['boost'].prefix.lib
         args = ['-DBoost_PYTHON_LIBRARY_RELEASE=' + boost_lib]
@@ -65,6 +63,9 @@ class Ecflow(CMakePackage):
         # https://jira.ecmwf.int/browse/SUP-2641#comment-208943
         use_static_boost = 'ON' if '+static_boost' in self.spec else 'OFF'
         args.append('-DENABLE_STATIC_BOOST_LIBS=' + use_static_boost)
+
+        ssl = 'ON' if '+ssl' in self.spec else 'OFF'
+        args.append('-DENABLE_SSL=' + ssl)
 
         ecflow_ui = 'ON' if '+ui' in self.spec else 'OFF'
         args.extend(['-DENABLE_UI=' + ecflow_ui, '-DENABLE_GUI=' + ecflow_ui])

--- a/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
@@ -28,7 +28,6 @@ class BaseEnv(BundlePackage):
 
     # I/O
     depends_on('zlib', type='run')
-    depends_on('szip', type='run')
     depends_on('hdf5', type='run')
     depends_on('netcdf-c', type='run')
     depends_on('netcdf-fortran', type='run')

--- a/var/spack/repos/jcsda-emc/packages/fiat/package.py
+++ b/var/spack/repos/jcsda-emc/packages/fiat/package.py
@@ -15,7 +15,6 @@ class Fiat(CMakePackage):
 
     maintainers = ['climbfuji']
 
-    version('develop', branch='develop', no_cache=True)
     version('main', branch='main', no_cache=True)
     # Defined for spack use only
     version('1.0.0', commit='1295120464c3905e5edcbb887e4921686653eab8', preferred=True)


### PR DESCRIPTION
Updates for spack-stack-1.0.0 release candidate 2:
- Add missing Python extension for `ecflow`, and add variant `ssl` (on by default)
- There is no develop branch for ``fiat``, remove
- Remove unused ``szip`` dependency from ``base-env``