### PR TITLE
Update setup_meta_modules to work with spack-built Python, add gsibec@1.0.6

### DIFF
--- a/var/spack/repos/jcsda-emc/packages/gsibec/package.py
+++ b/var/spack/repos/jcsda-emc/packages/gsibec/package.py
@@ -18,7 +18,7 @@ class Gsibec(CMakePackage):
     maintainers = ["mathomp4", "danholdaway"]
 
     version("develop", branch="develop")
-    version("1.0.6", sha256="xxxcecc59e38da7eefb5a8f27975b33752fa61a4abd3bdbbfb55578ea59d95b3")
+    version("1.0.6", sha256="10e2561685156bcfba35c7799732c77f9c05bd180888506a339540777db833dd")
     version("1.0.5", sha256="ac0cecc59e38da7eefb5a8f27975b33752fa61a4abd3bdbbfb55578ea59d95b3")
     version("1.0.4", sha256="6460e221f2a45640adab016336c070fbe3e7c4b6fc55257945bf5cdb38d5d3e2")
     version("1.0.3", sha256="f104daf55705c5093a3d984073f082017bc9166f51ded36c7f7bb8adf233c916")

--- a/var/spack/repos/jcsda-emc/packages/gsibec/package.py
+++ b/var/spack/repos/jcsda-emc/packages/gsibec/package.py
@@ -18,6 +18,7 @@ class Gsibec(CMakePackage):
     maintainers = ["mathomp4", "danholdaway"]
 
     version("develop", branch="develop")
+    version("1.0.6", sha256="xxxcecc59e38da7eefb5a8f27975b33752fa61a4abd3bdbbfb55578ea59d95b3")
     version("1.0.5", sha256="ac0cecc59e38da7eefb5a8f27975b33752fa61a4abd3bdbbfb55578ea59d95b3")
     version("1.0.4", sha256="6460e221f2a45640adab016336c070fbe3e7c4b6fc55257945bf5cdb38d5d3e2")
     version("1.0.3", sha256="f104daf55705c5093a3d984073f082017bc9166f51ded36c7f7bb8adf233c916")


### PR DESCRIPTION
## Description

This PR updates the `spack stack setup_meta_modules` extension to work with spack-built Python, as an alternative to external Python packages that we have been using so far.

There are indentation (whitespace) changes that make it hard to see the code differences, I recommend to hide those for reviewing the PR.

Also included in this PR: add `gsibec@1.0.6`.

## Testing

See https://github.com/NOAA-EMC/spack-stack/pull/413.