### PR TITLE
ESMF variants for overriding ESMF_OS and ESMF_COMM

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -91,6 +91,11 @@ class Esmf(MakefilePackage):
     )
     variant("debug", default=False, description="Make a debuggable version of the library")
     variant("shared", default=True, description="Build shared library")
+    # 'esmf_comm' and 'esmf_os' variants allow override values for their corresponding
+    # build environment variables. Documentation, including valid values, can be found at
+    # https://earthsystemmodeling.org/docs/release/latest/ESMF_usrdoc/node10.html#SECTION000105000000000000000
+    variant("esmf_comm", default="auto", description="Override for ESMF_COMM variable")
+    variant("esmf_os", default="auto", description="Override for ESMF_OS variable")
 
     # Required dependencies
     depends_on("zlib")
@@ -252,6 +257,11 @@ class Esmf(MakefilePackage):
         if any(cray_id in self.spec for cray_id in cray_identifiers):
             os.environ["ESMF_OS"] = "Unicos"
 
+        # Allow override of ESMF_OS:
+        os_variant = spec.variants["esmf_os"].value
+        if os_variant != "auto":
+            os.environ["ESMF_OS"] = os_variant
+
         #######
         # MPI #
         #######
@@ -284,6 +294,11 @@ class Esmf(MakefilePackage):
         else:
             # Force use of the single-processor MPI-bypass library.
             os.environ["ESMF_COMM"] = "mpiuni"
+
+        # Allow override of ESMF_COMM:
+        comm_variant = spec.variants["esmf_comm"].value
+        if comm_variant != "auto":
+            os.environ["ESMF_COMM"] = comm_variant
 
         ##########
         # LAPACK #


### PR DESCRIPTION
This PR adds changes recently made to the ESMF package in main spack which add variants that allow users to override the logic that sets ESMF_OS and ESMF_COMM with manually set values. This is my solution to the need to set ESMF_OS=Linux and ESMF_COMM=mpich3 on Acorn (this will be followed by an acorn config update to spack-stack). Tested on Acorn.