### PR TITLE
Add version restriction to netcdf-c 'byterange' variant

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -80,7 +80,7 @@ class NetcdfC(AutotoolsPackage):
     variant("zstd", default=True, description="Enable ZStandard compression", when="@4.9.0:")
     variant("optimize", default=True, description="Enable -O2 for a more optimized lib")
     variant("nczarr", default=True, description="Enable zarr storage support", when="@4.8.0:")
-    variant("byterange", default=False, description="Allow byte-range I/O")
+    variant("byterange", default=False, description="Allow byte-range I/O", when="@4.7.0:")
     variant(
         "fismahigh",
         default=False,


### PR DESCRIPTION
This PR adds a restriction of "@4.7.0:" for the netcdf-c byterange variant, which corresponds with the version where this option was added.