### PR TITLE
Don't install aws-parallelcluster with spack, need newer version with very complicated dependencies

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
@@ -21,7 +21,7 @@ class JediToolsEnv(BundlePackage):
 
     depends_on("awscli", type="run")
     # Only old versions - new versions have terrible dependencies
-    #depends_on("aws-parallelcluster", type="run")
+    # depends_on("aws-parallelcluster", type="run")
     # npm is needed for aws-parallelcluster, even when installed via pip in venv
     depends_on("npm", type="run")
     depends_on("py-click", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
@@ -20,7 +20,10 @@ class JediToolsEnv(BundlePackage):
     variant("latex", default=False, description="Enable building LaTeX documentation with Sphinx")
 
     depends_on("awscli", type="run")
-    depends_on("aws-parallelcluster", type="run")
+    # Only old versions - new versions have terrible dependencies
+    #depends_on("aws-parallelcluster", type="run")
+    # npm is needed for aws-parallelcluster, even when installed via pip in venv
+    depends_on("npm", type="run")
     depends_on("py-click", type="run")
     depends_on("py-openpyxl", type="run")
     depends_on("py-pandas", type="run")


### PR DESCRIPTION
Newer versions of `aws-parallelcluster` have very complicated dependencies, such as `aws_cdk`, which gets installed with `npm` (a Javascript package manager). Let's not build `aws-parallelcluster` with spack-stack, but instead build only `npm` and install `aws-parallelcluster` in a Python virtual environment that leverages the existing (Python and other) packages from spack-stack.