### PR TITLE
Update sha256 of crtm-fix@2.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -17,7 +17,7 @@ class CrtmFix(Package):
     maintainers = ["kgerheiser"]
 
     version("2.4.0", sha256="7924285b8aa25b0b864643f03e7f281ca1816958e24c76aa9531b3ca902bf6e9")
-    version("2.4.0_emc", sha256="84b176ee16cce0897377696cc4f621ef5a55cae7ea8280a0acd5ff70d4435995")
+    version("2.4.0_emc", sha256="88d659ae5bc4434f7fafa232ff65b4c48442d2d1a25f8fc96078094fa572ac1a")
     version("2.3.0_emc", sha256="fde73bb41c3c00666ab0eb8c40895e02d36fa8d7b0896c276375214a1ddaab8f")
 
     variant("big_endian", default=True, description="Install big_endian fix files")


### PR DESCRIPTION
## Description

As the tile says. Fixes #194 . I tested this on my macOS today, both crtm@2.3.0+fix and crtm@2.4.0 install cleanly with this change. Thanks @BenjaminTJohnson for updating the fix file tarball and providing the sha256 checksum.
