### PR TITLE
Update ecmwf-atlas, fckit, gsibec packages for skylab v4

### DIFF
--- a/var/spack/repos/builtin/packages/ecbuild/package.py
+++ b/var/spack/repos/builtin/packages/ecbuild/package.py
@@ -13,7 +13,7 @@ class Ecbuild(CMakePackage):
     homepage = "https://github.com/ecmwf/ecbuild"
     url = "https://github.com/ecmwf/ecbuild/archive/refs/tags/3.6.1.tar.gz"
 
-    maintainers = ["skosukhin"]
+    maintainers = ["skosukhin", "climbfuji"]
 
     version("3.6.5", sha256="98bff3d3c269f973f4bfbe29b4de834cd1d43f15b1c8d1941ee2bfe15e3d4f7f")
     version("3.6.1", sha256="796ccceeb7af01938c2f74eab0724b228e9bf1978e32484aa3e227510f69ac59")

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -20,6 +20,7 @@ class EcmwfAtlas(CMakePackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.32.1", sha256="3d1a46cb7f50e1a6ae9e7627c158760e132cc9f568152358e5f78460f1aaf01b")
     version("0.31.1", sha256="fa9274c74c40c2115b9c6120a7040e357b0c7f37b20b601b684d2a83a479cdfb")
     version("0.31.0", sha256="fa4ff8665544b8e19f79d171c540a9ca8bfc4127f52a3c4d4d618a2fe23354d7")
     version("0.30.0", commit="d81887206fc49c83fd5eb2e0e17457bdcd04731a")

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -16,18 +16,12 @@ class Fckit(CMakePackage):
     git = "https://github.com/ecmwf/fckit.git"
     url = "https://github.com/ecmwf/fckit/archive/0.9.0.tar.gz"
 
-    maintainers = ['rhoneyager', 'climbfuji']
+    maintainers = ['climbfuji']
 
     version('master', branch='master')
     version('develop', branch='develop')
-    version('0.9.5', commit='7ec9cf8ad8b619a8319199e834171c11e111c888', preferred=True)
-    version('0.9.4', commit='a83cfe6d4ed22c954548dd7c31e1fbad3cd2f908')
-    version('0.9.3', commit='3f612e107682c61c0b6806ea3fc12e9509a90664')
-    version('0.9.2', commit='26439f09a421b29d745f4c4810d7d40f2820f5ec')
-    version('0.9.1', commit='0b2c04d29ff141d1963e21da2add2e70f01163ce')
-    version('0.9.0', commit='9cd993a524264e079ae260dbc89faea599e270fc')
-    version('0.8.0', commit='4cd749f1eeac64eece00adb50abd072ea14fa2b1')
-    version('0.7.0', commit='5a9ad884c087ae4c188a5937acf078514519778f')
+    version("0.10.0", sha256="f16829f63a01cdef5e158ed2a51f6d4200b3fe6dce8f251af158141a1afe482b")
+    version("0.9.5", sha256="183cd78e66d3283d9e6e8e9888d3145f453690a4509fb701b28d1ac6757db5de")
 
     depends_on('mpi')
     depends_on('python')

--- a/var/spack/repos/builtin/packages/gsibec/package.py
+++ b/var/spack/repos/builtin/packages/gsibec/package.py
@@ -18,6 +18,7 @@ class Gsibec(CMakePackage):
     maintainers = ["mathomp4", "danholdaway"]
 
     version("develop", branch="develop")
+    version("1.0.7", sha256="53912f1f19d46f4941b377803cc2fce89a2b50d2ece7562f8fd65215a8908158")
     version("1.0.6", sha256="10e2561685156bcfba35c7799732c77f9c05bd180888506a339540777db833dd")
     version("1.0.5", sha256="ac0cecc59e38da7eefb5a8f27975b33752fa61a4abd3bdbbfb55578ea59d95b3")
     version("1.0.4", sha256="6460e221f2a45640adab016336c070fbe3e7c4b6fc55257945bf5cdb38d5d3e2")


### PR DESCRIPTION
## Description

Add new package versions for ecmwf-atlas, fckit, gsibec. Add myself to the maintainers for ecbuild. The new package versions are required for the upcoming spack-stack-1.3.0/Skylab v4 releases.

Tested with https://github.com/NOAA-EMC/spack-stack/pull/485 (to be worked on after https://github.com/NOAA-EMC/spack-stack/pull/463)