### PR TITLE
For cdo, only require threadsafe hdf5 if +openmp

### DIFF
--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -160,14 +160,14 @@ class Cdo(AutotoolsPackage):
     depends_on("netcdf-c", when="+netcdf")
     # The internal library of CDO implicitly links to hdf5.
     # We also need the backend of netcdf to be thread safe.
-    depends_on("hdf5+threadsafe", when="+netcdf")
+    depends_on("hdf5+threadsafe", when="+netcdf +openmp")
 
     depends_on("grib-api", when="grib2=grib-api")
     depends_on("eccodes", when="grib2=eccodes")
 
     depends_on("szip", when="+szip")
 
-    depends_on("hdf5+threadsafe", when="+hdf5")
+    depends_on("hdf5+threadsafe", when="+hdf5 +openmp")
 
     depends_on("udunits", when="+udunits2")
     depends_on("libxml2", when="+libxml2")


### PR DESCRIPTION
Changing cdo so that threadsafe hdf5 is only required when building with openmp. I plan to set cdo to ~openmp in common/packages.yaml because global workflow runs cdo single threaded.

Addresses https://github.com/NOAA-EMC/spack-stack/issues/496