### PR TITLE
Add ectrans@1.2.0 and fiat@1.1.0, update fms version

### DIFF
--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -21,9 +21,8 @@ class Ectrans(CMakePackage):
 
     version('develop', branch='develop', no_cache=True)
     version('main', branch='main', no_cache=True)
+    version("1.2.0", sha256="2ee6dccc8bbfcc23faada1d957d141f24e41bb077c1821a7bc2b812148dd336c")
     version("1.1.0", sha256="3c9848bb65033fbe6d791084ee347b3adf71d5dfe6d3c11385000017b6469a3e")
-    # Defined for spack use only
-    version('1.0.0', commit='ee1d307f1e47e1dd0b5ea91663a41df8a94cafb3')
 
     variant('build_type', default='RelWithDebInfo',
             description='CMake build type',

--- a/var/spack/repos/builtin/packages/fiat/package.py
+++ b/var/spack/repos/builtin/packages/fiat/package.py
@@ -18,6 +18,7 @@ class Fiat(CMakePackage):
 
     version("main", branch="main", no_cache=True)
     # Defined for spack use only
+    version("1.1.0", commit="9398e04fd5d00887b9598151abfa31c388e605d5")
     version("1.0.0", commit="1295120464c3905e5edcbb887e4921686653eab8")
 
     variant(

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
@@ -17,7 +17,7 @@ class JediUfsEnv(BundlePackage):
     version("1.0.0")
 
     depends_on("jedi-base-env", type="run")
-    depends_on("fms@2022.02+fpic", type="run")
+    depends_on("fms@2022.04+fpic", type="run")
 
     depends_on("bacio", type="run")
     depends_on("g2", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
@@ -26,7 +26,7 @@ class UfsWeatherModelEnv(BundlePackage):
     depends_on("base-env", type="run")
     depends_on("ufs-pyenv", type="run", when="+python")
 
-    depends_on("fms@2022.01", type="run")
+    depends_on("fms@2022.04", type="run")
     depends_on("bacio", type="run")
     depends_on("crtm@2.4.0", type="run")
     depends_on("g2", type="run")


### PR DESCRIPTION
## Description

- Add tags `ectrans@1.2.0` and `fiat@1.1.0`
- Update JCSDA-EMC environment packages to use `fms@2022.04`

## Testing

See https://github.com/NOAA-EMC/spack-stack/pull/446