### PR TITLE
Final updates required for building unified environment on HPC, cloud, macOS

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections
+import itertools
 import multiprocessing.pool
 import os
 import re
@@ -299,17 +300,24 @@ def modify_macho_object(cur_path, rpaths, deps, idpath, paths_to_paths):
     if idpath:
         new_idpath = paths_to_paths.get(idpath, None)
         if new_idpath and not idpath == new_idpath:
-            args += ["-id", new_idpath]
+            args += [("-id", new_idpath)]
+
     for dep in deps:
         new_dep = paths_to_paths.get(dep)
         if new_dep and dep != new_dep:
-            args += ["-change", dep, new_dep]
+            args += [("-change", dep, new_dep)]
 
+    new_rpaths = []
     for orig_rpath in rpaths:
         new_rpath = paths_to_paths.get(orig_rpath)
         if new_rpath and not orig_rpath == new_rpath:
-            args += ["-rpath", orig_rpath, new_rpath]
+            args_to_add = ("-rpath", orig_rpath, new_rpath)
+            if args_to_add not in args and new_rpath not in new_rpaths:
+                args += [args_to_add]
+                new_rpaths.append(new_rpath)
 
+    # Deduplicate and flatten
+    args = list(itertools.chain.from_iterable(llnl.util.lang.dedupe(args)))
     if args:
         args.append(str(cur_path))
         install_name_tool = executable.Executable("install_name_tool")

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -49,6 +49,11 @@ class Bufr(CMakePackage):
     depends_on("py-numpy", type="build", when="+python")
     depends_on("py-pip", type="build", when="+python")
 
+    # Need to make the lines shorter at least on some systems
+    def patch(self):
+        with when("@:11.7.1"):
+            filter_file("_lenslmax 120", "_lenslmax 60", "CMakeLists.txt")
+
     def cmake_args(self):
         args = [
             self.define_from_variant("ENABLE_PYTHON", "python"),

--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -29,15 +29,16 @@ class Libelf(AutotoolsPackage):
 
     provides("elf@0")
 
-    # configure: error: neither int nor long is 32-bit
-    depends_on("automake", when="platform=darwin target=aarch64:", type="build")
-    depends_on("autoconf", when="platform=darwin target=aarch64:", type="build")
-    depends_on("libtool", when="platform=darwin target=aarch64:", type="build")
-    depends_on("m4", when="platform=darwin target=aarch64:", type="build")
+    # configure: error: neither int nor long is 32-bit on aarch64
+    # and on x86_64 in Rosetta2 emulator mode
+    depends_on("automake", when="platform=darwin", type="build")
+    depends_on("autoconf", when="platform=darwin", type="build")
+    depends_on("libtool", when="platform=darwin", type="build")
+    depends_on("m4", when="platform=darwin", type="build")
 
     @property
     def force_autoreconf(self):
-        return self.spec.satisfies("platform=darwin target=aarch64:")
+        return self.spec.satisfies("platform=darwin")
 
     def configure_args(self):
         args = ["--enable-shared", "--disable-debug"]

--- a/var/spack/repos/jcsda-emc-bundles/packages/global-workflow-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/global-workflow-env/package.py
@@ -16,6 +16,7 @@ class GlobalWorkflowEnv(BundlePackage):
 
     version("1.0.0")
     variant("python", default=True, description="Build Python dependencies")
+    variant("ncl", default=True, description="Build NCL (NCAR Command Language)")
 
     depends_on("ufs-pyenv", when="+python")
     depends_on("prod-util")
@@ -42,7 +43,9 @@ class GlobalWorkflowEnv(BundlePackage):
     depends_on("met")
     depends_on("metplus")
     depends_on("gsi-ncdiag")
-    depends_on("ncl")
+    depends_on("ncl", when="+ncl")
     depends_on("crtm@2.4.0")
+
+    conflicts("platform=darwin", when="+ncl", msg="NCL doesn't build on macOS")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
## Description

A number of unrelated updates and bug fixes required for building the unified environment on HPC, cloud, macOS. All these were tested on the different platforms.

1. Make `ncl` a variant in global-workflow-env (by default on), and make it conflict with macOS
2. Bug fix in `bufr` for long lines in auto-generated code. Note that a similar change was merged into the NCEPLIBS-bufr repository on Feb 15 (https://github.com/NOAA-EMC/NCEPLIBS-bufr/pull/321), which means the workaround here is only needed for versions up to 11.7.1
3. Bug fix in `libelf`: also need to run `autoreconf` on macOS Intel when using Rosetta 2, not just on native M1
4. Cherry-pick 548aa21 from authoritative spack repository (https://github.com/spack/spack/pull/34375) - in preparation for using build caches

This PR has been tested extensively with https://github.com/NOAA-EMC/spack-stack/pull/454