### PR TITLE
Add package gsibec (aka gsibclim)

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -34,6 +34,7 @@ class JediBaseEnv(BundlePackage):
     depends_on("fftw-api", when="+fftw", type="run")
     depends_on("flex", type="run")
     depends_on("git-lfs", type="run")
+    depends_on("gsibec", type="run")
     depends_on("gsl-lite", type="run")
     depends_on("hdf", type="run")
     depends_on("jedi-cmake", type="run")

--- a/var/spack/repos/jcsda-emc/packages/gsibec/package.py
+++ b/var/spack/repos/jcsda-emc/packages/gsibec/package.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gsibec(CMakePackage):
+    """GSIbec: Extracts the background error covariance (BEC) model
+    capabilities from the Gridpoint Statistical Interpolation (GSI)
+    atmospheric analysis system into a library of its own."""
+
+    homepage = "https://github.com/GEOS-ESM/gsibec"
+    git = "https://github.com/GEOS-ESM/gsibec.git"
+    url = "https://github.com/GEOS-ESM/gsibec/archive/refs/tags/1.0.2.tar.gz"
+
+    maintainers = ["mathomp4", "danholdaway"]
+
+    version("develop", branch="develop")
+    version("1.0.2", sha256="7dc02f1f499e0d9f2843440f517d6c8e5d10ea084cbb2567ec198ba06816bc8b")
+
+    variant("mkl", default=False, description="Use MKL for LAPACK implementation")
+
+    depends_on("mpi", type=("build", "run"))
+    depends_on("netcdf-c +mpi", type=("build", "run"))
+    depends_on("netcdf-fortran", type=("build", "run"))
+
+    depends_on("mkl", when="+mkl", type=("build", "run"))
+    depends_on("lapack", when="~mkl", type=("build", "run"))
+
+    depends_on("ecbuild", type=("build"))
+    depends_on("jedi-cmake", type=("build"))
+    depends_on("sp", type=("build"))
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("ENABLE_MKL", "mkl"),
+        ]
+        return args


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/spack-stack/issues/280

For this version, I decided to turn off Intel MKL by default and use the spack `lapack` provider (as we are doing it for all other packages, e.g. ECMFW's `atlas`).

This packages builds cleanly on my macOS with `apple-clang` and `openmpi`. spack CI tests all passed.
