### PR TITLE
Add R2D2 mysql dependencies, remove ncl from global-workflow-env, Intel bug fix from spack repo

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -114,11 +114,11 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
             self.spec.mpifc = join_path(self.component_prefix.bin, "mpiifort")
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set("MPICH_CC", spack_cc)
-        env.set("MPICH_CXX", spack_cxx)
-        env.set("MPICH_F77", spack_f77)
-        env.set("MPICH_F90", spack_fc)
-        env.set("MPICH_FC", spack_fc)
+        env.set("I_MPI_CC", spack_cc)
+        env.set("I_MPI_CXX", spack_cxx)
+        env.set("I_MPI_F77", spack_f77)
+        env.set("I_MPI_F90", spack_fc)
+        env.set("I_MPI_FC", spack_fc)
 
         # Set compiler wrappers for dependent build stage
         if "+generic-names" in self.spec:

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -136,6 +136,14 @@ class Mysql(CMakePackage):
 
     patch("fix-no-server-5.5.patch", level=1, when="@5.5.0:5.5")
 
+    # For spack external find
+    executables = ["^mysql_config$"]
+
+    @classmethod
+    def determine_version(cls, exe):
+        return Executable(exe)("--version", output=str, error=str)
+        #return version_string.lstrip("qplugininfo").strip()
+
     @property
     def command(self):
         return Executable(self.prefix.bin.mysql_config)

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -142,7 +142,6 @@ class Mysql(CMakePackage):
     @classmethod
     def determine_version(cls, exe):
         return Executable(exe)("--version", output=str, error=str)
-        #return version_string.lstrip("qplugininfo").strip()
 
     @property
     def command(self):

--- a/var/spack/repos/jcsda-emc-bundles/packages/global-workflow-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/global-workflow-env/package.py
@@ -16,7 +16,6 @@ class GlobalWorkflowEnv(BundlePackage):
 
     version("1.0.0")
     variant("python", default=True, description="Build Python dependencies")
-    variant("ncl", default=True, description="Build NCL (NCAR Command Language)")
 
     depends_on("ufs-pyenv", when="+python")
     depends_on("prod-util")
@@ -43,9 +42,6 @@ class GlobalWorkflowEnv(BundlePackage):
     depends_on("met")
     depends_on("metplus")
     depends_on("gsi-ncdiag")
-    depends_on("ncl", when="+ncl")
     depends_on("crtm@2.4.0")
-
-    conflicts("platform=darwin", when="+ncl", msg="NCL doesn't build on macOS")
 
     # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ewok-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ewok-env/package.py
@@ -33,6 +33,7 @@ class JediEwokEnv(BundlePackage):
     depends_on("jedi-base-env +python", type="run")
     depends_on("py-boto3", type="run")
     depends_on("py-cartopy", type="run")
+    depends_on("py-gitpython", type="run")
     depends_on("py-jinja2", type="run")
     depends_on("py-ruamel-yaml", type="run")
     depends_on("py-ruamel-yaml-clib", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ewok-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ewok-env/package.py
@@ -36,7 +36,13 @@ class JediEwokEnv(BundlePackage):
     depends_on("py-jinja2", type="run")
     depends_on("py-ruamel-yaml", type="run")
     depends_on("py-ruamel-yaml-clib", type="run")
+
+    # Workflow engines
     depends_on("ecflow", type="run")
+
+    # R2D2 mysql backend
+    depends_on("mysql", type="run")
+    depends_on("py-mysql-connector-python", type="run")
 
     depends_on("solo", when="+solo", type="run")
     depends_on("r2d2", when="+r2d2", type="run")


### PR DESCRIPTION
## Description
Add the required dependencies for the upcoming R2D2 mysql backend implementation to `jedi-ewok-env` and make package `mysql` detectable as an external (building it in spack isn't straightforward at all, so let's try to use external `mysql` server installations wherever possible.

Further, `ncl` is removed from `global-workflow-env` as requested in https://github.com/NOAA-EMC/spack-stack/issues/471.

This PR also cherry-picks a bug fix for Intel from the authoritative spack repo, that has to do with the correct (spack) compiler wrappers being used by the MPI wrappers. See https://github.com/spack/spack/issues/35646 and https://github.com/spack/spack/pull/34956 for more information.

## Testing

See https://github.com/NOAA-EMC/spack-stack/pull/463