### PR TITLE
Add w3emc; remove w3nco.

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
@@ -33,7 +33,7 @@ class UfsWeatherModelEnv(BundlePackage):
     depends_on("g2tmpl", type="run")
     depends_on("ip", type="run")
     depends_on("sp", type="run")
-    depends_on("w3nco", type="run")
+    depends_on("w3emc", type="run")
 
     depends_on("esmf~debug", type="run", when="~debug")
     depends_on("esmf+debug", type="run", when="+debug")


### PR DESCRIPTION
Fixes [spack-stack #511](https://github.com/NOAA-EMC/spack-stack/issues/511).