### PR TITLE
Bufr test improvements

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/c-tests-libm.patch
+++ b/var/spack/repos/builtin/packages/bufr/c-tests-libm.patch
@@ -1,5 +1,5 @@
 --- a/test/CMakeLists.txt	2022-07-28 11:25:13.000000000 -0400
-+++ b/test/myCMakeLists.txt	2022-07-28 11:26:40.000000000 -0400
++++ b/test/CMakeLists.txt	2022-07-28 11:26:40.000000000 -0400
 @@ -205,7 +205,7 @@
      set(test_exe ${test}.x)
      add_executable(${test_exe} ${test_src})

--- a/var/spack/repos/builtin/packages/bufr/c-tests-libm.patch
+++ b/var/spack/repos/builtin/packages/bufr/c-tests-libm.patch
@@ -1,0 +1,11 @@
+--- a/test/CMakeLists.txt	2022-07-28 11:25:13.000000000 -0400
++++ b/test/myCMakeLists.txt	2022-07-28 11:26:40.000000000 -0400
+@@ -205,7 +205,7 @@
+     set(test_exe ${test}.x)
+     add_executable(${test_exe} ${test_src})
+     add_dependencies(${test_exe} bufr_${kind})
+-    target_link_libraries(${test_exe} PRIVATE bufr::bufr_${kind})
++    target_link_libraries(${test_exe} PRIVATE bufr::bufr_${kind} m)
+     add_test(NAME ${test} COMMAND ${CMAKE_BINARY_DIR}/test/${test_exe})
+   endforeach()
+ endforeach()

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -29,9 +29,13 @@ class Bufr(CMakePackage):
 
     # Patch to not add '-c' to ranlib flags when using llvm-ranlib on Apple systems
     patch('cmakelists-apple-llvm-ranlib.patch', when='@:11.6.0')
+    # C test does not explicity link to -lm causing DSO error when building shared libs
+    patch('c-tests-libm.patch', when='@11.5.0:11.7.0')
 
     variant('python', default=False, description='Enable Python interface?')
     variant('shared', default=True, description='Build shared libraries')
+    variant('tests', default=False, description='Build tests')
+
     extends('python', when='+python')
 
     depends_on('python@3:', type=('build', 'run'), when='+python')
@@ -43,6 +47,7 @@ class Bufr(CMakePackage):
         args = [
             self.define_from_variant('ENABLE_PYTHON', 'python'),
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('BUILD_TESTS', 'tests'),
         ]
 
         return args


### PR DESCRIPTION
Add variant to disable tests for bufr becuase it downloads test files during CMake phase 
* Fix https://github.com/NOAA-EMC/spack-stack/issues/287

Create patch that links to libm for C tests to workaround DSO error (ran into this in Docker container)
* Real fix here https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/223

Tested builds of versions 11.5, 11.6, and 11.7