### PR TITLE
Bug fix for "Download URL for crtm v3 not working"

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -53,7 +53,7 @@ class Crtm(CMakePackage):
     depends_on("ecbuild", type=("build"), when="@v2.4-jedi.2")
     depends_on("ecbuild", type=("build"), when="@v3.0.0-rc.1")
 
-    version("v3.0.0-rc.1", commit="b64fa71")
+    version("v3.0.0-rc.1", sha256="b7f8c251168bcc3c29586ee281ed456e3115735d65167adcbcf4f69be76b933c")
     # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
     version("2.4.0", commit="5ddd0d6")
     # Uses the tip of REL-2.3.0_emc branch
@@ -66,7 +66,8 @@ class Crtm(CMakePackage):
     version("v2.4-jedi.2", commit="62831cb")
 
     def url_for_version(self, version):
-        if version < Version("3.0.0"):
-            return "https://github.com/JCSDA/crtm/archive/refs/tags/{}.tar.gz".format(version)
-        else:
+        if self.spec.satisfies("@v3") or version >=  Version("3.0.0"):
             return "https://github.com/JCSDA/crtmv3/archive/refs/tags/{}.tar.gz".format(version)
+        else:
+            return "https://github.com/JCSDA/crtm/archive/refs/tags/{}.tar.gz".format(version)
+


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/spack/issues/245

Tested on Cheyenne with various versions of CRTM:
```
> ls -l tmp/crtm/
total 3
lrwxrwxrwx 1 heinzell ncar 50 Mar 17 08:22 crtm-2.4.0.tar.gz -> ../_source-cache/git/JCSDA/crtm.git/5ddd0d6.tar.gz
lrwxrwxrwx 1 heinzell ncar 50 Mar 17 08:17 crtm-v2.4-jedi.2.tar.gz -> ../_source-cache/git/JCSDA/crtm.git/62831cb.tar.gz
lrwxrwxrwx 1 heinzell ncar 99 Mar 17 08:17 crtm-v3.0.0-rc.1.tar.gz -> ../_source-cache/archive/b7/b7f8c251168bcc3c29586ee281ed456e3115735d65167adcbcf4f69be76b933c.tar.gz
```
