### PR TITLE
Update ESMF from develop

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -124,7 +124,9 @@ class Esmf(MakefilePackage):
             )
         else:
             # Starting with ESMF 8.2.1 releases are now in the form vx.y.z
-            return "https://github.com/esmf-org/esmf/archive/refs/tags/v{0}.tar.gz".format(version.dotted)
+            return "https://github.com/esmf-org/esmf/archive/refs/tags/v{0}.tar.gz".format(
+                version.dotted
+            )
 
     def edit(self, spec, prefix):
         # Installation instructions can be found at:

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -124,7 +124,7 @@ class Esmf(MakefilePackage):
             )
         else:
             # Starting with ESMF 8.2.1 releases are now in the form vx.y.z
-            return "[https://github.com/esmf-org/esmf/archive/v{0}.tar.gz]".format(version)
+            return "https://github.com/esmf-org/esmf/archive/refs/tags/v{0}.tar.gz".format(version.dotted)
 
     def edit(self, spec, prefix):
         # Installation instructions can be found at:


### PR DESCRIPTION
The latest merge of our code in ESMF into develop led to a minor change requested by the spack developers. Bringing this change back to our fork (cherry-picking).

For testing, see https://github.com/NOAA-EMC/spack-stack/pull/315