### PR TITLE
Add version statement for netcdf-c version 4.9.1

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -21,6 +21,7 @@ class NetcdfC(AutotoolsPackage):
     maintainers = ["skosukhin", "WardF"]
 
     version("main", branch="main")
+    version("4.9.1", sha256="4ee8d5f6b50a1eb4ad4c10f24531e36261fd1882410fb08435eb2ddfd49a0908")
     version("4.9.0", sha256="9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6")
     version("4.8.1", sha256="bc018cc30d5da402622bf76462480664c6668b55eb16ba205a0dfb8647161dd0")
     version("4.8.0", sha256="aff58f02b1c3e91dc68f989746f652fe51ff39e6270764e484920cb8db5ad092")


### PR DESCRIPTION
This PR simply adds the version statement to the netcdf-c package.py script so that we can start experimenting with netcdf-c 4.9.1.

I tried building with this change and I verified that the tar file download successfully, the unpacking of the tar file succeeded, and the execution of the configure script completed successfully. However, the build (compile) step fails. Because of this, I have not changed any default configurations so netcdf-c 4.9.0 will be the newest version used anywhere and that version successfully builds.

This change is partially addressing NOAA-EMC/spack-stack/issues/453