### PR TITLE
Add missing dependency of mapl on cmake

### DIFF
--- a/var/spack/repos/jcsda-emc/packages/mapl/package.py
+++ b/var/spack/repos/jcsda-emc/packages/mapl/package.py
@@ -63,6 +63,7 @@ class Mapl(CMakePackage):
     variant("debug", default=False, description="Make a debuggable version of the library")
     variant("extdata2g", default=False, description="Use ExtData2G")
 
+    depends_on("cmake@3.17:")
     depends_on("mpi")
     depends_on("hdf5")
     depends_on("netcdf-c")


### PR DESCRIPTION
As the title says. Fixes #165 (see discussion on versions in the issue).