### PR TITLE
MAPL: revert esma_cmake to v3.17.0 from v3.21.0

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -45,7 +45,7 @@ class Mapl(CMakePackage):
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
-        tag="v3.21.0",
+        tag="v3.17.0",
         when="@2.22.0:",
     )
     resource(


### PR DESCRIPTION
I'm guessing we've only tested mapl > 2.22.0 since some of the mapl package.py updates... In any case, esma_cmake v3.21.0 breaks mapl@2.22.0, so this PR reverts it to using v3.17.0 because we've built and tested that combination a million times.