### PR TITLE
Bug fix for building hdf4 on Apple M1 arch64

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/hdfi_h_apple_m1.patch
+++ b/var/spack/repos/builtin/packages/hdf/hdfi_h_apple_m1.patch
@@ -1,0 +1,11 @@
+--- a/hdf/src/hdfi.h	2022-11-07 11:51:28.000000000 -0700
++++ b/hdf/src/hdfi.h	2022-11-07 11:51:08.000000000 -0700
+@@ -1343,7 +1343,7 @@
+ #endif /* IA64 */
+ 
+ /* Linux AArch64 */
+-#if defined __aarch64__
++#if defined __aarch64__ && ! defined (__APPLE__)
+ 
+ #ifdef GOT_MACHINE
+ If you get an error on this line more than one machine type has been defined.

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -93,6 +93,8 @@ class Hdf(AutotoolsPackage):
         sha256="49733dd6143be7b30a28d386701df64a72507974274f7e4c0a9e74205510ea72",
         when="@4.2.15:",
     )
+    # https://github.com/NOAA-EMC/spack-stack/issues/317
+    patch("hdfi_h_apple_m1.patch", when="@4.2.15: target=aarch64: platform=darwin")
 
     @property
     def libs(self):


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/spack-stack/issues/317.

I tested this on my macOS, native M1 environment, and ran the unit tests that come with hdf - they all pass.