### PR TITLE
Add patch for enabling two level namespace with openmpi on MacOS

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -206,7 +206,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     def patch(self):
         if '+two_level_namespace' in self.spec and self.spec.satisfies('platform=darwin'):
             print("Applying configure patch for two_level namespace on MacOS")
-            os.system("sed -i '.bak' -e 's/-flat_namespace/-commons,use_dylibs/g' configure")
+            filter_file(r'-flat_namespace', '-commons,use_dylibs', 'configure')
 
     variant(
         'fabrics',

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -205,7 +205,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     # hardwired in.
     def patch(self):
         if '+two_level_namespace' in self.spec and self.spec.satisfies('platform=darwin'):
-            print("Applying configure patch for two_level namespace on MacOS")
+            print("Applying configure patch for two_level_namespace on MacOS")
             filter_file(r'-flat_namespace', '-commons,use_dylibs', 'configure')
 
     variant(


### PR DESCRIPTION
Identical to https://github.com/NOAA-EMC/spack/pull/107, but for the release v1 branch.