### PR TITLE
Bug fix in package Python: fix fa…

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -6,7 +6,6 @@
 import glob
 import json
 import os
-import pathlib
 import platform
 import re
 import subprocess
@@ -1012,10 +1011,10 @@ config.update(get_paths())
             # but doesn't have the correct filename suffix. This confuses several
             # packages (e.g. met) that use python.libs.ld_flags. Repair this by
             # pointing back to the symbolic link .../libs/libpython3.9.dylib
-            file_extension_shared = pathlib.Path(config['LDLIBRARY']).suffix
+            file_extension_shared = os.path.splitext(config['LDLIBRARY'])[-1]
             if file_extension_shared=='':
                 config['LDLIBRARY'] = "libpython{}.{}".format(version, dso_suffix)
-            file_extension_static = pathlib.Path(config['LIBRARY']).suffix
+            file_extension_static = os.path.splitext(config['LIBRARY'])[-1]
             if file_extension_static=='':
                 config['LIBRARY'] = "libpython{}.a".format(version)
             self._config_vars[dag_hash] = config

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1011,12 +1011,12 @@ config.update(get_paths())
             # but doesn't have the correct filename suffix. This confuses several
             # packages (e.g. met) that use python.libs.ld_flags. Repair this by
             # pointing back to the symbolic link .../libs/libpython3.9.dylib
-            file_extension_shared = os.path.splitext(config['LDLIBRARY'])[-1]
-            if file_extension_shared=='':
-                config['LDLIBRARY'] = "libpython{}.{}".format(version, dso_suffix)
-            file_extension_static = os.path.splitext(config['LIBRARY'])[-1]
-            if file_extension_static=='':
-                config['LIBRARY'] = "libpython{}.a".format(version)
+            file_extension_shared = os.path.splitext(config["LDLIBRARY"])[-1]
+            if file_extension_shared == "":
+                config["LDLIBRARY"] = "libpython{}.{}".format(version, dso_suffix)
+            file_extension_static = os.path.splitext(config["LIBRARY"])[-1]
+            if file_extension_static == "":
+                config["LIBRARY"] = "libpython{}.a".format(version)
             self._config_vars[dag_hash] = config
         return self._config_vars[dag_hash]
 


### PR DESCRIPTION
When using homebrew on macOS, the spack Python package `self.config_vars["LDLIBRARY"]` variable points to `Python.framework/Versions/3.9/Python`, which is indeed a shared library but doesn't have the correct filename suffix. This confuses several packages (e.g. `met`) that use `python.libs.ld_flags`. Repair this by pointing back to the symbolic link `Python.framework/Versions/3.9/lib/libpython3.9.dylib`.

Tested on macOS with homebrew, fixes https://github.com/NOAA-EMC/spack-stack/issues/316 (and answers the discussion in https://github.com/dtcenter/METplus/discussions/1762).

The corresponding issue and pull request for the authoritative spack repository are (cherry-picked commits)

https://github.com/spack/spack/issues/33409
https://github.com/spack/spack/pull/33410
