### PR TITLE
By default, installing source files

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1855,7 +1855,7 @@ class BuildProcessInstaller(object):
         self.fake = install_args.get("fake", False)
 
         # whether to install source code with the packag
-        self.install_source = install_args.get("install_source", False)
+        self.install_source = install_args.get("install_source", True)
 
         # whether to keep the build stage after installation
         self.keep_stage = install_args.get("keep_stage", False)
@@ -2371,7 +2371,7 @@ class BuildRequest(object):
             ("fake", False),
             ("install_deps", True),
             ("install_package", True),
-            ("install_source", False),
+            ("install_source", True),
             ("package_cache_only", False),
             ("package_use_cache", True),
             ("keep_prefix", False),


### PR DESCRIPTION
## Description

Change the default value for installing source to `true` in `lib/spack/spack/installer.py`. This way, we don't have to remember to add `--source` to the `spack install` command. This change will likely have to remain in our fork, I don't expect the spack developers to accept this into the authoritative repository.

A documentation update PR for spack-stack ... **MISSING**