### PR TITLE
Bug fix in FMS to build on macOS with OpenMP enabled

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -84,6 +84,7 @@ class Fms(CMakePackage):
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")
     depends_on("mpi")
+    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     depends_on("libyaml", when="+yaml")
 
     # DH* 20220602


### PR DESCRIPTION
## Description

All in the title. Same bug fix as was merged recently for eckit, fckit, ecmwf-atlas (#196).

Tested as part of https://github.com/NOAA-EMC/spack-stack/pull/405