### PR TITLE
Add shared variant to Bufr

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -31,6 +31,7 @@ class Bufr(CMakePackage):
     patch('cmakelists-apple-llvm-ranlib.patch', when='@:11.6.0')
 
     variant('python', default=False, description='Enable Python interface?')
+    variant('shared', default=True, description='Build shared libraries')
     extends('python', when='+python')
 
     depends_on('python@3:', type=('build', 'run'), when='+python')
@@ -40,7 +41,8 @@ class Bufr(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define_from_variant('ENABLE_PYTHON', 'python')
+            self.define_from_variant('ENABLE_PYTHON', 'python'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ]
 
         return args
@@ -68,8 +70,9 @@ class Bufr(CMakePackage):
 
     def _setup_bufr_environment(self, env, suffix):
         libname = 'libbufr_{0}'.format(suffix)
+        shared = True if '+shared' in self.spec else False
         lib = find_libraries(libname, root=self.prefix,
-                             shared=False, recursive=True)
+                             shared=shared, recursive=True)
 
         lib_envname = 'BUFR_LIB{0}'.format(suffix)
         inc_envname = 'BUFR_INC{0}'.format(suffix)
@@ -81,7 +84,7 @@ class Bufr(CMakePackage):
         # Bufr has _DA (dynamic allocation) libs in versions <= 11.5.0
         if self.spec.satisfies('@:11.5.0'):
             da_lib = find_libraries(libname + "_DA", root=self.prefix,
-                                    shared=False, recursive=True)
+                                    shared=shared, recursive=True)
             env.set(lib_envname + '_DA', da_lib[0])
             env.set(inc_envname + '_DA', include_dir)
 

--- a/var/spack/repos/jcsda-emc/packages/met/package.py
+++ b/var/spack/repos/jcsda-emc/packages/met/package.py
@@ -101,8 +101,8 @@ class Met(AutotoolsPackage):
         if '+grib2' in spec:
             g2c = spec['g2c']
             shared_g2c = True if '+shared' in g2c else False
-            g2c_libdir = find_libraries('libg2c', root=g2c.prefix,
-                                        shared=shared_g2c, recursive=True).directories[0]
+            g2c_libdir = find_libraries('libg2c', root=g2c.prefix, shared=shared_g2c,
+                                        recursive=True).directories[0]
             env.set('MET_GRIB2CLIB', g2c_libdir)
             env.set('MET_GRIB2CINC', g2c.prefix.include)
             env.set('GRIB2CLIB_NAME', '-lg2c')

--- a/var/spack/repos/jcsda-emc/packages/met/package.py
+++ b/var/spack/repos/jcsda-emc/packages/met/package.py
@@ -92,15 +92,17 @@ class Met(AutotoolsPackage):
         libs.append('-lz')
 
         bufr = spec['bufr']
+        shared_bufr = True if '+shared' in bufr else False
         bufr_libdir = find_libraries('libbufr_4', root=bufr.prefix,
-                                     shared=False, recursive=True).directories[0]
+                                     shared=shared_bufr, recursive=True).directories[0]
         env.set('BUFRLIB_NAME', '-lbufr_4')
         env.set('MET_BUFRLIB', bufr_libdir)
 
         if '+grib2' in spec:
             g2c = spec['g2c']
+            shared_g2c = True if '+shared' in g2c else False
             g2c_libdir = find_libraries('libg2c', root=g2c.prefix,
-                                        shared=False, recursive=True).directories[0]
+                                        shared=shared_g2c, recursive=True).directories[0]
             env.set('MET_GRIB2CLIB', g2c_libdir)
             env.set('MET_GRIB2CINC', g2c.prefix.include)
             env.set('GRIB2CLIB_NAME', '-lg2c')


### PR DESCRIPTION
And properly check for the right library type when it can be +shared/~shared.

Using shared libraries avoids issues when linking to MET because of issues with common symbols on macOS.