### PR TITLE
Add optional --compiler argument to spack stack create env

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
@@ -84,6 +84,11 @@ def setup_common_parser_args(subparser):
         help='Base packages.yaml, use to override common packages.yaml.'
     )
 
+    subparser.add_argument(
+        '--compiler', type=str, required=False, default=None,
+        help='Set compiler. No default.'
+    )
+
 
 def setup_ctr_parser(subparser):
     """ create container-specific parsing options"""
@@ -145,6 +150,7 @@ def dict_from_args(args):
     dict['install_prefix'] = args.prefix
     dict['base_packages'] = args.packages
     dict['dir'] = args.dir
+    dict['compiler'] = args.compiler
 
     return dict
 

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -187,7 +187,9 @@ class StackEnv(object):
         # Commonly used config settings
         if self.compiler:
             compiler = 'packages:all::compiler:[{}]'.format(self.compiler)
+            compiler_one_of = 'packages:all:require:one_of:[\'{}\']'.format(self.compiler)
             spack.config.add(compiler, scope=env_scope)
+            spack.config.add(compiler_one_of, scope=env_scope)
         if self.mpi:
             mpi = 'packages:all::providers:mpi:[{}]'.format(self.mpi)
             spack.config.add(mpi, scope=env_scope)

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -187,7 +187,7 @@ class StackEnv(object):
         # Commonly used config settings
         if self.compiler:
             compiler = 'packages:all::compiler:[{}]'.format(self.compiler)
-            compiler_one_of = 'packages:all:require:one_of:[\'{}\']'.format(self.compiler)
+            compiler_one_of = 'packages:all:require:one_of:[\'%{}\']'.format(self.compiler)
             spack.config.add(compiler, scope=env_scope)
             spack.config.add(compiler_one_of, scope=env_scope)
         if self.mpi:


### PR DESCRIPTION
This PR facilitates the use of sites with multiple compilers by adding an optional argument `--compiler <compiler name>` to `spack stack create env`. For example, adding `--compiler intel@1.2.3` would yield the following portion of spack.yaml:
```
  packages:
    all:
      compiler: [intel@1.2.3]
      require:
      - one_of: ['%intel@1.2.3']
```

Default behavior is the current behavior (no "packages" section added to spack.yaml).