### PR TITLE
Enable two level namespace with openmpi on MacOS

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -205,7 +205,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     # hardwired in.
     def patch(self):
         if '+two_level_namespace' in self.spec and self.spec.satisfies('platform=darwin'):
-            print("Applying configure patch for two_level namespace on MacOS")
+            print("Applying configure patch for two_level_namespace on MacOS")
             os.system("sed -i '.bak' -e 's/-flat_namespace/-commons,use_dylibs/g' configure")
 
     variant(


### PR DESCRIPTION
This PR adds a patch that will enable two-level namespace linking on the MacOS for the openmpi package. The issue with the prior solution for two-level namespace with openmpi is that the `-flat_namespace` linker option is hardwired into the openmpi configure script and cannot be overridden. This patch replaces `-flat_namespace` with `-commons,use_dylibs` within the configure script itself (but only when on a darwin platform and when the two_level_namespace variant is selected.