### PR TITLE
Fix JCSDA-EMC container unit tests

### DIFF
--- a/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
+++ b/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
@@ -5,7 +5,7 @@ import pytest
 import spack
 import spack.main
 
-stack_create = spack.main.SpackCommand('stack')
+stack_create = spack.main.SpackCommand("stack")
 
 
 # Find spack-stack directory assuming this Spack instance
@@ -13,17 +13,17 @@ stack_create = spack.main.SpackCommand('stack')
 def stack_path(*paths):
     stack_dir = os.path.dirname(spack.paths.spack_root)
 
-    if not os.path.exists(os.path.join(stack_dir, '.spackstack')):
+    if not os.path.exists(os.path.join(stack_dir, ".spackstack")):
         return None
 
     return os.path.join(stack_dir, *paths)
 
 
-test_dir = stack_path('envs', 'unit-tests', 'stack-create')
+test_dir = stack_path("envs", "unit-tests", "stack-create")
 
 
 def all_templates():
-    template_path = stack_path('configs', 'templates')
+    template_path = stack_path("configs", "templates")
     if template_path:
         _, templates, _ = next(os.walk(template_path))
         return list(templates)
@@ -32,7 +32,7 @@ def all_templates():
 
 
 def all_sites():
-    site_path = stack_path('configs', 'sites')
+    site_path = stack_path("configs", "sites")
     if site_path:
         _, sites, _ = next(os.walk(site_path))
         return list(sites)
@@ -41,7 +41,7 @@ def all_sites():
 
 
 def all_containers():
-    container_path = stack_path('configs', 'containers')
+    container_path = stack_path("configs", "containers")
     if container_path:
         _, _, containers = next(os.walk(container_path))
         # Exclude files like "README.md"
@@ -51,32 +51,29 @@ def all_containers():
         return None
 
 
-@pytest.mark.extension('stack')
-@pytest.mark.parametrize('template', all_templates())
-@pytest.mark.filterwarnings('ignore::UserWarning')
+@pytest.mark.extension("stack")
+@pytest.mark.parametrize("template", all_templates())
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_apps(template):
     if not template:
         return
-    stack_create('create', 'env', '--template', template,
-                 '--dir', test_dir, '--overwrite')
+    stack_create("create", "env", "--template", template, "--dir", test_dir, "--overwrite")
 
 
-@pytest.mark.extension('stack')
-@pytest.mark.parametrize('site', all_sites())
-@pytest.mark.filterwarnings('ignore::UserWarning')
+@pytest.mark.extension("stack")
+@pytest.mark.parametrize("site", all_sites())
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_sites(site):
     if not site:
         return
-    stack_create('create', 'env', '--site', site,
-                 '--dir', test_dir, '--overwrite')
+    stack_create("create", "env", "--site", site, "--dir", test_dir, "--overwrite")
 
 
-@pytest.mark.extension('stack')
-@pytest.mark.parametrize('container', all_containers())
-@pytest.mark.filterwarnings('ignore::UserWarning')
+@pytest.mark.extension("stack")
+@pytest.mark.parametrize("container", all_containers())
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_containers(container):
     if not container:
         return
     container_wo_ext = os.path.splitext(container)[0]
-    stack_create('create', 'ctr', container_wo_ext,
-                 '--dir', test_dir, '--overwrite')
+    stack_create("create", "ctr", container_wo_ext, "--dir", test_dir, "--overwrite")

--- a/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
+++ b/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
@@ -44,6 +44,8 @@ def all_containers():
     container_path = stack_path('configs', 'containers')
     if container_path:
         _, _, containers = next(os.walk(container_path))
+        # Exclude files like "README.md"
+        containers = [x for x in containers if x.endswith(".yaml")]
         return containers
     else:
         return None

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -19,6 +19,7 @@ class Curl(AutotoolsPackage):
 
     executables = ["^curl$"]
 
+    version("7.85.0", sha256="21a7e83628ee96164ac2b36ff6bf99d467c7b0b621c1f7e317d8f0d96011539c")
     version("7.84.0", sha256="702fb26e73190a3bd77071aa146f507b9817cc4dfce218d2ab87f00cd3bc059d")
     version("7.83.0", sha256="247c7ec7521c4258e65634e529270d214fe32969971cccb72845e7aa46831f96")
     version("7.82.0", sha256="46d9a0400a33408fd992770b04a44a7434b3036f2e8089ac28b57573d59d371f")


### PR DESCRIPTION
## Description

Need to exclude `README.md` from list of container recipes (it's simply looking for all files in `configs/containers`. Lines 47-48 in `lib/jcsda-emc/spack-stack/tests/test_stack_create.py`.

Also need to "black-format" `lib/jcsda-emc/spack-stack/tests/test_stack_create.py` to make the spack style tests pass (all remaining changes).

This fixes the unit test problem in spack-stack PRs. The style tests now also pass. The remaining CI test errors are due to jedi-cmake not being in the authoritative repo (but in `jcsda-emc`), something we don't have a good solution for.
```
=================================== FAILURES ===================================
_________________________ test_all_dependencies_exist __________________________

    def test_all_dependencies_exist():
        """Make sure no packages have nonexisting dependencies."""
        missing = {}
        pkgs = [pkg for pkg in spack.repo.path.all_package_names()]
        spack.package_base.possible_dependencies(*pkgs, transitive=True, missing=missing)
    
        lines = ["%s: [%s]" % (name, ", ".join(deps)) for name, deps in missing.items()]
>       assert not missing, "These packages have missing dependencies:\n" + ("\n".join(lines))
E       AssertionError: These packages have missing dependencies:
E         fms: [jedi-cmake]
E       assert not {'fms': {'jedi-cmake'}}
```

**Also included:** cherry-picking an update from spack to build a newer version of `curl` with the Intel compiler in the containers (`7.85.0`). Older versions of `curl` fail to build with Intel.