### PR TITLE
Investigate RHEL CI failures

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -170,6 +170,15 @@ jobs:
       run: |
           source share/spack/setup-env.sh
           spack -d bootstrap now --dev
+          echo AJWR
+          mkdir -p /__w/spack/spack/opt/spack/gpg
+          echo whoami: $(whoami)
+          ls -ld /__w/spack
+          ls -ld /__w/spack/spack
+          ls -ld /__w/spack/spack/opt
+          ls -ld /__w/spack/spack/opt/spack
+          ls -ld /__w/spack/spack/opt/spack/gpg
+          echo AJWRend
           spack unit-test -k 'not cvs and not svn and not hg' -x --verbose
   # Test for the clingo based solver (using clingo-cffi)
   clingo-cffi:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -162,15 +162,10 @@ jobs:
           useradd spack-test
           chown -R spack-test .
     - name: remove-extension
+      shell: runuser -u spack-test -- bash {0}
       run: |
-          echo AJWR1
-          ls -l /__w/spack/spack
           source share/spack/setup-env.sh
-          echo AJWR2
-          ls -l /__w/spack/spack
           spack config --scope=defaults rm "config:extensions"
-          echo AJWR3
-          ls -l /__w/spack/spack
     - name: Run unit tests
       shell: runuser -u spack-test -- bash {0}
       run: |

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -161,7 +161,9 @@ jobs:
           . .github/workflows/setup_git.sh
           useradd spack-test
           chown -R spack-test .
+          find -maxdepth 2 | xargs ls -ld
     - name: remove-extension
+      shell: runuser -u spack-test -- bash {0}
       run: |
           source share/spack/setup-env.sh
           spack config --scope=defaults rm "config:extensions"

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -162,7 +162,6 @@ jobs:
           useradd spack-test
           chown -R spack-test .
     - name: remove-extension
-      shell: runuser -u spack-test -- bash {0}
       run: |
           echo AJWR1
           ls -l /__w/spack/spack

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -161,26 +161,22 @@ jobs:
           . .github/workflows/setup_git.sh
           useradd spack-test
           chown -R spack-test .
-          find -maxdepth 2 | xargs ls -ld
     - name: remove-extension
       shell: runuser -u spack-test -- bash {0}
       run: |
+          echo AJWR1
+          ls -l /__w/spack/spack
           source share/spack/setup-env.sh
+          echo AJWR2
+          ls -l /__w/spack/spack
           spack config --scope=defaults rm "config:extensions"
+          echo AJWR3
+          ls -l /__w/spack/spack
     - name: Run unit tests
       shell: runuser -u spack-test -- bash {0}
       run: |
           source share/spack/setup-env.sh
           spack -d bootstrap now --dev
-          echo AJWR
-          mkdir -p /__w/spack/spack/opt/spack/gpg
-          echo whoami: $(whoami)
-          ls -ld /__w/spack
-          ls -ld /__w/spack/spack
-          ls -ld /__w/spack/spack/opt
-          ls -ld /__w/spack/spack/opt/spack
-          ls -ld /__w/spack/spack/opt/spack/gpg
-          echo AJWRend
           spack unit-test -k 'not cvs and not svn and not hg' -x --verbose
   # Test for the clingo based solver (using clingo-cffi)
   clingo-cffi:


### PR DESCRIPTION
Failure was due to setup-env.sh being run as root, which creates the opt/ directory, which then can't be written to by the user spack-test. I don't think there's any reason to run the remove-extension step as root, so this PR modifies it to run with spack-test.

Fixes #223, addresses #202 - @climbfuji Are there any other issues regarding #202 or did I just make a duplicate issue? (: