### PR TITLE
Add new CRTM version v2.4_jedi

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -38,11 +38,11 @@ class Crtm(CMakePackage):
     # depends_on("ecbuild", when="@2.4.0:", type=("build"))
 
     # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
-    version("2.4.0", commit="a831626")
+    version("2.4.0", commit="5ddd0d6")
     # Uses the tip of REL-2.3.0_emc branch
     version("2.3.0", commit="99760e6")
     # JEDI applications so far use these versions
     # Branch release/crtm_jedi
     version("v2.3-jedi.4", commit="bfede42")
     # Branch release/crtm_jedi_v2.4.0
-    version("v2.4_jedi", commit="3119d66")
+    version("v2.4_jedi", commit="0ee3593")

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -14,9 +14,9 @@ class Crtm(CMakePackage):
 
     homepage = "https://www.jcsda.org/jcsda-project-community-radiative-transfer-model"
     git = "https://github.com/JCSDA/crtm.git"
-    url = "https://github.com/NOAA-EMC/EMC_crtm/archive/refs/tags/v2.3.0.tar.gz"
+    url = "https://github.com/JCSDA/crtm/archive/refs/tags/v2.3.0.tar.gz"
 
-    maintainers = ["t-brown", "edwardhartnett", "kgerheiser", "Hang-Lei-NOAA"]
+    maintainers = ["BenjaminTJohnson", "edwardhartnett", "Hang-Lei-NOAA", "climbfuji"]
 
     variant(
         "fix",
@@ -41,5 +41,8 @@ class Crtm(CMakePackage):
     version("2.4.0", commit="a831626")
     # Uses the tip of REL-2.3.0_emc branch
     version("2.3.0", commit="99760e6")
-    # JEDI applications so far use this version
+    # JEDI applications so far use these versions
+    # Branch release/crtm_jedi
     version("v2.3-jedi.4", commit="bfede42")
+    # Branch release/crtm_jedi_v2.4.0
+    version("v2.4_jedi", commit="3119d66")

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -27,11 +27,13 @@ class Crtm(CMakePackage):
     depends_on("git-lfs")
     depends_on("netcdf-fortran", when="@2.4.0:")
     depends_on("netcdf-fortran", when="@v2.3-jedi.4")
+    depends_on("netcdf-fortran", when="@v2.4_jedi")
 
     depends_on("crtm-fix@2.3.0_emc", when="@2.3.0 +fix")
     depends_on("crtm-fix@2.4.0_emc", when="@2.4.0 +fix")
 
     depends_on("ecbuild", type=("build"), when="@v2.3-jedi.4")
+    depends_on("ecbuild", type=("build"), when="@v2.4_jedi")
 
     # ecbuild release v2.4.0 is broken
     # add ecbuild dependency for next release with fix


### PR DESCRIPTION
As the title says - also update the list of maintainers to more accurately reflect who is maintaining the CRTM package in spack, and fix the URL to point to the authoritative CRTM repository.

See https://github.com/NOAA-EMC/spack/issues/155 for a detailed description.

Fixes #155 