### PR TITLE
Add xarray and f90nml to jedi-base-env, remove `npm` from `jedi-tools-env`

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -43,6 +43,7 @@ class JediBaseEnv(BundlePackage):
     depends_on("nlohmann-json-schema-validator", type="run")
     depends_on("odc", type="run")
     depends_on("py-eccodes", type="run")
+    depends_on("py-f90nml", type="run")
     depends_on("py-h5py", type="run")
     depends_on("py-netcdf4", type="run")
     depends_on("py-pandas", type="run")
@@ -52,6 +53,7 @@ class JediBaseEnv(BundlePackage):
     depends_on("py-python-dateutil", type="run")
     depends_on("py-pyyaml", type="run")
     depends_on("py-scipy", type="run")
+    depends_on("py-xarray", type="run")
     depends_on("udunits", type="run")
 
     # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
@@ -22,8 +22,10 @@ class JediToolsEnv(BundlePackage):
     depends_on("awscli", type="run")
     # Only old versions - new versions have terrible dependencies
     # depends_on("aws-parallelcluster", type="run")
-    # npm is needed for aws-parallelcluster, even when installed via pip in venv
-    depends_on("npm", type="run")
+    # npm is needed for aws-parallelcluster, even when installed
+    # via pip in venv - however, several build errors in npm and
+    # node-js - install all of this outside of spack-stack for now
+    # depends_on("npm", type="run")
     depends_on("py-click", type="run")
     depends_on("py-openpyxl", type="run")
     depends_on("py-pandas", type="run")


### PR DESCRIPTION
- Packages `xarray` and `f90nml` are required in `jedi-base-env`, added there.
- Revert previous change to build `npm` as part of `jedi-tools-env` - numerous build errors for `npm` and one of its dependencies `node-js`. For now (or in the long term), install `aws-parallelcluster` and its dependencies outside of spack-stack.

Working towards https://github.com/NOAA-EMC/spack-stack/issues/147
Working towards https://github.com/NOAA-EMC/spack-stack/issues/242