### PR TITLE
Workaround for missing `rpath` on macOS for several packages

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -128,3 +128,9 @@ class Bzip2(Package, SourcewarePackage):
             force_remove("bunzip2", "bzcat")
             symlink("bzip2", "bunzip2")
             symlink("bzip2", "bzcat")
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -43,3 +43,10 @@ class Crtm(CMakePackage):
     version("2.3.0", commit="99760e6")
     # JEDI applications so far use this version
     version("v2.3-jedi.4", commit="bfede42")
+
+    @run_after("install")
+    def darwin_fix(self):
+        with when("@v2.3-jedi.4"):
+            # The shared library is not installed correctly on Darwin; fix this
+            if self.spec.satisfies("platform=darwin"):
+                fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -156,3 +156,9 @@ class Eckit(CMakePackage):
             args.append(self.define("ENABLE_LAPACK", "linalg=lapack" in self.spec))
 
         return args
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -114,3 +114,10 @@ class Fms(CMakePackage):
             args.append(self.define('CMAKE_Fortran_FLAGS', ' '.join(fflags)))
 
         return args
+
+    @run_after("install")
+    def darwin_fix(self):
+        with when("@release-jcsda"):
+            # The shared library is not installed correctly on Darwin; fix this
+            if self.spec.satisfies("platform=darwin"):
+                fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/llvm-openmp/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp/package.py
@@ -54,3 +54,9 @@ class LlvmOpenmp(CMakePackage):
     @property
     def libs(self):
         return find_libraries("libomp", root=self.prefix, recursive=True)
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -34,3 +34,9 @@ class Odc(CMakePackage):
             self.define("ENABLE_TESTS", self.run_tests),
         ]
         return args
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/jcsda-emc/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/jcsda-emc/packages/ecmwf-atlas/package.py
@@ -64,3 +64,9 @@ class EcmwfAtlas(CMakePackage):
         if '~shared' in self.spec:
             res.append('-DBUILD_SHARED_LIBS=OFF')
         return res
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/jcsda-emc/packages/ectrans/package.py
+++ b/var/spack/repos/jcsda-emc/packages/ectrans/package.py
@@ -59,3 +59,9 @@ class Ectrans(CMakePackage):
             self.define_from_variant('ENABLE_TRANSI', 'transi')
         ]
         return args
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/jcsda-emc/packages/fckit/package.py
+++ b/var/spack/repos/jcsda-emc/packages/fckit/package.py
@@ -58,3 +58,9 @@ class Fckit(CMakePackage):
         res.append('-DECBUILD_CXX_IMPLICIT_LINK_LIBRARIES={}'.format(cxxlib))
 
         return res
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/jcsda-emc/packages/fiat/package.py
+++ b/var/spack/repos/jcsda-emc/packages/fiat/package.py
@@ -46,3 +46,9 @@ class Fiat(CMakePackage):
         ]
 
         return args
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
Several packages in our stack, apparently mostly (all?) built with `ecbuild`, have missing `rpath` information. See https://github.com/NOAA-EMC/spack-stack/issues/133 for example.

This PR provides a workaround by using an existing tool in `spack` that replaces the incomplete `rpath` with a fixed path. This is **not** an ideal solution. Ideally, we want to add the correct `rpath` to the library, not replace it with a fixed path.

However, this PR provides a way to test if these changes help addressing the EWOK issue JCSDA folks have been seeing, and it provides a list of packages that need to be fixed one or the other way.

Packages that I fixed along the way, and for which I am not sure if it's needed: `llvm-openmp` and `bzip2`.