### PR TITLE
Add variant fftw to jedi-base-env

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -18,6 +18,10 @@ class JediBaseEnv(BundlePackage):
 
     version('1.0.0')
 
+    # Variants defining packages that we cannot distribute publicly
+    # Need to find a free fftw provider for fftw-api ...
+    variant('fftw', default=True, description='Build fftw')
+
     depends_on('base-env',                       type='run')
     depends_on('bison',                          type='run')
     depends_on('blas',                           type='run')
@@ -29,7 +33,7 @@ class JediBaseEnv(BundlePackage):
     depends_on('ecmwf-atlas',                    type='run')
     depends_on('eigen',                          type='run')
     depends_on('fckit',                          type='run')
-    depends_on('fftw-api',                       type='run')
+    depends_on('fftw-api', when='+fftw',         type='run')
     depends_on('flex',                           type='run')
     depends_on('git-lfs',                        type='run')
     depends_on('gsl-lite',                       type='run')

--- a/var/spack/repos/jcsda-emc/packages/ewok/package.py
+++ b/var/spack/repos/jcsda-emc/packages/ewok/package.py
@@ -19,8 +19,7 @@ class Ewok(PythonPackage):
     maintainers = ['climbfuji', 'ericlingerfelt']
 
     version('develop', branch='develop', no_cache=True)
-    # DH* TODO UPDATE FOR RELEASE
-    version('1.0.0', branch='develop', no_cache=True)
+    version('0.0.1', commit='69fff0f460fdb639db4fd38574dee8262b8a1f84', preferred=True)
 
     depends_on('python@3.7:',         type=('build', 'run'))
     depends_on('py-pyyaml',           type=('build', 'run'))

--- a/var/spack/repos/jcsda-emc/packages/r2d2/package.py
+++ b/var/spack/repos/jcsda-emc/packages/r2d2/package.py
@@ -19,8 +19,7 @@ class R2d2(PythonPackage):
     maintainers = ['climbfuji', 'ericlingerfelt']
 
     version('develop', branch='develop', no_cache=True)
-    # DH* TODO UPDATE FOR RELEASE
-    version('1.0.0', branch='develop', no_cache=True)
+    version('0.0.1', commit='011990d36c9c651593e5e158b5ad7ef07aee16dc', preferred=True)
 
     depends_on('python@3.7:', type=('build', 'run'))
     depends_on('py-pyyaml@5.3.1:', type=('build', 'run'))

--- a/var/spack/repos/jcsda-emc/packages/solo/package.py
+++ b/var/spack/repos/jcsda-emc/packages/solo/package.py
@@ -19,8 +19,7 @@ class Solo(PythonPackage):
     maintainers = ['climbfuji', 'ericlingerfelt']
 
     version('develop', branch='develop', no_cache=True)
-    # DH* TODO UPDATE FOR RELEASE
-    version('1.0.0', branch='develop', no_cache=True)
+    version('1.0.0', commit='dba076088917ba6b5e58ff4112c6d287f6d1c72c', preferred=True)
 
     depends_on('python@3.7:', type=('build', 'run'))
     depends_on('py-pyyaml@5.3.1:', type=('build', 'run'))

--- a/var/spack/repos/jcsda-emc/packages/solo/package.py
+++ b/var/spack/repos/jcsda-emc/packages/solo/package.py
@@ -19,7 +19,7 @@ class Solo(PythonPackage):
     maintainers = ['climbfuji', 'ericlingerfelt']
 
     version('develop', branch='develop', no_cache=True)
-    version('1.0.0', commit='dba076088917ba6b5e58ff4112c6d287f6d1c72c', preferred=True)
+    version('1.0.0', commit='3ba965b531c6bcb135f0199669a788fad32a4c95', preferred=True)
 
     depends_on('python@3.7:', type=('build', 'run'))
     depends_on('py-pyyaml@5.3.1:', type=('build', 'run'))


### PR DESCRIPTION
Add variant fftw to jedi-base-env, so that the `fftw-api` dependency can be turned off for public JEDI releases. (JEDI is using an Apache 2 license, which cannot link to GPLv3 - which is what `fftw` is.)