### PR TITLE
Update ECMWF odc library, add to jedi-base-env

### DIFF
--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -14,6 +14,10 @@ class Odc(CMakePackage):
 
     maintainers = ['skosukhin']
 
+    version('1.4.5', sha256='8532d0453531d62e1f15791d1c5c96540b842913bd211a8ef090211eaf4cccae', preferred=True)
+    version('1.4.4', sha256='65cb7b491566d3de14b66741544360f20eaaf1a6d5a24af7d8b939dd50e26431')
+    version('1.4.2', sha256='19572e93238c1531bcf0f7966f0d2342a0400f5fe9deb934a384228f895909c9')
+    version('1.4.1', sha256='e79707c8cd951a3d79439013d43d6b2888956a34e9b76ce416bece5262b77d93')
     version('1.3.0', sha256='97a4f10765b341cc8ccbbf203f5559cb1b838cbd945f48d4cecb1bc4305e6cd6')
 
     variant('fortran', default=False,

--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -14,7 +14,7 @@ class Odc(CMakePackage):
 
     maintainers = ['skosukhin']
 
-    version('1.4.5', sha256='8532d0453531d62e1f15791d1c5c96540b842913bd211a8ef090211eaf4cccae', preferred=True)
+    version('1.4.5', sha256='8532d0453531d62e1f15791d1c5c96540b842913bd211a8ef090211eaf4cccae')
     version('1.4.4', sha256='65cb7b491566d3de14b66741544360f20eaaf1a6d5a24af7d8b939dd50e26431')
     version('1.4.2', sha256='19572e93238c1531bcf0f7966f0d2342a0400f5fe9deb934a384228f895909c9')
     version('1.4.1', sha256='e79707c8cd951a3d79439013d43d6b2888956a34e9b76ce416bece5262b77d93')

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -40,6 +40,7 @@ class JediBaseEnv(BundlePackage):
     depends_on('netcdf-cxx4',                    type='run')
     depends_on('nlohmann-json',                  type='run')
     depends_on('nlohmann-json-schema-validator', type='run')
+    depends_on('odc',                            type='run')
     depends_on('py-eccodes',                     type='run')
     depends_on('py-h5py',                        type='run')
     depends_on('py-netcdf4',                     type='run')


### PR DESCRIPTION
This PR upgrades the odc packaging to have access to newer versions (version 1.4.5 in particular).

This PR needs to be merged with noaa-emc/spack-stack/pull/283