### PR TITLE
release/1.1.0: several bug fixes from installation of release/1.1.0 on HPCs, cloud, macOS

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -6,11 +6,13 @@ on:
       - develop
       - releases/**
       - jcsda_emc_spack_stack
+      - release/**
   pull_request:
     branches:
       - develop
       - releases/**
       - jcsda_emc_spack_stack
+      - release/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -43,7 +43,10 @@ class Crtm(CMakePackage):
     # depends_on("ecbuild", when="@2.4.0:", type=("build"))
 
     # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
-    version("2.4.0", commit="5ddd0d6")  # use commit="690da37" for JCSDA-internal
+    # Use this hash with JCSDA (public)
+    version("2.4.0", commit="5ddd0d6")
+    # Use this hash with JCSDA-internal
+    # version("2.4.0", commit="690da37")
     # Uses the tip of REL-2.3.0_emc branch
     version("2.3.0", commit="99760e6")
     # JEDI applications so far use these versions

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -43,7 +43,7 @@ class Crtm(CMakePackage):
     # depends_on("ecbuild", when="@2.4.0:", type=("build"))
 
     # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
-    version("2.4.0", commit="5ddd0d6") # use commit="690da37" for JCSDA-internal
+    version("2.4.0", commit="5ddd0d6")  # use commit="690da37" for JCSDA-internal
     # Uses the tip of REL-2.3.0_emc branch
     version("2.3.0", commit="99760e6")
     # JEDI applications so far use these versions

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -15,6 +15,8 @@ class Crtm(CMakePackage):
     homepage = "https://www.jcsda.org/jcsda-project-community-radiative-transfer-model"
     git = "https://github.com/JCSDA/crtm.git"
     url = "https://github.com/JCSDA/crtm/archive/refs/tags/v2.3.0.tar.gz"
+    # git = "https://github.com/JCSDA-internal/crtm.git"
+    # url = "https://github.com/JCSDA-internal/crtm/archive/refs/tags/v2.3.0.tar.gz"
 
     maintainers = ["BenjaminTJohnson", "edwardhartnett", "Hang-Lei-NOAA", "climbfuji"]
 
@@ -24,6 +26,7 @@ class Crtm(CMakePackage):
         description='Download CRTM coeffecient or "fix" files (several GBs).',
     )
 
+    depends_on("cmake@3.15:")
     depends_on("git-lfs")
     depends_on("netcdf-fortran", when="@2.4.0:")
     depends_on("netcdf-fortran", when="@v2.3-jedi.4")
@@ -40,7 +43,7 @@ class Crtm(CMakePackage):
     # depends_on("ecbuild", when="@2.4.0:", type=("build"))
 
     # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
-    version("2.4.0", commit="5ddd0d6")
+    version("2.4.0", commit="5ddd0d6") # use commit="690da37" for JCSDA-internal
     # Uses the tip of REL-2.3.0_emc branch
     version("2.3.0", commit="99760e6")
     # JEDI applications so far use these versions

--- a/var/spack/repos/builtin/packages/ncview/package.py
+++ b/var/spack/repos/builtin/packages/ncview/package.py
@@ -25,7 +25,13 @@ class Ncview(AutotoolsPackage):
 
         config_args = []
 
+        # Problems on some systems (e.g. NASA Discover with Intel)
+        # to find udunits include and library files despite
+        # dependency being specified above
+        config_args.append("--with-udunits2_incdir={}".format(spec["udunits"].prefix.include)
+        config_args.append("--with-udunits2_libdir={}".format(spec["udunits"].prefix.lib)
+
         if spec.satisfies("^netcdf-c+mpi"):
-            config_args.append("CC={0}".format(spec["mpi"].mpicc))
+            config_args.append("CC={}".format(spec["mpi"].mpicc))
 
         return config_args

--- a/var/spack/repos/builtin/packages/ncview/package.py
+++ b/var/spack/repos/builtin/packages/ncview/package.py
@@ -28,8 +28,8 @@ class Ncview(AutotoolsPackage):
         # Problems on some systems (e.g. NASA Discover with Intel)
         # to find udunits include and library files despite
         # dependency being specified above
-        config_args.append("--with-udunits2_incdir={}".format(spec["udunits"].prefix.include)
-        config_args.append("--with-udunits2_libdir={}".format(spec["udunits"].prefix.lib)
+        config_args.append("--with-udunits2_incdir={}".format(spec["udunits"].prefix.include))
+        config_args.append("--with-udunits2_libdir={}".format(spec["udunits"].prefix.lib))
 
         if spec.satisfies("^netcdf-c+mpi"):
             config_args.append("CC={}".format(spec["mpi"].mpicc))

--- a/var/spack/repos/jcsda-emc/packages/jedi-cmake/package.py
+++ b/var/spack/repos/jcsda-emc/packages/jedi-cmake/package.py
@@ -11,7 +11,7 @@ class JediCmake(CMakePackage):
 
     homepage = "https://github.com/JCSDA/jedi-cmake"
     git = "https://github.com/JCSDA/jedi-cmake.git"
-    #url = "https://github.com/JCSDA/jedi-cmake/archive/refs/tags/1.4.0.tar.gz"
+    # url = "https://github.com/JCSDA/jedi-cmake/archive/refs/tags/1.4.0.tar.gz"
 
     maintainers = ["climbfuji"]
 

--- a/var/spack/repos/jcsda-emc/packages/jedi-cmake/package.py
+++ b/var/spack/repos/jcsda-emc/packages/jedi-cmake/package.py
@@ -11,7 +11,7 @@ class JediCmake(CMakePackage):
 
     homepage = "https://github.com/JCSDA/jedi-cmake"
     git = "https://github.com/JCSDA/jedi-cmake.git"
-    url = "https://github.com/JCSDA/jedi-cmake/archive/refs/tags/1.4.0.tar.gz"
+    #url = "https://github.com/JCSDA/jedi-cmake/archive/refs/tags/1.4.0.tar.gz"
 
     maintainers = ["climbfuji"]
 
@@ -23,9 +23,6 @@ class JediCmake(CMakePackage):
         preferred=True,
         submodules=True,
     )
-    version("1.3.0", sha256="3e92339df858e9663b2cdd9f7bb7e56d18098e9c60606fe7af9e5f5911e5ca55")
-    version("1.2.0", sha256="eb9f1c403d1b43a90a5e774097382b183d56d5b40a1204b51af2da8db1559b21")
-    version("1.1.0", sha256="f1fe41eb5edd343bdf57eb76bea6d1b9f015878f0a9d0eb1e9dba18b903d3b35")
-    version("1.0.0", sha256="d773a800350e69372355b45e89160b593818cd438a86925b8a689c47996a0b9a")
+    version("1.3.0", commit="729a9b2ec97a7e93cbc58213493f28ca11f08754")
 
     depends_on("cmake @3.10:", type=("build"))


### PR DESCRIPTION
## Bug fixes

### jedi-cmake

Turns out that `jedi-cmake@1.4.0` with recursive checkout doesn't install as it's currently written in the containers, because the containers somehow think they want to pull a `.tar.gz` file. The solution is to remove the `url` entry and specify only git commits, no `sha256` checksums.

This works on the containers and elsewhere and needs to be sent back to develop later.

###  crtm
Add comments in `crtm` package to switch to JCSDA-internal. These comments make it easier and faster to switch. This should stay in the release branch and not be merged back to develop.

Bug fix: `crtm` depends on `cmake@3.15` or later, this dependency was not captured in the package beforehand. This needs to be sent back to develop later.

### ncview
On some systems (e.g. Discover with Intel), `ncview` didn't find `udunits` even though the dependency was loaded by spack. This PR addresses that by explicitly passing the `udunits` `include` and `lib` dirs to `ncview`. This needs to be sent back to develop later.

## Features

### Enable CI tests for `release/**`

Enable CI tests for `release/**` - i.e. for this branch. Turns out that they don't run right now, however, because of Github action / spack (authoritative) changes beyond our control. This should be sent back to develop later for future use.
