### PR TITLE
FISMA-high compliance

### DIFF
--- a/var/spack/repos/builtin/packages/ecbuild/package.py
+++ b/var/spack/repos/builtin/packages/ecbuild/package.py
@@ -25,3 +25,12 @@ class Ecbuild(CMakePackage):
 
     # Some of the installed scripts require running Perl:
     depends_on("perl", type=("build", "run"))
+
+    variant("fismahigh", default=False, description="Apply patches for FISMA-high compliance")
+
+    def patch(self):
+        if self.spec.satisfies("+fismahigh"):
+            filter_file("ssh://[^\"]+", "", "cmake/compat/ecmwf_git.cmake")
+            filter_file("https?://[^\"]+", "", "cmake/compat/ecmwf_git.cmake")
+            filter_file("https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_check_urls.cmake")
+            filter_file("https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_get_test_data.cmake")

--- a/var/spack/repos/builtin/packages/ecbuild/package.py
+++ b/var/spack/repos/builtin/packages/ecbuild/package.py
@@ -26,7 +26,7 @@ class Ecbuild(CMakePackage):
     # Some of the installed scripts require running Perl:
     depends_on("perl", type=("build", "run"))
 
-    variant("fismahigh", default=False, description="Apply patches for FISMA-high compliance")
+    variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
 
     @when("+fismahigh")
     def patch(self):

--- a/var/spack/repos/builtin/packages/ecbuild/package.py
+++ b/var/spack/repos/builtin/packages/ecbuild/package.py
@@ -30,7 +30,11 @@ class Ecbuild(CMakePackage):
 
     @when("+fismahigh")
     def patch(self):
-        filter_file("ssh://[^\"]+", "", "cmake/compat/ecmwf_git.cmake")
-        filter_file("https?://[^\"]+", "", "cmake/compat/ecmwf_git.cmake")
-        filter_file("https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_check_urls.cmake")
-        filter_file("https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_get_test_data.cmake")
+        filter_file('ssh://[^"]+', "", "cmake/compat/ecmwf_git.cmake")
+        filter_file('https?://[^"]+', "", "cmake/compat/ecmwf_git.cmake")
+        filter_file(
+            "https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_check_urls.cmake"
+        )
+        filter_file(
+            "https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_get_test_data.cmake"
+        )

--- a/var/spack/repos/builtin/packages/ecbuild/package.py
+++ b/var/spack/repos/builtin/packages/ecbuild/package.py
@@ -28,9 +28,9 @@ class Ecbuild(CMakePackage):
 
     variant("fismahigh", default=False, description="Apply patches for FISMA-high compliance")
 
+    @when("+fismahigh")
     def patch(self):
-        if self.spec.satisfies("+fismahigh"):
-            filter_file("ssh://[^\"]+", "", "cmake/compat/ecmwf_git.cmake")
-            filter_file("https?://[^\"]+", "", "cmake/compat/ecmwf_git.cmake")
-            filter_file("https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_check_urls.cmake")
-            filter_file("https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_get_test_data.cmake")
+        filter_file("ssh://[^\"]+", "", "cmake/compat/ecmwf_git.cmake")
+        filter_file("https?://[^\"]+", "", "cmake/compat/ecmwf_git.cmake")
+        filter_file("https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_check_urls.cmake")
+        filter_file("https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_get_test_data.cmake")

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -196,6 +196,7 @@ class Eckit(CMakePackage):
     def _enable_experimental(self):
         return "linalg=armadillo" in self.spec
 
+    @when("+fismahigh")
     def patch(self):
-        if self.spec.satisfies("+fismahigh") and os.exists(".travis.yml"):
+        if os.path.exists(".travis.yml"):
             os.remove(".travis.yml")

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -51,6 +53,7 @@ class Eckit(CMakePackage):
         description="Enable support for Unicode characters in Yaml/JSON" "parsers",
     )
     variant("aio", default=True, description="Enable asynchronous IO")
+    variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
 
     # Build issues with cmake 3.20, not sure about 3.21
     depends_on("cmake@3.12:3.19,3.22:", type="build")
@@ -192,3 +195,7 @@ class Eckit(CMakePackage):
     @property
     def _enable_experimental(self):
         return "linalg=armadillo" in self.spec
+
+    def patch(self):
+        if self.spec.satisfies("+fismahigh") and os.exists(".travis.yml"):
+            os.remove(".travis.yml")

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -85,7 +85,7 @@ class EcmwfAtlas(CMakePackage):
     def patch(self):
         filter_file("http://www\.ecmwf\.int", "", "cmake/atlas-import.cmake.in")
         filter_file("int\.ecmwf", "", "cmake/atlas-import.cmake.in")
-        filter_file("http[^\"]+", "", "cmake/atlas_export.cmake")
+        filter_file('http[^"]+', "", "cmake/atlas_export.cmake")
         patterns = [".travis.yml", "tools/install*.sh", "tools/github-sha.sh"]
         for pattern in patterns:
             paths = glob.glob(pattern)

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
+import os
+
 from spack import *
 
 
@@ -40,6 +43,7 @@ class Fckit(CMakePackage):
     variant('openmp', default=True, description='Use OpenMP?')
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant('shared', default=True)
+    variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
 
     def cmake_args(self):
         args = [
@@ -61,3 +65,10 @@ class Fckit(CMakePackage):
         args.append('-DECBUILD_CXX_IMPLICIT_LINK_LIBRARIES={}'.format(cxxlib))
 
         return args
+
+    @when("+fismahigh")
+    def patch(self):
+        patterns = ["tools/install-*", "tools/github-sha*", ".travis.yml"]
+        for pattern in patterns:
+            for path in glob.glob(pattern):
+                os.remove(path)

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -81,7 +81,11 @@ class NetcdfC(AutotoolsPackage):
     variant("optimize", default=True, description="Enable -O2 for a more optimized lib")
     variant("nczarr", default=True, description="Enable zarr storage support", when="@4.8.0:")
     variant("byterange", default=False, description="Allow byte-range I/O")
-    variant("fismahigh", default=False, description="Disable network connectivity to support FISMA-high compliance")
+    variant(
+        "fismahigh",
+        default=False,
+        description="Disable network connectivity to support FISMA-high compliance",
+    )
 
     # It's unclear if cdmremote can be enabled if '--enable-netcdf-4' is passed
     # to the configure script. Since netcdf-4 support is mandatory we comment

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -141,6 +141,11 @@ class NetcdfC(AutotoolsPackage):
     conflicts("+parallel-netcdf", when="@:4.0")
     conflicts("+hdf4", when="@:4.0")
 
+    conflicts("+dap", when="+fismahigh")
+    conflicts("+byterange", when="+fismahigh")
+    conflicts("+nczarr", when="+fismahigh")
+
+
     filter_compiler_wrappers("nc-config", relative_root="bin")
 
     @property

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -79,6 +79,9 @@ class NetcdfC(AutotoolsPackage):
     variant("fsync", default=False, description="Enable fsync support")
     variant("zstd", default=True, description="Enable ZStandard compression", when="@4.9.0:")
     variant("optimize", default=True, description="Enable -O2 for a more optimized lib")
+    variant("nczarr", default=True, description="Enable zarr storage support", when="@4.8.0:")
+    variant("byterange", default=False, description="Allow byte-range I/O")
+    variant("fismahigh", default=False, description="Disable network connectivity to support FISMA-high compliance")
 
     # It's unclear if cdmremote can be enabled if '--enable-netcdf-4' is passed
     # to the configure script. Since netcdf-4 support is mandatory we comment
@@ -187,6 +190,8 @@ class NetcdfC(AutotoolsPackage):
             cflags.append(self.compiler.cc_pic_flag)
 
         config_args += self.enable_or_disable("dap")
+        config_args += self.enable_or_disable("nczarr")
+        config_args += self.enable_or_disable("byterange")
         # config_args += self.enable_or_disable('cdmremote')
 
         # if '+dap' in self.spec or '+cdmremote' in self.spec:

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -47,3 +49,9 @@ class Yafyaml(CMakePackage):
         description="The build type to build",
         values=("Debug", "Release"),
     )
+    variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
+
+    @when("+fismahigh")
+    def patch(self):
+        if os.path.exists("tools/ci-install-gfe.bash"):
+            os.remove("tools/ci-install-gfe.bash")


### PR DESCRIPTION
This PR adds a `fismahigh` variant for netcdf-c, plus the five packages covered by https://github.com/NOAA-EMC/hpc-stack/pull/495 : ecbuild, eckit, fckit, yafyaml, and (ecmwf-)atlas. For netcdf-c, I added `byterange` and `nczarr` variants.

Fixes https://github.com/NOAA-EMC/spack-stack/issues/382