### PR TITLE
Bug fix for crtm: JEDI release depends on netCDF-Fortran

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -21,6 +21,7 @@ class Crtm(CMakePackage):
 
     depends_on('git-lfs')
     depends_on('netcdf-fortran', when='@2.4.0:')
+    depends_on('netcdf-fortran', when='@v2.3-jedi.4:')
 
     depends_on('crtm-fix@2.3.0_emc', when='@2.3.0 +fix')
     depends_on('crtm-fix@2.4.0_emc', when='@2.4.0 +fix')


### PR DESCRIPTION
As the title says. Super annoying having to deal with two different types of the code with different requirements, in addition the already confusing versions and combinations with fixed files.