### PR TITLE
Bug fix for py-scipy with Intel (error loading scipy with Intel compilers)

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -2,10 +2,9 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from spack.package import *
-
-
 import platform
+
+from spack.package import *
 
 
 class PyScipy(PythonPackage):

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -160,13 +160,6 @@ class PyScipy(PythonPackage):
         # Pick up Blas/Lapack from numpy
         self.spec["py-numpy"].package.setup_build_environment(env)
 
-        # https://github.com/scipy/scipy/issues/14935
-        # Disable pythran backend with latest Intel compilers
-        # Turns out it also doesn't work with previous versions
-        if self.spec.satisfies("%intel") or \
-                self.spec.satisfies("%intel-oneapi-compilers"):
-            env.set("SCIPY_USE_PYTHRAN", "0")
-
         # Kluge to get the gfortran linker to work correctly on Big
         # Sur, at least until a gcc release > 10.2 is out with a fix.
         # (There is a fix in their development tree.)

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -152,6 +152,12 @@ class PyScipy(PythonPackage):
             if self.spec.satisfies("^py-numpy@1.16:1.17"):
                 env.set("NPY_DISTUTILS_APPEND_FLAGS", "1")
 
+        # https://github.com/scipy/scipy/issues/14935
+        if (self.spec.satisfies('%intel ^py-pythran')
+            or self.spec.satisfies('%oneapi ^py-pythran')):
+            if spec["py-pythran"].version < Version("0.12"):
+                env.set('SCIPY_USE_PYTHRAN', '0')
+
         # Pick up Blas/Lapack from numpy
         self.spec["py-numpy"].package.setup_build_environment(env)
 

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -155,7 +155,7 @@ class PyScipy(PythonPackage):
         # https://github.com/scipy/scipy/issues/14935
         if (self.spec.satisfies('%intel ^py-pythran')
             or self.spec.satisfies('%oneapi ^py-pythran')):
-            if spec["py-pythran"].version < Version("0.12"):
+            if self.spec["py-pythran"].version < Version("0.12"):
                 env.set('SCIPY_USE_PYTHRAN', '0')
 
         # Pick up Blas/Lapack from numpy

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -132,7 +132,7 @@ class PyScipy(PythonPackage):
             with open("setup.cfg", "w") as f:
                 f.write("[config_fc]\n")
                 f.write("fcompiler = fujitsu\n")
-        elif (self.spec.satisfies("%intel") or self.spec.satisfies("%oneapi")):
+        elif self.spec.satisfies("%intel") or self.spec.satisfies("%oneapi"):
             if self.spec.satisfies("target=x86:"):
                 with open("setup.cfg", "w") as f:
                     f.write("[config_fc]\n")
@@ -153,10 +153,9 @@ class PyScipy(PythonPackage):
                 env.set("NPY_DISTUTILS_APPEND_FLAGS", "1")
 
         # https://github.com/scipy/scipy/issues/14935
-        if (self.spec.satisfies('%intel ^py-pythran')
-            or self.spec.satisfies('%oneapi ^py-pythran')):
+        if self.spec.satisfies("%intel ^py-pythran") or self.spec.satisfies("%oneapi ^py-pythran"):
             if self.spec["py-pythran"].version < Version("0.12"):
-                env.set('SCIPY_USE_PYTHRAN', '0')
+                env.set("SCIPY_USE_PYTHRAN", "0")
 
         # Pick up Blas/Lapack from numpy
         self.spec["py-numpy"].package.setup_build_environment(env)


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/spack-stack/issues/291 by cherry-picking the commits in PR https://github.com/spack/spack/pull/32767.

Tested on Discover with Intel, for which the problem was originally reported in https://github.com/NOAA-EMC/spack-stack/issues/291.

CI tests all passed for https://github.com/NOAA-EMC/spack/pull/178/commits/55051d09257eb24da480067806843b96485e376d.