### PR TITLE
Updates required for creating binary (build) caches

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1213,17 +1213,6 @@ def _build_tarball(
     # create info for later relocation and create tar
     write_buildinfo_file(spec, workdir, relative)
 
-    # remove all __pycache__ directories and compiled Python files (*.pyc)
-    # to avoid problems like ValueError:bad marshal data
-    cmd = "rm -fr `find {} -type d -name __pycache__` 2>/dev/null"
-    status = os.system(cmd)
-    if status:
-        raise Exception("Failed to execute '{}'".format(cmd))
-    cmd = "rm -fr `find {} -type f -name *.pyc` 2>/dev/null"
-    status = os.system(cmd)
-    if status:
-        raise Exception("Failed to execute '{}'".format(cmd))
-
     # optionally make the paths in the binaries relative to each other
     # in the spack install tree before creating tarball
     if relative:
@@ -1373,6 +1362,7 @@ def push(specs, push_url, specs_kwargs=None, **kwargs):
     # TODO: This seems to be an easy target for task
     # TODO: distribution using a parallel pool
     for node in nodes:
+        tty.msg('Creating buildcache for "{0}"'.format(node.format()))
         try:
             _build_tarball(node, push_url, **kwargs)
         except NoOverwriteException as e:

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -111,6 +111,17 @@ def setup_parser(subparser):
             " or only the dependencies"
         ),
     )
+    create.add_argument(
+        "--skip-on-error",
+        action="store_true",
+        default=False,
+        help=(
+            "Ignore errors when creating buildcaches."
+            " This option is useful when creating buildcaches"
+            " for multiple specs at once (e.g. all specs in"
+            " an environment)"
+        ),
+    )
     arguments.add_common_arguments(create, ["specs"])
     create.set_defaults(func=create_fn)
 
@@ -399,6 +410,7 @@ def create_fn(args):
         "unsigned": args.unsigned,
         "allow_root": args.allow_root,
         "regenerate_index": args.rebuild_index,
+        "skip_on_error": args.skip_on_error,
     }
     bindist.push(matches, push_url, specs_kwargs, **kwargs)
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -498,7 +498,7 @@ _spack_buildcache() {
 _spack_buildcache_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -r --rel -f --force -u --unsigned -a --allow-root -k --key -d --directory -m --mirror-name --mirror-url --rebuild-index --spec-file --only"
+        SPACK_COMPREPLY="-h --help -r --rel -f --force -u --unsigned -a --allow-root -k --key -d --directory -m --mirror-name --mirror-url --rebuild-index --spec-file --only --skip-on-error"
     else
         _all_packages
     fi

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -85,3 +85,11 @@ class Ecflow(CMakePackage):
             self.define("Python3_EXECUTABLE", self.spec["python"].package.command),
             self.define("BOOST_ROOT", self.spec["boost"].prefix),
         ]
+
+    # A recursive link in the ecflow source code causes the binary cache
+    # creation to fail. This file is only in the install tree if the
+    # --source option is set when installing the package, but force_remove
+    # acts like "rm -f" and won't abort if the file doesn't exist.
+    @run_after("install")
+    def remove_recursive_symlink_in_source_code(self):
+        force_remove(join_path(self.prefix, "share/ecflow/src/cereal/cereal"))


### PR DESCRIPTION
## Description

These updates are required for creating build caches for all packages in an environment by skipping packages with errors instead of aborting, which is what spack does at the moment. I created a corresponding issue and PR in the upstream spack repo: https://github.com/spack/spack/issues/35602 and https://github.com/spack/spack/pull/35601.

Note that the changes differ slightly from this PR due to the updates that went into spack develop in these files. I will take care of resolving the conflicts when we bring these changes down to our fork).

## Testing
Tested successfully on my macOS. See https://github.com/NOAA-EMC/spack-stack/pull/484 for the corresponding spack-stack PR.