### PR TITLE
Update broken checksum for the crtm-fix@2.4.0_emc tar file.

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -22,7 +22,7 @@ class CrtmFix(Package):
         "climbfuji",
     ]
 
-    version("2.4.0_emc", sha256="88d659ae5bc4434f7fafa232ff65b4c48442d2d1a25f8fc96078094fa572ac1a")
+    version("2.4.0_emc", sha256="d0f1b2ae2905457f4c3731746892aaa8f6b84ee0691f6228dfbe48917df1e85e")
     version("2.3.0_emc", sha256="1452af2d1d11d57ef3c57b6b861646541e7042a9b0f3c230f9a82854d7e90924")
 
     variant("big_endian", default=True, description="Install big_endian fix files")


### PR DESCRIPTION
This PR fixes the broken checksum for the crtm-fix@2.4.0_emc version in the crtm-fix package.py script.

I tested this on my Mac (arm64, apple clang 14.0.0, gnu fortran 12.2.0) using the unified-dev templat, macos-default site config. I went through the normal steps to the install step, and then ran `spack install -v crtm-fix` which downloaded the tar file, passed the checksum test, and installed successfully. 