### PR TITLE
Prevent overlinking against MPI libraries in ECMWF software and add support for different build types

### DIFF
--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -26,6 +26,10 @@ class Eckit(CMakePackage):
 
     version('1.16.0', sha256='9e09161ea6955df693d3c9ac70131985eaf7cf24a9fa4d6263661c6814ebbaf1')
 
+    variant('build_type', default='RelWithDebInfo',
+        description='CMake build type',
+        values=('Debug', 'Release', 'RelWithDebInfo'))
+
     variant('shared', default=True, description='Build shared libraries')
     variant('tools', default=True, description='Build the command line tools')
     variant('mpi', default=True, description='Enable MPI support')
@@ -145,12 +149,12 @@ class Eckit(CMakePackage):
             # args.append('-DBUILD_SHARED_LIBS=OFF')
             raise InstrallError("eckit static build not supported")
 
-        if '+mpi' in self.spec:
-            args += [
-                '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
-                '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
-                '-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc,
-            ]
+        #if '+mpi' in self.spec:
+        #    args += [
+        #        '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
+        #        '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
+        #        '-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc,
+        #    ]
 
         if 'linalg=mkl' not in self.spec:
             # ENABLE_LAPACK is ignored if MKL backend is enabled

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -149,13 +149,6 @@ class Eckit(CMakePackage):
             # args.append('-DBUILD_SHARED_LIBS=OFF')
             raise InstrallError("eckit static build not supported")
 
-        #if '+mpi' in self.spec:
-        #    args += [
-        #        '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
-        #        '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
-        #        '-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc,
-        #    ]
-
         if 'linalg=mkl' not in self.spec:
             # ENABLE_LAPACK is ignored if MKL backend is enabled
             # (the LAPACK backend is still built though):

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -27,8 +27,8 @@ class Eckit(CMakePackage):
     version('1.16.0', sha256='9e09161ea6955df693d3c9ac70131985eaf7cf24a9fa4d6263661c6814ebbaf1')
 
     variant('build_type', default='RelWithDebInfo',
-        description='CMake build type',
-        values=('Debug', 'Release', 'RelWithDebInfo'))
+            description='CMake build type',
+            values=('Debug', 'Release', 'RelWithDebInfo'))
 
     variant('shared', default=True, description='Build shared libraries')
     variant('tools', default=True, description='Build the command line tools')

--- a/var/spack/repos/jcsda-emc/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/jcsda-emc/packages/ecmwf-atlas/package.py
@@ -38,6 +38,10 @@ class EcmwfAtlas(CMakePackage):
     patch('clang_include_array.patch', when='%apple-clang')
     patch('clang_include_array.patch', when='%clang')
 
+    variant('build_type', default='RelWithDebInfo',
+        description='CMake build type',
+        values=('Debug', 'Release', 'RelWithDebInfo'))
+
     variant('shared', default=True)
 
     variant('trans', default=False)

--- a/var/spack/repos/jcsda-emc/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/jcsda-emc/packages/ecmwf-atlas/package.py
@@ -39,8 +39,8 @@ class EcmwfAtlas(CMakePackage):
     patch('clang_include_array.patch', when='%clang')
 
     variant('build_type', default='RelWithDebInfo',
-        description='CMake build type',
-        values=('Debug', 'Release', 'RelWithDebInfo'))
+            description='CMake build type',
+            values=('Debug', 'Release', 'RelWithDebInfo'))
 
     variant('shared', default=True)
 

--- a/var/spack/repos/jcsda-emc/packages/ectrans/package.py
+++ b/var/spack/repos/jcsda-emc/packages/ectrans/package.py
@@ -23,6 +23,10 @@ class Ectrans(CMakePackage):
     # Defined for spack use only
     version('1.0.0', commit='ee1d307f1e47e1dd0b5ea91663a41df8a94cafb3', preferred=True)
 
+    variant('build_type', default='RelWithDebInfo',
+        description='CMake build type',
+        values=('Debug', 'Release', 'RelWithDebInfo'))
+
     variant('mpi', default=True, description='Use MPI?')
     variant('openmp', default=True, description='Use OpenMP?')
 

--- a/var/spack/repos/jcsda-emc/packages/ectrans/package.py
+++ b/var/spack/repos/jcsda-emc/packages/ectrans/package.py
@@ -24,8 +24,8 @@ class Ectrans(CMakePackage):
     version('1.0.0', commit='ee1d307f1e47e1dd0b5ea91663a41df8a94cafb3', preferred=True)
 
     variant('build_type', default='RelWithDebInfo',
-        description='CMake build type',
-        values=('Debug', 'Release', 'RelWithDebInfo'))
+            description='CMake build type',
+            values=('Debug', 'Release', 'RelWithDebInfo'))
 
     variant('mpi', default=True, description='Use MPI?')
     variant('openmp', default=True, description='Use OpenMP?')

--- a/var/spack/repos/jcsda-emc/packages/fckit/package.py
+++ b/var/spack/repos/jcsda-emc/packages/fckit/package.py
@@ -30,6 +30,10 @@ class Fckit(CMakePackage):
     depends_on('python')
     depends_on('ecbuild', type=('build'))
 
+    variant('build_type', default='RelWithDebInfo',
+        description='CMake build type',
+        values=('Debug', 'Release', 'RelWithDebInfo'))
+
     variant('eckit', default=True)
     depends_on('eckit+mpi', when='+eckit')
 
@@ -38,9 +42,9 @@ class Fckit(CMakePackage):
     def cmake_args(self):
         res = [
             self.define_from_variant('ENABLE_ECKIT', 'eckit'),
-            '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
-            '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
-            '-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc,
+            #'-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
+            #'-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
+            #'-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc,
             "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec['python'].command.path,
             '-DFYPP_NO_LINE_NUMBERING=ON'
         ]

--- a/var/spack/repos/jcsda-emc/packages/fckit/package.py
+++ b/var/spack/repos/jcsda-emc/packages/fckit/package.py
@@ -42,9 +42,6 @@ class Fckit(CMakePackage):
     def cmake_args(self):
         res = [
             self.define_from_variant('ENABLE_ECKIT', 'eckit'),
-            #'-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
-            #'-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
-            #'-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc,
             "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec['python'].command.path,
             '-DFYPP_NO_LINE_NUMBERING=ON'
         ]

--- a/var/spack/repos/jcsda-emc/packages/fckit/package.py
+++ b/var/spack/repos/jcsda-emc/packages/fckit/package.py
@@ -31,8 +31,8 @@ class Fckit(CMakePackage):
     depends_on('ecbuild', type=('build'))
 
     variant('build_type', default='RelWithDebInfo',
-        description='CMake build type',
-        values=('Debug', 'Release', 'RelWithDebInfo'))
+            description='CMake build type',
+            values=('Debug', 'Release', 'RelWithDebInfo'))
 
     variant('eckit', default=True)
     depends_on('eckit+mpi', when='+eckit')

--- a/var/spack/repos/jcsda-emc/packages/fiat/package.py
+++ b/var/spack/repos/jcsda-emc/packages/fiat/package.py
@@ -19,6 +19,10 @@ class Fiat(CMakePackage):
     # Defined for spack use only
     version('1.0.0', commit='1295120464c3905e5edcbb887e4921686653eab8', preferred=True)
 
+    variant('build_type', default='RelWithDebInfo',
+        description='CMake build type',
+        values=('Debug', 'Release', 'RelWithDebInfo'))
+
     variant('mpi', default=True, description='Use MPI?')
     variant('openmp', default=True, description='Use OpenMP?')
     variant('fckit', default=True, description='Use fckit?')

--- a/var/spack/repos/jcsda-emc/packages/fiat/package.py
+++ b/var/spack/repos/jcsda-emc/packages/fiat/package.py
@@ -20,8 +20,8 @@ class Fiat(CMakePackage):
     version('1.0.0', commit='1295120464c3905e5edcbb887e4921686653eab8', preferred=True)
 
     variant('build_type', default='RelWithDebInfo',
-        description='CMake build type',
-        values=('Debug', 'Release', 'RelWithDebInfo'))
+            description='CMake build type',
+            values=('Debug', 'Release', 'RelWithDebInfo'))
 
     variant('mpi', default=True, description='Use MPI?')
     variant('openmp', default=True, description='Use OpenMP?')


### PR DESCRIPTION
## Description

Prevent overlinking against MPI libraries in ECMWF software and add support for different build types (fiat, ectrans, eckit, fckit, atlas).

I tested this on Discover with Intel, on Orion with GNU, and on my local macOS with apple-clang+gfortran. I also installed all the packages with build type `Debug` and verified that `CMAKE_BUILD_TYPE=Debug` got passed to each of them:
```
spack install --reuse --verbose ecmwf-atlas build_type=Debug ^fckit build_type=Debug ^ eckit build_type=Debug ^ fiat build_type=Debug ^ ectrans build_type=Debug 2>&1 | tee log.install.ecmwf-packages-debug
```

Note. I addressed all style errors, the remaining errors are known and unrelated to this PR. @kgerheiser is working on a solution for these errors.