### PR TITLE
Bug fix for py-shapely@1.8.x with external miniconda in spack

### DIFF
--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -42,6 +42,11 @@ class PyShapely(PythonPackage):
           sha256='8583cdc97648277fa4faea8bd88d49e43390e87f697b966bd2b4290fba945ba0',
           when='@:1.7.0')
 
+    # Spack might be using an external, barebone miniconda installation, in which case
+    # the hacky logic in py-shapely@1.8.x looks for libgeos_c.so in the miniconda
+    # install tree ... need to comment that out so that spack's libgeos_c.so is found
+    patch('shapely-1.8.0-geos.py.patch', when='@1.8.0:1.8.3')
+
     @when('^python@3.7:')
     def patch(self):
         # Python 3.7 changed the thread storage API, precompiled *.c files

--- a/var/spack/repos/builtin/packages/py-shapely/shapely-1.8.0-geos.py.patch
+++ b/var/spack/repos/builtin/packages/py-shapely/shapely-1.8.0-geos.py.patch
@@ -1,0 +1,35 @@
+--- a/shapely/geos.py	2022-08-04 11:15:00.000000000 -0600
++++ b/shapely/geos.py	2022-08-04 11:16:57.000000000 -0600
+@@ -88,9 +88,12 @@
+         if len(geos_pyinstaller_so) >= 1:
+             _lgeos = CDLL(geos_pyinstaller_so[0])
+             LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
+-    elif exists_conda_env():
+-        # conda package.
+-        _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.so'))
++    # Spack might be using a barebone miniconda installation, in which case
++    # this elif block makes py-shapely look for libgeos_c.so in the miniconda
++    # install tree ... need to comment out so that spack's libgeos_c.so is found
++    #elif exists_conda_env():
++    #    # conda package.
++    #    _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.so'))
+     else:
+         alt_paths = [
+             'libgeos_c.so.1',
+@@ -119,10 +122,12 @@
+         else:
+             _lgeos = CDLL(geos_whl_dylib)
+             LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
+-
+-    elif exists_conda_env():
+-        # conda package.
+-        _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.dylib'))
++    # Spack might be using a barebone miniconda installation, in which case
++    # this elif block makes py-shapely look for libgeos_c.so in the miniconda
++    # install tree ... need to comment out so that spack's libgeos_c.so is found
++    #elif exists_conda_env():
++    #    # conda package.
++    #    _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.dylib'))
+     else:
+         if hasattr(sys, 'frozen'):
+             try:


### PR DESCRIPTION
Patch for in `var/spack/repos/builtin/packages/py-shapely/package.py`: if external miniconda is used, don't look for `libgeos_c.so` in the miniconda path, use spack package instead. 

This is only an issue in 1.8.x (and possibly earlier, but we don't use those). Versions 2.x use an entirely different logic to import geos properly.

For testing, see: https://github.com/NOAA-EMC/spack-stack/pull/300