### PR TITLE
release/1.2.0: add crtm@2.4-jedi.1, add debug build option for crtm, bug fix for matplotlib with older versions of Intel

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -30,6 +30,12 @@ class Crtm(CMakePackage):
         default=False,
         description='Download CRTM coeffecient or "fix" files (several GBs).',
     )
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
+    )
 
     depends_on("cmake@3.15:")
     depends_on("git-lfs")
@@ -56,3 +62,5 @@ class Crtm(CMakePackage):
     version("v2.3-jedi.4", commit="bfede42")
     # Branch release/crtm_jedi_v2.4.0
     version("v2.4_jedi", commit="0ee3593")
+    version("v2.4-jedi.1", commit="8222341") # jcsda public
+    #version("v2.4-jedi.1", commit="af0d875") # jcsda-internal

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -48,6 +48,7 @@ class Crtm(CMakePackage):
 
     depends_on("ecbuild", type=("build"), when="@v2.3-jedi.4")
     depends_on("ecbuild", type=("build"), when="@v2.4_jedi")
+    depends_on("ecbuild", type=("build"), when="@v2.4-jedi.1")
 
     # ecbuild release v2.4.0 is broken
     # add ecbuild dependency for next release with fix

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -42,7 +42,7 @@ class Crtm(CMakePackage):
     depends_on("netcdf-fortran", when="@2.4.0:")
     depends_on("netcdf-fortran", when="@v2.3-jedi.4")
     depends_on("netcdf-fortran", when="@v2.4-jedi")
-    depends_on("netcdf-fortran", when="@v2.4-jedi")
+    depends_on("netcdf-fortran", when="@v2.4-jedi.1")
 
     depends_on("crtm-fix@2.3.0_emc", when="@2.3.0 +fix")
     depends_on("crtm-fix@2.4.0_emc", when="@2.4.0 +fix")

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -41,14 +41,15 @@ class Crtm(CMakePackage):
     depends_on("git-lfs")
     depends_on("netcdf-fortran", when="@2.4.0:")
     depends_on("netcdf-fortran", when="@v2.3-jedi.4")
-    depends_on("netcdf-fortran", when="@v2.4_jedi")
+    depends_on("netcdf-fortran", when="@v2.4-jedi")
+    #depends_on("netcdf-fortran", when="@v2.4-jedi")
 
     depends_on("crtm-fix@2.3.0_emc", when="@2.3.0 +fix")
     depends_on("crtm-fix@2.4.0_emc", when="@2.4.0 +fix")
 
     depends_on("ecbuild", type=("build"), when="@v2.3-jedi.4")
-    depends_on("ecbuild", type=("build"), when="@v2.4_jedi")
-    depends_on("ecbuild", type=("build"), when="@v2.4-jedi.1")
+    depends_on("ecbuild", type=("build"), when="@v2.4-jedi")
+    #depends_on("ecbuild", type=("build"), when="@v2.4-jedi.1")
 
     # ecbuild release v2.4.0 is broken
     # add ecbuild dependency for next release with fix
@@ -62,6 +63,6 @@ class Crtm(CMakePackage):
     # Branch release/crtm_jedi
     version("v2.3-jedi.4", commit="bfede42")
     # Branch release/crtm_jedi_v2.4.0
-    version("v2.4_jedi", commit="0ee3593")
+    version("v2.4-jedi", commit="0ee3593")
     version("v2.4-jedi.1", commit="8222341") # jcsda public
     #version("v2.4-jedi.1", commit="af0d875") # jcsda-internal

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -42,14 +42,14 @@ class Crtm(CMakePackage):
     depends_on("netcdf-fortran", when="@2.4.0:")
     depends_on("netcdf-fortran", when="@v2.3-jedi.4")
     depends_on("netcdf-fortran", when="@v2.4-jedi")
-    #depends_on("netcdf-fortran", when="@v2.4-jedi")
+    depends_on("netcdf-fortran", when="@v2.4-jedi")
 
     depends_on("crtm-fix@2.3.0_emc", when="@2.3.0 +fix")
     depends_on("crtm-fix@2.4.0_emc", when="@2.4.0 +fix")
 
     depends_on("ecbuild", type=("build"), when="@v2.3-jedi.4")
     depends_on("ecbuild", type=("build"), when="@v2.4-jedi")
-    #depends_on("ecbuild", type=("build"), when="@v2.4-jedi.1")
+    depends_on("ecbuild", type=("build"), when="@v2.4-jedi.1")
 
     # ecbuild release v2.4.0 is broken
     # add ecbuild dependency for next release with fix
@@ -64,5 +64,4 @@ class Crtm(CMakePackage):
     version("v2.3-jedi.4", commit="bfede42")
     # Branch release/crtm_jedi_v2.4.0
     version("v2.4-jedi", commit="0ee3593")
-    version("v2.4-jedi.1", commit="8222341") # jcsda public
-    #version("v2.4-jedi.1", commit="af0d875") # jcsda-internal
+    version("v2.4-jedi.1", commit="8222341")

--- a/var/spack/repos/builtin/packages/py-contourpy/package.py
+++ b/var/spack/repos/builtin/packages/py-contourpy/package.py
@@ -19,3 +19,11 @@ class PyContourpy(PythonPackage):
     depends_on("py-pybind11@2.6:", type=("build", "link"))
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-numpy@1.16:", type=("build", "run"))
+
+    # py-contourpy uses c++-17 flags that cause a problem
+    # with older Intel compilers (@19) in combination with
+    # C++-17 capable backends (gnu@9:). Instead of trying
+    # to figure out what gnu version the Intel compiler
+    # uses as backend, simply refuse to build. See also:
+    # https://bitbucket.org/berkeleylab/upcxx/issues/302/build-failure-for-intel-c-with-std-c-17
+    conflicts("%intel@:19")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -23,7 +23,7 @@ class JediBaseEnv(BundlePackage):
     variant("python", default=True, description="Build Python libraries")
 
     depends_on("base-env", type="run")
-    depends_on("bison@3:", type="run")
+    depends_on("bison", type="run")
     depends_on("blas", type="run")
     depends_on("boost", type="run")
     depends_on("bufr", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -27,7 +27,7 @@ class JediBaseEnv(BundlePackage):
     depends_on("blas", type="run")
     depends_on("boost", type="run")
     depends_on("bufr", type="run")
-    depends_on("crtm@v2.4_jedi", type="run")
+    depends_on("crtm@v2.4-jedi.1", type="run")
     depends_on("ecbuild", type="run")
     depends_on("eccodes", type="run")
     depends_on("eckit", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -23,7 +23,7 @@ class JediBaseEnv(BundlePackage):
     variant("python", default=True, description="Build Python libraries")
 
     depends_on("base-env", type="run")
-    depends_on("bison", type="run")
+    depends_on("bison@3:", type="run")
     depends_on("blas", type="run")
     depends_on("boost", type="run")
     depends_on("bufr", type="run")


### PR DESCRIPTION
## Description

For release/1.2.0 branch:
- add `crtm@2.4-jedi.1` tag
- add debug build option for `crtm`
- in `var/spack/repos/builtin/packages/py-contourpy/package.py`: workaround for matplotlib with older versions of Intel: Newer matplotlib versions depend on `contourpy`, which uses `c++-17` flags that cause a problem with older Intel compilers (`intel@:19`) in combination with C++-17 capable backends (`gnu@9:`). Instead of trying to figure out what gnu version the Intel compiler uses as backend, simply refuse to build. This forces spack to use older versions of matplotlib (essentially the version that we have been using so far everywhere, 3.5.2) in such cases. See also: https://bitbucket.org/berkeleylab/upcxx/issues/302/build-failure-for-intel-c-with-std-c-17

## Testing

See https://github.com/NOAA-EMC/spack-stack/pull/418