### PR TITLE
Explicitly disable libxml2 for netcdf-c@4.9.2 when ~dap

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -216,6 +216,9 @@ class NetcdfC(AutotoolsPackage):
         elif self.spec.satisfies("@4.8.0:"):
             # Prevent overlinking to a system installation of libcurl:
             config_args.append("ac_cv_lib_curl_curl_easy_setopt=no")
+            # 4.9.2 configure complains about libxml2 even with ~dap:
+            if self.spec.satisfies("@4.9.2"):
+                config_args.append("--disable-libxml2")
 
         if self.spec.satisfies("@4.4:"):
             if "+mpi" in self.spec:

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -217,7 +217,7 @@ class NetcdfC(AutotoolsPackage):
             # Prevent overlinking to a system installation of libcurl:
             config_args.append("ac_cv_lib_curl_curl_easy_setopt=no")
             # 4.9.2 configure complains about libxml2 even with ~dap:
-            if self.spec.satisfies("@4.9.2"):
+            if self.spec.satisfies("@4.9.1:4.9.2"):
                 config_args.append("--disable-libxml2")
 
         if self.spec.satisfies("@4.4:"):


### PR DESCRIPTION
This PR explicitly sets `--disable-libxml2` for `netcdf-c@4.9.2~dap`. Fixes configure bug where it complains about missing libxml2 even with `~dap`. Can get pushed to main Spack with other changes since 4.9.2 isn't in there yet.

Tested on acorn with ufs static template.