### PR TITLE
For only macos, add llvm-openmp dependency for eckit, atlas, fckit.

### DIFF
--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -60,6 +60,7 @@ class Eckit(CMakePackage):
     depends_on("ecbuild@3.5:", type="build")
 
     depends_on("mpi", when="+mpi")
+    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
 
     depends_on("yacc", type="build", when="+admin")
     depends_on("flex", type="build", when="+admin")

--- a/var/spack/repos/jcsda-emc/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/jcsda-emc/packages/ecmwf-atlas/package.py
@@ -47,6 +47,7 @@ class EcmwfAtlas(CMakePackage):
     )
 
     variant('openmp', default=True, description='Use OpenMP?')
+    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant("shared", default=True)
 
     variant("trans", default=False)

--- a/var/spack/repos/jcsda-emc/packages/fckit/package.py
+++ b/var/spack/repos/jcsda-emc/packages/fckit/package.py
@@ -38,6 +38,7 @@ class Fckit(CMakePackage):
     depends_on('eckit+mpi', when='+eckit')
 
     variant('openmp', default=True, description='Use OpenMP?')
+    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant('shared', default=True)
 
     def cmake_args(self):


### PR DESCRIPTION
This PR adds llvm-openmp as a dependency for the ECMWF eckit, fckit and atlas packages, but only when building on macos.