### PR TITLE
Add checksum for parallelio-2.5.3.

### DIFF
--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -18,6 +18,7 @@ class Parallelio(CMakePackage):
 
     version('2.5.7', sha256='af8af04e41af17f98f2c90b996ef0d8bcd980377e0b35e57b38938c7fdc87cbd')
     version('2.5.4', sha256='e51dc71683da808a714deddc1a80c2650ce847110383e42f1710f3ba567e7a65')
+    version('2.5.3', sha256='205a0a128fd5262700efc230b3380dc5ab10e74bc5d273ae05db76c9d95487ca')
     version('2.5.2', sha256='935bc120ef3bf4fe09fb8bfdf788d05fb201a125d7346bf6b09e27ac3b5f345c')
 
     variant('pnetcdf', default=False, description='enable pnetcdf')


### PR DESCRIPTION
The current develop branches of UFS-WM (https://github.com/ufs-community/ufs-weather-model/blob/develop/modulefiles/ufs_common) and SRW app (https://github.com/ufs-community/ufs-srweather-app/blob/develop/modulefiles/srw_common) utilize Parallelio 2.5.3. In conjunction with the proposed addition of a UFS-SRW develop spack-stack template (https://github.com/NOAA-EMC/spack-stack/pull/259), the addition of a checksum for Paralleio-2.5.3 would be required. This PR adds this checksum to the Parallelio package.py script.

Successful installation and loading of Paralleio-2.5.3 was performed on Orion using the aforementioned UFS-SRW develop spack template, and can be found here: /work/noaa/epic-ps/tools/spack-stack/spack-stack/envs/ufs-srw-dev.orion/install/modulefiles/Core.

This work was done jointly with @EdwardSnyder-NOAA.