### PR TITLE
Update CRTM from spack develop, and changes required for unified spack-stack environment

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -5,31 +5,34 @@
 
 import os
 
-from spack import *
+from spack.package import *
 
 
 class CrtmFix(Package):
-    """CRTM coeffecient files"""
+    """CRTM coefficient files"""
 
     homepage = "https://github.com/NOAA-EMC/crtm"
-    url = "ftp://ftp.ucar.edu/pub/cpaess/bjohns/fix_REL-2.3.0_emc.tgz"
+    url = "ftp://ftp.ssec.wisc.edu/pub/s4/CRTM/fix_REL-2.3.0_emc.tgz"
 
-    maintainers = ["kgerheiser"]
+    maintainers = [
+        "BenjaminTJohnson",
+        "edwardhartnett",
+        "AlexanderRichert-NOAA",
+        "Hang-Lei-NOAA",
+        "climbfuji",
+    ]
 
-    version("2.4.0", sha256="7924285b8aa25b0b864643f03e7f281ca1816958e24c76aa9531b3ca902bf6e9")
     version("2.4.0_emc", sha256="88d659ae5bc4434f7fafa232ff65b4c48442d2d1a25f8fc96078094fa572ac1a")
-    version("2.3.0_emc", sha256="fde73bb41c3c00666ab0eb8c40895e02d36fa8d7b0896c276375214a1ddaab8f")
+    version("2.3.0_emc", sha256="1452af2d1d11d57ef3c57b6b861646541e7042a9b0f3c230f9a82854d7e90924")
 
     variant("big_endian", default=True, description="Install big_endian fix files")
-    variant("little_endian", default=False,
-            description="Install little endian fix files")
+    variant("little_endian", default=False, description="Install little endian fix files")
     variant("netcdf", default=True, description="Install netcdf fix files")
 
-    conflicts("+big_endian", when="+little_endian",
-              msg="big_endian and little_endian conflict")
+    conflicts("+big_endian", when="+little_endian", msg="big_endian and little_endian conflict")
 
     def url_for_version(self, version):
-        url = "ftp://ftp.ucar.edu/pub/cpaess/bjohns/fix_REL-{}.tgz"
+        url = "ftp://ftp.ssec.wisc.edu/pub/s4/CRTM/fix_REL-{}.tgz"
         return url.format(version)
 
     def install(self, spec, prefix):
@@ -54,19 +57,22 @@ class CrtmFix(Package):
         # Remove the incorrect file, and install it as noACC,, then install
         # correct file under new name.
         if "+big_endian" in spec and spec.version == Version("2.4.0_emc"):
-            remove_path = join_path(os.getcwd(), "fix", "SpcCoeff",
-                                    "Big_Endian", "amsua_metop-c.SpcCoeff.bin")
+            remove_path = join_path(
+                os.getcwd(), "fix", "SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin"
+            )
             fix_files.remove(remove_path)
 
             # This file is incorrect, install it as a different name.
-            install(join_path("fix", "SpcCoeff", "Big_Endian",
-                              "amsua_metop-c.SpcCoeff.bin"),
-                    join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.noACC.bin"))
+            install(
+                join_path("fix", "SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin"),
+                join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.noACC.bin"),
+            )
 
             # This "Little_Endian" file is actually the correct one.
-            install(join_path("fix", "SpcCoeff", "Little_Endian",
-                              "amsua_metop-c_v2.SpcCoeff.bin"),
-                    join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.bin"))
+            install(
+                join_path("fix", "SpcCoeff", "Little_Endian", "amsua_metop-c_v2.SpcCoeff.bin"),
+                join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.bin"),
+            )
 
         for f in fix_files:
             install(f, self.prefix.fix)

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -41,7 +41,6 @@ class Crtm(CMakePackage):
     depends_on("git-lfs")
     depends_on("netcdf-fortran", when="@2.4.0:")
     depends_on("netcdf-fortran", when="@v2.3-jedi.4")
-    depends_on("netcdf-fortran", when="@v2.4-jedi")
     depends_on("netcdf-fortran", when="@v2.4-jedi.1")
     depends_on("netcdf-fortran", when="@v2.4-jedi.2")
 
@@ -49,7 +48,6 @@ class Crtm(CMakePackage):
     depends_on("crtm-fix@2.4.0_emc", when="@2.4.0 +fix")
 
     depends_on("ecbuild", type=("build"), when="@v2.3-jedi.4")
-    depends_on("ecbuild", type=("build"), when="@v2.4-jedi")
     depends_on("ecbuild", type=("build"), when="@v2.4-jedi.1")
     depends_on("ecbuild", type=("build"), when="@v2.4-jedi.2")
 
@@ -65,6 +63,5 @@ class Crtm(CMakePackage):
     # Branch release/crtm_jedi
     version("v2.3-jedi.4", commit="bfede42")
     # Branch release/crtm_jedi_v2.4.0
-    version("v2.4-jedi", commit="0ee3593")
     version("v2.4-jedi.1", commit="8222341")
     version("v2.4-jedi.2", commit="62831cb")

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -22,6 +22,7 @@ class Ecflow(CMakePackage):
     maintainers = ["climbfuji"]
 
     # https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.8.3-Source.tar.gz?api=v2
+    version("5.8.4", sha256="bc628556f8458c269a309e4c3b8d5a807fae7dfd415e27416fe9a3f544f88951")
     version("5.8.3", sha256="1d890008414017da578dbd5a95cb1b4d599f01d5a3bb3e0297fe94a87fbd81a6")
     version("4.13.0", sha256="c743896e0ec1d705edd2abf2ee5a47f4b6f7b1818d8c159b521bdff50a403e39")
     version("4.12.0", sha256="566b797e8d78e3eb93946b923ef540ac61f50d4a17c9203d263c4fd5c39ab1d1")

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -42,6 +42,8 @@ class Hdf5(CMakePackage):
     version("develop-1.10", branch="hdf5_1_10")
     version("develop-1.8", branch="hdf5_1_8")
 
+    version("1.14.0", sha256="a571cc83efda62e1a51a0a912dd916d01895801c5025af91669484a1575a6ef4")
+
     # Odd versions are considered experimental releases
     version("1.13.3", sha256="83c7c06671f975cee6944b0b217f95005faa55f79ea5532cf4ac268989866af4")
     version("1.13.2", sha256="01643fa5b37dba7be7c4db6bbf3c5d07adf5c1fa17dbfaaa632a279b1b2f06da")

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -42,13 +42,16 @@ class Hdf5(CMakePackage):
     version("develop-1.10", branch="hdf5_1_10")
     version("develop-1.8", branch="hdf5_1_8")
 
-    version("1.14.0", sha256="a571cc83efda62e1a51a0a912dd916d01895801c5025af91669484a1575a6ef4")
-
     # Odd versions are considered experimental releases
     version("1.13.3", sha256="83c7c06671f975cee6944b0b217f95005faa55f79ea5532cf4ac268989866af4")
     version("1.13.2", sha256="01643fa5b37dba7be7c4db6bbf3c5d07adf5c1fa17dbfaaa632a279b1b2f06da")
 
     # Even versions are maintenance versions
+    version(
+        "1.14.0",
+        sha256="a571cc83efda62e1a51a0a912dd916d01895801c5025af91669484a1575a6ef4",
+        preferred=True,
+    )
     version(
         "1.12.2",
         sha256="2a89af03d56ce7502dcae18232c241281ad1773561ec00c0f0e8ee2463910f14",

--- a/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
@@ -36,6 +36,7 @@ class BaseEnv(BundlePackage):
     depends_on("nccmp", type="run")
 
     # Python
-    depends_on("python@3.7:")
+    depends_on("python@3.7:", type="run")
+    depends_on("py-pip", type="run")
 
     # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/global-workflow-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/global-workflow-env/package.py
@@ -19,6 +19,7 @@ class GlobalWorkflowEnv(BundlePackage):
 
     depends_on("ufs-pyenv", when="+python")
     depends_on("prod-util")
+    depends_on("grib-util")
     depends_on("nco")
     depends_on("cdo")
     depends_on("netcdf-c")

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-srw-app-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-srw-app-env/package.py
@@ -25,7 +25,7 @@ class UfsSrwAppEnv(BundlePackage):
     depends_on("netcdf-fortran")
     depends_on("parallelio")
     depends_on("esmf")
-    depends_on("fms@2022.01")
+    depends_on("fms@2022.04")
     depends_on("bacio")
     depends_on("crtm@2.4.0")
     depends_on("g2")
@@ -40,7 +40,9 @@ class UfsSrwAppEnv(BundlePackage):
     depends_on("nemsiogfs")
     depends_on("sfcio")
     depends_on("sigio")
+    depends_on("wrf-io")
     depends_on("w3emc")
     depends_on("wgrib2")
+    depends_on("gsi-ncdiag")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
## Description

- Update CRTM and CRTM-fix from spack develop (we made a number of important changes there recently)
- Update several other packages so that we can build a unified spack-stack environment (see https://github.com/NOAA-EMC/spack-stack/pull/454)

## Testing and more information
See https://github.com/NOAA-EMC/spack-stack/pull/454