### PR TITLE
Patch CDO Intel internal compiler error

### DIFF
--- a/var/spack/repos/builtin/packages/cdo/intel-compare.patch
+++ b/var/spack/repos/builtin/packages/cdo/intel-compare.patch
@@ -1,0 +1,15 @@
+--- a/src/compare.h	2021-10-29 12:00:30.000000000 -0400
++++ b/src/compare.h	2022-07-11 17:04:31.000000000 -0400
+@@ -10,7 +10,11 @@
+ static inline bool
+ DBL_IS_EQUAL(double x, double y)
+ {
+-  return (std::isnan(x) || std::isnan(y) ? (std::isnan(x) && std::isnan(y)) : !(x < y || y < x));
++    if (std::isnan(x) || std::isnan(y)) {
++        return std::isnan(x) && std::isnan(y);
++    } else {
++        return !(x < y || y < x);
++    }
+ }
+ 
+ //#define IS_NOT_EQUAL(x, y) (x < y || y < x)

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -89,6 +89,10 @@ class Cdo(AutotoolsPackage):
     conflicts('%gcc@9:', when='@:1.9.6',
               msg='GCC 9 changed OpenMP data sharing behavior')
 
+    # Internal compiler error when building with Intel 2022.1.2
+    # https://github.com/NOAA-EMC/spack-stack/issues/248
+    patch('intel-compare.patch', when='%intel')
+
     def configure_args(self):
         config_args = []
 


### PR DESCRIPTION
Manually expand the ternary operator which seems to satisfy the compiler.

Fix https://github.com/NOAA-EMC/spack-stack/issues/248