### PR TITLE
Bug fixes for py-numpy and py-scipy with older Intel compilers (e.g., Intel 19)

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -167,7 +167,8 @@ class PyNumpy(PythonPackage):
             # Newer/other flavors of Cray systems using the Intel compilers directly
             # (icc, ...), therefore use this workaround only if 'cc' is used.
             if self.compiler.cc == 'cc':
-                gcc_version = Version(spack.compiler.get_compiler_version_output('gcc', '-dumpversion'))
+                gcc_version = Version(spack.compiler.get_compiler_version_output(
+                                      'gcc', '-dumpversion'))
                 # Note that this only returns the major versions on some systems,
                 # to be on the safe side add a guard here to prevent versions <6
                 if gcc_version < Version('6'):
@@ -190,7 +191,8 @@ class PyNumpy(PythonPackage):
                 try:
                     gcc_version = Version(out.split()[5].decode('utf-8'))
                 except IndexError:
-                    gcc_version = Version(spack.compiler.get_compiler_version_output('gcc', '-dumpversion'))
+                    gcc_version = Version(spack.compiler.get_compiler_version_output(
+                                          'gcc', '-dumpversion'))
             if gcc_version < Version('4.8'):
                 raise InstallError('The GCC version that the Intel compiler '
                                    'uses must be >= 4.8. The GCC in use is '

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -184,7 +184,13 @@ class PyNumpy(PythonPackage):
                 )
                 p1.stderr.close()
                 out, err = p2.communicate()
-                gcc_version = Version(out.split()[5].decode('utf-8'))
+                # Because compiler env variables aren't loaded in the flag_handler
+                # phase, the above command ("icc -v") may fail (no Intel license file
+                # found etc). Fall back to calling "gcc -v" directly.
+                try:
+                    gcc_version = Version(out.split()[5].decode('utf-8'))
+                except IndexError:
+                    gcc_version = Version(spack.compiler.get_compiler_version_output('gcc', '-dumpversion'))
             if gcc_version < Version('4.8'):
                 raise InstallError('The GCC version that the Intel compiler '
                                    'uses must be >= 4.8. The GCC in use is '

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -120,8 +120,9 @@ class PyScipy(PythonPackage):
 
         # https://github.com/scipy/scipy/issues/14935
         # Disable pythran backend with latest Intel compilers
-        if self.spec.satisfies('%intel@2021:') or \
-                self.spec.satisfies('%intel-oneapi-compilers@2021:'):
+        # Turns out it also doesn't work with previous versions
+        if self.spec.satisfies('%intel') or \
+                self.spec.satisfies('%intel-oneapi-compilers'):
             env.set('SCIPY_USE_PYTHRAN', '0')
 
         # Kluge to get the gfortran linker to work correctly on Big


### PR DESCRIPTION
## Description

Bug fixes for py-numpy and py-scipy with older Intel compilers. These came up when building spack-stack (skylab-1.0.0) on Cheyenne with Intel 19.

- Bug fix in var/spack/repos/builtin/packages/py-numpy/package.py: logic to determine gcc version when using Intel not working for older compilers that need license environment variable set
- Bug fix in var/spack/repos/builtin/packages/py-scipy/package.py: disable pythran backend with all Intel compilers

Required for https://github.com/NOAA-EMC/spack-stack/issues/296