### PR TITLE
Add version 11.7.1 to the NCEPLIBS-bufr package.py script.

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -30,7 +30,7 @@ class Bufr(CMakePackage):
     # Patch to not add "-c" to ranlib flags when using llvm-ranlib on Apple systems
     patch("cmakelists-apple-llvm-ranlib.patch", when="@:11.6.0")
     # C test does not explicity link to -lm causing DSO error when building shared libs
-    patch("c-tests-libm.patch", when="@11.5.0:11.7.1")
+    patch("c-tests-libm.patch", when="@11.5.0:11.7.0")
 
     variant("python", default=False, description="Enable Python interface?")
     variant("shared", default=True, description="Build shared libraries")
@@ -76,8 +76,7 @@ class Bufr(CMakePackage):
     def _setup_bufr_environment(self, env, suffix):
         libname = "libbufr_{0}".format(suffix)
         shared = True if "+shared" in self.spec else False
-        lib = find_libraries(libname, root=self.prefix,
-                             shared=shared, recursive=True)
+        lib = find_libraries(libname, root=self.prefix, shared=shared, recursive=True)
 
         lib_envname = "BUFR_LIB{0}".format(suffix)
         inc_envname = "BUFR_INC{0}".format(suffix)

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -21,6 +21,7 @@ class Bufr(CMakePackage):
 
     maintainers = ["t-brown", "kgerheiser", "edwardhartnett", "Hang-Lei-NOAA", "jbathegit"]
 
+    version("11.7.1", sha256="6533ce6eaa6b02c0cb5424cfbc086ab120ccebac3894980a4daafd4dfadd71f8")
     version("11.7.0", sha256="6a76ae8e7682bbc790321bf80c2f9417775c5b01a5c4f10763df92e01b20b9ca")
     version("11.6.0", sha256="af4c04e0b394aa9b5f411ec5c8055888619c724768b3094727e8bb7d3ea34a54")
     version("11.5.0", sha256="d154839e29ef1fe82e58cf20232e9f8a4f0610f0e8b6a394b7ca052e58f97f43")
@@ -29,7 +30,7 @@ class Bufr(CMakePackage):
     # Patch to not add "-c" to ranlib flags when using llvm-ranlib on Apple systems
     patch("cmakelists-apple-llvm-ranlib.patch", when="@:11.6.0")
     # C test does not explicity link to -lm causing DSO error when building shared libs
-    patch("c-tests-libm.patch", when="@11.5.0:11.7.0")
+    patch("c-tests-libm.patch", when="@11.5.0:11.7.1")
 
     variant("python", default=False, description="Enable Python interface?")
     variant("shared", default=True, description="Build shared libraries")


### PR DESCRIPTION
This PR adds in the latest tagged version (11.7.1) of the NCEPLIBS-bufr library. This version is needed by @rmclaren's bufr converter program.

Please note that jcsda-internal/ioda-converters/pull/1006 is good with version 11.7.0, and it is subsequent PRs that require 11.7.1.