### PR TITLE
Change variant fpic to pic for fms

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -82,7 +82,7 @@ class Fms(CMakePackage):
         when="@2022.02:",
     )
     variant(
-        "fpic", default=False, description="Build with position independent code", when="@2022.02:"
+        "pic", default=False, description="Build with position independent code", when="@2022.02:"
     )
 
     depends_on("netcdf-c")
@@ -104,7 +104,7 @@ class Fms(CMakePackage):
             self.define_from_variant("ENABLE_QUAD_PRECISION", "quad_precision"),
             self.define_from_variant("WITH_YAML", "yaml"),
             self.define_from_variant("CONSTANTS"),
-            self.define_from_variant("FPIC"),
+            self.define_from_variant("FPIC", "pic"),
         ]
 
         args.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
@@ -17,7 +17,7 @@ class JediUfsEnv(BundlePackage):
     version("1.0.0")
 
     depends_on("jedi-base-env", type="run")
-    depends_on("fms@2022.04+fpic", type="run")
+    depends_on("fms@2022.04+pic", type="run")
 
     depends_on("bacio", type="run")
     depends_on("g2", type="run")


### PR DESCRIPTION
This PR changes `fpic` to `pic` for fms to make it consistent with everything else.