### PR TITLE
Bug fix for shapely: find libgeos when using spack and spack modules

### DIFF
--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -47,7 +47,8 @@ class PyShapely(PythonPackage):
 
     # Spack might be using an external, barebone miniconda installation, in which case
     # the hacky logic in py-shapely@1.8.x looks for libgeos_c.so in the miniconda
-    # install tree ... need to comment that out so that spack"s libgeos_c.so is found
+    # install tree ... need to comment that out so that spack"s libgeos_c.so is found.
+    # Also need to add logic to find libgeos_c.so from spack geos modules, if loaded.
     patch("shapely-1.8.0-geos.py.patch", when="@1.8.0:1.8.3")
 
     @when("^python@3.7:")

--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -47,7 +47,7 @@ class PyShapely(PythonPackage):
 
     # Spack might be using an external, barebone miniconda installation, in which case
     # the hacky logic in py-shapely@1.8.x looks for libgeos_c.so in the miniconda
-    # install tree ... need to comment that out so that spack"s libgeos_c.so is found.
+    # install tree ... need to comment that out so that spack's libgeos_c.so is found.
     # Also need to add logic to find libgeos_c.so from spack geos modules, if loaded.
     patch("shapely-1.8.0-geos.py.patch", when="@1.8.0:1.8.3")
 

--- a/var/spack/repos/builtin/packages/py-shapely/shapely-1.8.0-geos.py.patch
+++ b/var/spack/repos/builtin/packages/py-shapely/shapely-1.8.0-geos.py.patch
@@ -1,6 +1,6 @@
---- a/shapely/geos.py	2022-08-04 11:15:00.000000000 -0600
-+++ b/shapely/geos.py	2022-08-04 11:16:57.000000000 -0600
-@@ -88,9 +88,12 @@
+--- a/shapely/geos.py	2022-08-24 13:21:33.000000000 -0600
++++ b/shapely/geos.py	2022-08-24 13:23:54.000000000 -0600
+@@ -88,14 +88,21 @@
          if len(geos_pyinstaller_so) >= 1:
              _lgeos = CDLL(geos_pyinstaller_so[0])
              LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
@@ -14,9 +14,22 @@
 +    #    # conda package.
 +    #    _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.so'))
      else:
-         alt_paths = [
-             'libgeos_c.so.1',
-@@ -119,10 +122,12 @@
+-        alt_paths = [
+-            'libgeos_c.so.1',
+-            'libgeos_c.so',
+-        ]
++        # Use geos installation if spack geos module is loaded
++        if 'geos_ROOT' in os.environ:
++            alt_paths = [os.path.join(os.environ['geos_ROOT'], 'lib', 'libgeos_c.dylib')]
++        else:
++            alt_paths = [
++                'libgeos_c.so.1',
++                'libgeos_c.so',
++            ]
+         _lgeos = load_dll('geos_c', fallbacks=alt_paths)
+ 
+     # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
+@@ -119,10 +126,12 @@
          else:
              _lgeos = CDLL(geos_whl_dylib)
              LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
@@ -33,3 +46,13 @@
      else:
          if hasattr(sys, 'frozen'):
              try:
+@@ -139,6 +148,9 @@
+                 if hasattr(sys, '_MEIPASS'):
+                     alt_paths.append(
+                         os.path.join(sys._MEIPASS, 'libgeos_c.1.dylib'))
++        # Use geos installation if spack geos module is loaded
++        elif 'geos_ROOT' in os.environ:
++            alt_paths = [os.path.join(os.environ['geos_ROOT'], 'lib', 'libgeos_c.dylib')]
+         else:
+             alt_paths = [
+                 # The Framework build from Kyng Chaos


### PR DESCRIPTION
## Description

This PR adds yet another bug fix to the crooked logic of `shapely@1.8.0` to find `libgeos` when using spack.

**Note.** I don't intend to send this change back to the authoritative repo. This is a temporary workaround. In the long run, we want to move on to newer versions of `shapely` (currently we have to use version 1.8.0 due to the way our plotting scripts are written). The author of `shapely` was very well aware of how bad the code to find `libgeos` was in 1.8.x and rewrote the entire code for versions 2+.

## Testing

**This needs to be tested in the CI systems**: see https://github.com/NOAA-EMC/spack-stack/pull/318