### PR TITLE
Add gsibec versions 1.0.3, 1.0.4, 1.0.5

### DIFF
--- a/var/spack/repos/jcsda-emc/packages/gsibec/package.py
+++ b/var/spack/repos/jcsda-emc/packages/gsibec/package.py
@@ -18,6 +18,8 @@ class Gsibec(CMakePackage):
     maintainers = ["mathomp4", "danholdaway"]
 
     version("develop", branch="develop")
+    version("1.0.4", sha256="6460e221f2a45640adab016336c070fbe3e7c4b6fc55257945bf5cdb38d5d3e2")
+    version("1.0.3", sha256="f104daf55705c5093a3d984073f082017bc9166f51ded36c7f7bb8adf233c916")
     version("1.0.2", sha256="7dc02f1f499e0d9f2843440f517d6c8e5d10ea084cbb2567ec198ba06816bc8b")
 
     variant("mkl", default=False, description="Use MKL for LAPACK implementation")

--- a/var/spack/repos/jcsda-emc/packages/gsibec/package.py
+++ b/var/spack/repos/jcsda-emc/packages/gsibec/package.py
@@ -18,6 +18,7 @@ class Gsibec(CMakePackage):
     maintainers = ["mathomp4", "danholdaway"]
 
     version("develop", branch="develop")
+    version("1.0.5", sha256="ac0cecc59e38da7eefb5a8f27975b33752fa61a4abd3bdbbfb55578ea59d95b3")
     version("1.0.4", sha256="6460e221f2a45640adab016336c070fbe3e7c4b6fc55257945bf5cdb38d5d3e2")
     version("1.0.3", sha256="f104daf55705c5093a3d984073f082017bc9166f51ded36c7f7bb8adf233c916")
     version("1.0.2", sha256="7dc02f1f499e0d9f2843440f517d6c8e5d10ea084cbb2567ec198ba06816bc8b")


### PR DESCRIPTION
As the title says. Working towards https://github.com/NOAA-EMC/spack-stack/issues/346.

Tested with https://github.com/NOAA-EMC/spack-stack/pull/347