### PR TITLE
Add 'beta' variant to ESMF to give correct MAPL modulefile names

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -96,7 +96,7 @@ class Esmf(MakefilePackage):
     # https://earthsystemmodeling.org/docs/release/latest/ESMF_usrdoc/node10.html#SECTION000105000000000000000
     variant("esmf_comm", default="auto", description="Override for ESMF_COMM variable")
     variant("esmf_os", default="auto", description="Override for ESMF_OS variable")
-    variant("beta", default=False, description="Dummy variant for beta versions")
+    variant("beta", default="none", description="Named variant for beta versions")
 
     # Required dependencies
     depends_on("zlib")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -96,6 +96,8 @@ class Esmf(MakefilePackage):
     # https://earthsystemmodeling.org/docs/release/latest/ESMF_usrdoc/node10.html#SECTION000105000000000000000
     variant("esmf_comm", default="auto", description="Override for ESMF_COMM variable")
     variant("esmf_os", default="auto", description="Override for ESMF_OS variable")
+    # Set the 'snapshot' variant any time a beta snapshot is used in order to obtain
+    # correct module name behavior for MAPL.
     variant("snapshot", default="none", description="Named variant for snapshots versions (e.g., 'b09')")
 
     # Required dependencies

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -96,7 +96,7 @@ class Esmf(MakefilePackage):
     # https://earthsystemmodeling.org/docs/release/latest/ESMF_usrdoc/node10.html#SECTION000105000000000000000
     variant("esmf_comm", default="auto", description="Override for ESMF_COMM variable")
     variant("esmf_os", default="auto", description="Override for ESMF_OS variable")
-    variant("beta", default="none", description="Named variant for beta versions")
+    variant("snapshot", default="none", description="Named variant for snapshots versions (e.g., 'b09')")
 
     # Required dependencies
     depends_on("zlib")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -96,6 +96,7 @@ class Esmf(MakefilePackage):
     # https://earthsystemmodeling.org/docs/release/latest/ESMF_usrdoc/node10.html#SECTION000105000000000000000
     variant("esmf_comm", default="auto", description="Override for ESMF_COMM variable")
     variant("esmf_os", default="auto", description="Override for ESMF_OS variable")
+    variant("beta", default=False, description="Dummy variant for beta versions")
 
     # Required dependencies
     depends_on("zlib")


### PR DESCRIPTION
This PR adds a dummy variant for ESMF that allows it to be designated as a beta version. This can then be used to distinguish beta vs. non-beta versions in modules.yaml. Note that this approach will not accommodate the possibility of multiple beta versions for a given x.y.z version number. Currently, it is expected that the variant value will be set by the user (generally speaking, in spack-stack config). I am open to the possibility that this can be done automatically, but I wanted to find an approach that didn't involve having to enumerate every ESMF beta version. If there were some way to do "if 'b' in version_number" when creating a variant, that would certainly do the trick.

The default value of the variant is false, so it needs to be specified in any spec where a beta version is getting used, and "~beta" must be specified in modules.yaml in order to make the spec matching for, e.g., 8.3.0 and 8.3.0b09 mutually exclusive.