### PR TITLE
Bug fix for mapl when environment variable BASEDIR is set

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections
+import itertools
 import multiprocessing.pool
 import os
 import re
@@ -299,17 +300,24 @@ def modify_macho_object(cur_path, rpaths, deps, idpath, paths_to_paths):
     if idpath:
         new_idpath = paths_to_paths.get(idpath, None)
         if new_idpath and not idpath == new_idpath:
-            args += ["-id", new_idpath]
+            args += [("-id", new_idpath)]
+
     for dep in deps:
         new_dep = paths_to_paths.get(dep)
         if new_dep and dep != new_dep:
-            args += ["-change", dep, new_dep]
+            args += [("-change", dep, new_dep)]
 
+    new_rpaths = []
     for orig_rpath in rpaths:
         new_rpath = paths_to_paths.get(orig_rpath)
         if new_rpath and not orig_rpath == new_rpath:
-            args += ["-rpath", orig_rpath, new_rpath]
+            args_to_add = ("-rpath", orig_rpath, new_rpath)
+            if args_to_add not in args and new_rpath not in new_rpaths:
+                args += [args_to_add]
+                new_rpaths.append(new_rpath)
 
+    # Deduplicate and flatten
+    args = list(itertools.chain.from_iterable(llnl.util.lang.dedupe(args)))
     if args:
         args.append(str(cur_path))
         install_name_tool = executable.Executable("install_name_tool")

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -122,10 +122,10 @@ class Mapl(CMakePackage):
               r'\1 %s '%nc_flags, "pfio/CMakeLists.txt")
 
     def setup_build_environment(self, env):
-        # This is really, really bad. esma_cmake, an internal
-        # dependency of mapl, is looking for the cmake argument
-        # -DBASEDIR, and if it doesn't find it, it's looking
-        # for an environment variable with the same name. This
-        # name is common and used all over the place, and if
-        # it is set it breaks the mapl build. Unset it here ...
+        # esma_cmake, an internal dependency of mapl, is
+        # looking for the cmake argument -DBASEDIR, and
+        # if it doesn't find it, it's looking for an
+        # environment variable with the same name. This
+        # name is common and used all over the place,
+        # and if it is set it breaks the mapl build.
         env.unset("BASEDIR")

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -119,3 +119,12 @@ class Mapl(CMakePackage):
               subprocess.check_output(nc_pc_cmd, encoding="utf8").strip()
             filter_file("(target_link_libraries[^)]+PUBLIC )", \
               r'\1 %s '%nc_flags, "pfio/CMakeLists.txt")
+
+    def setup_build_environment(self, env):
+        # This is really, really bad. esma_cmake, an internal
+        # dependency of mapl, is looking for the cmake argument
+        # -DBASEDIR, and if it doesn't find it, it's looking
+        # for an environment variable with the same name. This
+        # name is common and used all over the place, and if
+        # it is set it breaks the mapl build. Unset it here ...
+        env.unset("BASEDIR")


### PR DESCRIPTION
## Description

Fixes a problem with ``mapl`` where the presence of the environment variable `BASEDIR` wrecks havoc for the build of the package. This environment variable isn't needed when using spack to build ``mapl`` and other GEOS packages. It's only needed when using the old `baselibs` system developed by NASA.

Tested with https://github.com/NOAA-EMC/spack-stack/pull/476.