### PR TITLE
Add new versions of eccodes and py-eccodes

### DIFF
--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -48,6 +48,7 @@ class Eccodes(CMakePackage):
     maintainers = ["skosukhin"]
 
     version("develop", branch="develop")
+    version("2.27.0", sha256="xxx5131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e")
     version("2.25.0", sha256="8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e")
     version("2.24.2", sha256="c60ad0fd89e11918ace0d84c01489f21222b11d6cad3ff7495856a0add610403")
     version("2.23.0", sha256="cbdc8532537e9682f1a93ddb03440416b66906a4cc25dec3cbd73940d194bf0c")

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -48,7 +48,7 @@ class Eccodes(CMakePackage):
     maintainers = ["skosukhin"]
 
     version("develop", branch="develop")
-    version("2.27.0", sha256="xxx5131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e")
+    version("2.27.0", sha256="ede5b3ffd503967a5eac89100e8ead5e16a881b7585d02f033584ed0c4269c99")
     version("2.25.0", sha256="8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e")
     version("2.24.2", sha256="c60ad0fd89e11918ace0d84c01489f21222b11d6cad3ff7495856a0add610403")
     version("2.23.0", sha256="cbdc8532537e9682f1a93ddb03440416b66906a4cc25dec3cbd73940d194bf0c")

--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -14,6 +14,7 @@ class PyEccodes(PythonPackage):
     homepage = "https://github.com/ecmwf/eccodes-python"
     pypi = "eccodes/eccodes-1.3.2.tar.gz"
 
+    version("1.5.0", sha256="xxx2adfdc1bc658356163c9cef1857d4b2bae99399660d3d4fcb145a52d3b2a6")
     version("1.3.2", sha256="f282adfdc1bc658356163c9cef1857d4b2bae99399660d3d4fcb145a52d3b2a6")
 
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -14,7 +14,7 @@ class PyEccodes(PythonPackage):
     homepage = "https://github.com/ecmwf/eccodes-python"
     pypi = "eccodes/eccodes-1.3.2.tar.gz"
 
-    version("1.5.0", sha256="xxx2adfdc1bc658356163c9cef1857d4b2bae99399660d3d4fcb145a52d3b2a6")
+    version("1.5.0", sha256="e70c8f159140c343c215fd608ddf533be652ff05ad2ff17243c7b66cf92127fa")
     version("1.3.2", sha256="f282adfdc1bc658356163c9cef1857d4b2bae99399660d3d4fcb145a52d3b2a6")
 
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -14,7 +14,7 @@ class PyEccodes(PythonPackage):
     homepage = "https://github.com/ecmwf/eccodes-python"
     pypi = "eccodes/eccodes-1.3.2.tar.gz"
 
-    version("1.5.0", sha256="e70c8f159140c343c215fd608ddf533be652ff05ad2ff17243c7b66cf92127fa")
+    version("1.4.2", sha256="63fa80a1d1b445904f486bc396a6a6605df029f4e215acc28ceb1a1ff5eb664f")
     version("1.3.2", sha256="f282adfdc1bc658356163c9cef1857d4b2bae99399660d3d4fcb145a52d3b2a6")
 
     depends_on("py-setuptools", type="build")
@@ -27,12 +27,8 @@ class PyEccodes(PythonPackage):
     def setup_build_environment(self, env):
         if sys.platform == "darwin":
             env.prepend_path("DYLD_LIBRARY_PATH", self.spec["eccodes"].libs.directories[0])
-            if self.spec.satisfies("@1.5.0"):
-                env.prepend_path("DYLD_LIBRARY_PATH", self.spec["libffi"].libs.directories[0])
         else:
             env.prepend_path("LD_LIBRARY_PATH", self.spec["eccodes"].libs.directories[0])
-            if self.spec.satisfies("@1.5.0"):
-                env.prepend_path("LD_LIBRARY_PATH", self.spec["libffi"].libs.directories[0])
 
     def setup_run_environment(self, env):
         self.setup_build_environment(env)

--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -27,8 +27,12 @@ class PyEccodes(PythonPackage):
     def setup_build_environment(self, env):
         if sys.platform == "darwin":
             env.prepend_path("DYLD_LIBRARY_PATH", self.spec["eccodes"].libs.directories[0])
+            if self.spec.satisfies("@1.5.0"):
+                env.prepend_path("DYLD_LIBRARY_PATH", self.spec["libffi"].libs.directories[0])
         else:
             env.prepend_path("LD_LIBRARY_PATH", self.spec["eccodes"].libs.directories[0])
+            if self.spec.satisfies("@1.5.0"):
+                env.prepend_path("LD_LIBRARY_PATH", self.spec["libffi"].libs.directories[0])
 
     def setup_run_environment(self, env):
         self.setup_build_environment(env)


### PR DESCRIPTION
## Description

Add new versions `eccodes@2.27.0` and `py-eccodes@1.4.2` requested by @gthompsnJCSDA.

Tested with corresponding spack-stack PR https://github.com/NOAA-EMC/spack-stack/pull/337