### PR TITLE
Update jedi-ufs-env and add sp to jedi-base-env

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -46,6 +46,7 @@ class JediBaseEnv(BundlePackage):
     depends_on("nlohmann-json", type="run")
     depends_on("nlohmann-json-schema-validator", type="run")
     depends_on("odc", type="run")
+    depends_on("sp", type="run")
     depends_on("udunits", type="run")
 
     with when("+python"):

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
@@ -17,13 +17,15 @@ class JediUfsEnv(BundlePackage):
     version("1.0.0")
 
     depends_on("jedi-base-env", type="run")
-    depends_on("fms@release-jcsda", type="run")
+    depends_on("fms@2022.02+fpic", type="run")
 
     depends_on("bacio", type="run")
     depends_on("g2", type="run")
     depends_on("g2tmpl", type="run")
     depends_on("ip", type="run")
-    depends_on("sp", type="run")
+    depends_on("nemsio", type="run")
+    depends_on("sigio", type="run")
+    depends_on("w3emc", type="run")
     depends_on("w3nco", type="run")
 
     depends_on("esmf~debug", type="run")


### PR DESCRIPTION
## Description

- Update `jedi-ufs-env` to support building `ufs-bundle` (currently branch atm-soca-s2s_dom, https://github.com/JCSDA/ufs-bundle/tree/feature/atm-soca-s2s_dom).
- Add `sp` as dependency to `jedi-base-env`

## Testing

See https://github.com/NOAA-EMC/spack-stack/pull/416