### PR TITLE
Release/v1: fix mapl@2.12.3 build errors by adding missing netCDF C and Fortran dependencies

### DIFF
--- a/var/spack/repos/jcsda-emc/packages/mapl/mapl-2.12.3-netcdf-c.patch
+++ b/var/spack/repos/jcsda-emc/packages/mapl/mapl-2.12.3-netcdf-c.patch
@@ -1,0 +1,31 @@
+--- a/CMakeLists.txt	2022-06-23 10:37:36.000000000 -0600
++++ b/CMakeLists.txt	2022-06-23 10:38:44.000000000 -0600
+@@ -103,7 +103,7 @@
+ ecbuild_declare_project()
+ 
+ if (NOT Baselibs_FOUND)
+-  find_package(NetCDF REQUIRED Fortran)
++  find_package(NetCDF REQUIRED C Fortran)
+   add_definitions(-DHAS_NETCDF4)
+   add_definitions(-DHAS_NETCDF3)
+   add_definitions(-DNETCDF_NEED_NF_MPIIO)
+--- a/pfio/CMakeLists.txt	2022-06-23 10:37:41.000000000 -0600
++++ b/pfio/CMakeLists.txt	2022-06-23 10:38:13.000000000 -0600
+@@ -91,7 +91,7 @@
+   StringVectorUtil.F90
+   )
+ 
+-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran TYPE ${MAPL_LIBRARY_TYPE})
++esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE ${MAPL_LIBRARY_TYPE})
+ target_link_libraries (${this} PUBLIC GFTL_SHARED::gftl-shared PRIVATE MPI::MPI_Fortran)
+ # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
+ if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+@@ -129,7 +129,7 @@
+ ecbuild_add_executable (
+   TARGET pfio_writer.x
+   SOURCES pfio_writer.F90
+-  LIBS ${this} NetCDF::NetCDF_Fortran MPI::MPI_Fortran)
++  LIBS ${this} NetCDF::NetCDF_Fortran NetCDF::NetCDF_C MPI::MPI_Fortran)
+ set_target_properties (pfio_writer.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
+ 
+ #--------------------

--- a/var/spack/repos/jcsda-emc/packages/mapl/package.py
+++ b/var/spack/repos/jcsda-emc/packages/mapl/package.py
@@ -42,6 +42,9 @@ class Mapl(CMakePackage):
     # Patch to configure Apple M1 chip in x86_64 Rosetta 2 emulator mode
     patch('esma_cmake_apple_m1_rosetta.patch')
 
+    # Patch to add missing NetCDF C target in various CMakeLists.txt
+    patch('mapl-2.12.3-netcdf-c.patch', when='@2.12.3:')
+
     variant('flap', default=False)
     variant('pflogger', default=False)
     variant('esma_gfe_namespace', default=True)
@@ -51,6 +54,7 @@ class Mapl(CMakePackage):
     depends_on('mpi')
     depends_on('hdf5')
     depends_on('netcdf-c')
+    depends_on('netcdf-fortran')
     depends_on('esmf~debug', when='~debug')
     depends_on('esmf+debug', when='+debug')
     depends_on('yafyaml@:0.5.1')
@@ -63,7 +67,6 @@ class Mapl(CMakePackage):
             self.define_from_variant('BUILD_WITH_PFLOGGER', 'pflogger'),
             self.define_from_variant('ESMA_USE_GFE_NAMESPACE', 'esma_gfe_namespace'),
             self.define_from_variant('BUILD_SHARED_MAPL', 'shared'),
-            '-DCMAKE_Fortran_FLAGS=-ffree-line-length-none',
             '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
             '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
             '-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc


### PR DESCRIPTION
In mapl@2.12.3, `pfio_get_att_string.c` depends on `netcdf-c`, but that dependency is not configured in the `cmake` configuration. In addition, the spack recipe is not looking for `netcdf-fortran`.

This PR fixes both errors and removes a redundant (and wrong) Fortran compiler flag for GNU that is also passed to Intel (it is passed to GNU correctly a little further down in the spack recipe).

This fixed my build problem of mapl@2.12.3 on macOS. It also fixes the build problem on Discover :-)

@srherbener can you please try if that fixes your problem, too? For this, you should do the following after checking out/pulling in the changes in this PR (if not starting from a fresh checkout and clean environment):
```
spack clean -a
rm -fr envs/name_of_my_env/.spack-env/repos/*
rm envs/name_of_my_env/spack.lock
spack concretize
spack spec mapl
```
Make sure that the output of `spack spec mapl` lists two hashes in the `patches=` argument, not just one.

Fixes https://github.com/NOAA-EMC/spack-stack/issues/224

Fixes https://github.com/NOAA-EMC/spack-stack/issues/213

Fixes https://github.com/NOAA-EMC/spack/issues/100