### PR TITLE
Bug fix for ca-certificates-mozilla/package.py to enable spack install --source

### DIFF
--- a/var/spack/repos/builtin/packages/ca-certificates-mozilla/package.py
+++ b/var/spack/repos/builtin/packages/ca-certificates-mozilla/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 
@@ -124,6 +122,5 @@ class CaCertificatesMozilla(Package):
     def install(self, spec, prefix):
         share = join_path(prefix, "share")
         # https://github.com/spack/spack/issues/32948
-        if not os.path.isdir(share):
-            mkdir(share)
+        mkdirp(share)
         install("cacert-{0}.pem".format(spec.version), join_path(share, "cacert.pem"))

--- a/var/spack/repos/builtin/packages/ca-certificates-mozilla/package.py
+++ b/var/spack/repos/builtin/packages/ca-certificates-mozilla/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -121,5 +123,7 @@ class CaCertificatesMozilla(Package):
     # Install the the pem file as share/cacert.pem
     def install(self, spec, prefix):
         share = join_path(prefix, "share")
-        mkdir(share)
+        # https://github.com/spack/spack/issues/32948
+        if not os.path.isdir(share):
+            mkdir(share)
         install("cacert-{0}.pem".format(spec.version), join_path(share, "cacert.pem"))


### PR DESCRIPTION
This PR is cherry-picking two commits from PR https://github.com/spack/spack/pull/32953 that was merged into the authoritative spack repository.

The original issue was https://github.com/spack/spack/issues/32948.

This PR closes #https://github.com/NOAA-EMC/spack-stack/issues/369