### PR TITLE
Merge release/1.3.0 into jcsda_emc_spack_stack

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/h5py370_hdf51140.patch
+++ b/var/spack/repos/builtin/packages/py-h5py/h5py370_hdf51140.patch
@@ -1,0 +1,146 @@
+--- a/h5py/api_types_hdf5.pxd	2023-03-30 22:22:49
++++ b/h5py/api_types_hdf5.pxd	2023-03-30 22:25:19
+@@ -235,40 +235,100 @@
+     H5FD_MPIO_INDEPENDENT = 0,
+     H5FD_MPIO_COLLECTIVE
+ 
++  # File driver identifier type and values
++  IF HDF5_VERSION >= (1, 14, 0):
++    ctypedef int H5FD_class_value_t
++
++    H5FD_class_value_t H5_VFD_INVALID      # -1
++    H5FD_class_value_t H5_VFD_SEC2         # 0
++    H5FD_class_value_t H5_VFD_CORE         # 1
++    H5FD_class_value_t H5_VFD_LOG          # 2
++    H5FD_class_value_t H5_VFD_FAMILY       # 3
++    H5FD_class_value_t H5_VFD_MULTI        # 4
++    H5FD_class_value_t H5_VFD_STDIO        # 5
++    H5FD_class_value_t H5_VFD_SPLITTER     # 6
++    H5FD_class_value_t H5_VFD_MPIO         # 7
++    H5FD_class_value_t H5_VFD_DIRECT       # 8
++    H5FD_class_value_t H5_VFD_MIRROR       # 9
++    H5FD_class_value_t H5_VFD_HDFS         # 10
++    H5FD_class_value_t H5_VFD_ROS3         # 11
++    H5FD_class_value_t H5_VFD_SUBFILING    # 12
++    H5FD_class_value_t H5_VFD_IOC          # 13
++    H5FD_class_value_t H5_VFD_ONION        # 14
++
+   # Class information for each file driver
+-  ctypedef struct H5FD_class_t:
+-    const char *name
+-    haddr_t maxaddr
+-    H5F_close_degree_t fc_degree
+-    herr_t  (*terminate)()
+-    hsize_t (*sb_size)(H5FD_t *file)
+-    herr_t  (*sb_encode)(H5FD_t *file, char *name, unsigned char *p)
+-    herr_t  (*sb_decode)(H5FD_t *f, const char *name, const unsigned char *p)
+-    size_t  fapl_size
+-    void *  (*fapl_get)(H5FD_t *file)
+-    void *  (*fapl_copy)(const void *fapl)
+-    herr_t  (*fapl_free)(void *fapl)
+-    size_t  dxpl_size
+-    void *  (*dxpl_copy)(const void *dxpl)
+-    herr_t  (*dxpl_free)(void *dxpl)
+-    H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr)
+-    herr_t  (*close)(H5FD_t *file)
+-    int     (*cmp)(const H5FD_t *f1, const H5FD_t *f2)
+-    herr_t  (*query)(const H5FD_t *f1, unsigned long *flags)
+-    herr_t  (*get_type_map)(const H5FD_t *file, H5FD_mem_t *type_map)
+-    haddr_t (*alloc)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
+-    herr_t  (*free)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size)
+-    haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type)
+-    herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
+-    haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type)
+-    herr_t  (*get_handle)(H5FD_t *file, hid_t fapl, void**file_handle)
+-    herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer)
+-    herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer)
+-    herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
+-    herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
+-    herr_t  (*lock)(H5FD_t *file, hbool_t rw)
+-    herr_t  (*unlock)(H5FD_t *file)
+-    H5FD_mem_t fl_map[<int>H5FD_MEM_NTYPES]
++  IF HDF5_VERSION < (1, 14, 0):
++    ctypedef struct H5FD_class_t:
++      const char *name
++      haddr_t maxaddr
++      H5F_close_degree_t fc_degree
++      herr_t  (*terminate)()
++      hsize_t (*sb_size)(H5FD_t *file)
++      herr_t  (*sb_encode)(H5FD_t *file, char *name, unsigned char *p)
++      herr_t  (*sb_decode)(H5FD_t *f, const char *name, const unsigned char *p)
++      size_t  fapl_size
++      void *  (*fapl_get)(H5FD_t *file)
++      void *  (*fapl_copy)(const void *fapl)
++      herr_t  (*fapl_free)(void *fapl)
++      size_t  dxpl_size
++      void *  (*dxpl_copy)(const void *dxpl)
++      herr_t  (*dxpl_free)(void *dxpl)
++      H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr)
++      herr_t  (*close)(H5FD_t *file)
++      int     (*cmp)(const H5FD_t *f1, const H5FD_t *f2)
++      herr_t  (*query)(const H5FD_t *f1, unsigned long *flags)
++      herr_t  (*get_type_map)(const H5FD_t *file, H5FD_mem_t *type_map)
++      haddr_t (*alloc)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
++      herr_t  (*free)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size)
++      haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type)
++      herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
++      haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type)
++      herr_t  (*get_handle)(H5FD_t *file, hid_t fapl, void**file_handle)
++      herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer)
++      herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer)
++      herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
++      herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
++      herr_t  (*lock)(H5FD_t *file, hbool_t rw)
++      herr_t  (*unlock)(H5FD_t *file)
++      H5FD_mem_t fl_map[<int>H5FD_MEM_NTYPES]
++  ELSE:
++    unsigned H5FD_CLASS_VERSION  # File driver struct version
++
++    ctypedef struct H5FD_class_t:
++      unsigned version  # File driver class struct version number
++      H5FD_class_value_t value
++      const char *name
++      haddr_t maxaddr
++      H5F_close_degree_t fc_degree
++      herr_t  (*terminate)()
++      hsize_t (*sb_size)(H5FD_t *file)
++      herr_t  (*sb_encode)(H5FD_t *file, char *name, unsigned char *p)
++      herr_t  (*sb_decode)(H5FD_t *f, const char *name, const unsigned char *p)
++      size_t  fapl_size
++      void *  (*fapl_get)(H5FD_t *file)
++      void *  (*fapl_copy)(const void *fapl)
++      herr_t  (*fapl_free)(void *fapl)
++      size_t  dxpl_size
++      void *  (*dxpl_copy)(const void *dxpl)
++      herr_t  (*dxpl_free)(void *dxpl)
++      H5FD_t *(*open)(const char *name, unsigned flags, hid_t fapl, haddr_t maxaddr)
++      herr_t  (*close)(H5FD_t *file)
++      int     (*cmp)(const H5FD_t *f1, const H5FD_t *f2)
++      herr_t  (*query)(const H5FD_t *f1, unsigned long *flags)
++      herr_t  (*get_type_map)(const H5FD_t *file, H5FD_mem_t *type_map)
++      haddr_t (*alloc)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
++      herr_t  (*free)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size)
++      haddr_t (*get_eoa)(const H5FD_t *file, H5FD_mem_t type)
++      herr_t  (*set_eoa)(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
++      haddr_t (*get_eof)(const H5FD_t *file, H5FD_mem_t type)
++      herr_t  (*get_handle)(H5FD_t *file, hid_t fapl, void**file_handle)
++      herr_t  (*read)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, void *buffer)
++      herr_t  (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer)
++      herr_t  (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
++      herr_t  (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
++      herr_t  (*lock)(H5FD_t *file, hbool_t rw)
++      herr_t  (*unlock)(H5FD_t *file)
++      H5FD_mem_t fl_map[<int>H5FD_MEM_NTYPES]
+ 
+   # The main datatype for each driver
+   ctypedef struct H5FD_t:
+--- a/h5py/h5fd.pyx	2023-03-30 22:22:49
++++ b/h5py/h5fd.pyx	2023-03-30 22:25:29
+@@ -216,5 +216,7 @@
+                H5FD_MEM_SUPER,  # lheap
+                H5FD_MEM_SUPER   # ohdr
+ 	       ]
++IF HDF5_VERSION >= (1, 14, 0):
++    info.version = H5FD_CLASS_VERSION
+ 
+ fileobj_driver = H5FDregister(&info)

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -75,6 +75,10 @@ class PyH5py(PythonPackage):
     depends_on("py-mpi4py@3.0.2:", when="@3.3.0:+mpi^python@3:3.7", type=("build", "run"))
     depends_on("py-mpi4py@3.0.3:", when="@3:+mpi^python@3.8.0:", type=("build", "run"))
 
+    # Patch version 3.7.0 so that it works with hdf5@1.14.0 (3.8.0 doesn't build correctly)
+    # https://github.com/h5py/h5py/pull/2194/commits
+    patch("h5py370_hdf51140.patch", when="@3.7.0")
+
     def setup_build_environment(self, env):
         env.set("HDF5_DIR", self.spec["hdf5"].prefix)
         if "+mpi" in self.spec:

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -16,6 +16,7 @@ class PyH5py(PythonPackage):
     maintainers = ["bryanherman", "takluyver"]
 
     version("master", branch="master")
+    version("3.8.0", sha256="6fead82f0c4000cf38d53f9c030780d81bfa0220218aee13b90b7701c937d95f")
     version("3.7.0", sha256="3fcf37884383c5da64846ab510190720027dca0768def34dd8dcb659dbe5cbf3")
     version("3.6.0", sha256="8752d2814a92aba4e2b2a5922d2782d0029102d99caaf3c201a566bc0b40db29")
     version("3.5.0", sha256="77c7be4001ac7d3ed80477de5b6942501d782de1bbe4886597bdfec2a7ab821f")
@@ -60,7 +61,8 @@ class PyH5py(PythonPackage):
     # Link dependencies (py-h5py v2 cannot build against HDF5 1.12 regardless
     # of API setting)
     depends_on("hdf5@1.8.4:1.11 +hl", when="@:2")
-    depends_on("hdf5@1.8.4: +hl", when="@3:")
+    depends_on("hdf5@1.8.4:1.12.99 +hl", when="@3:3.7")
+    depends_on("hdf5@1.8.4: +hl", when="@3.8:")
 
     # MPI dependencies
     depends_on("hdf5+mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -61,6 +61,7 @@ class PyH5py(PythonPackage):
     # Link dependencies (py-h5py v2 cannot build against HDF5 1.12 regardless
     # of API setting)
     depends_on("hdf5@1.8.4:1.11 +hl", when="@:2")
+    # https://forum.hdfgroup.org/t/runtimeerror-wrong-file-driver-version/10123
     depends_on("hdf5@1.8.4:1.12.99 +hl", when="@3:3.7")
     depends_on("hdf5@1.8.4: +hl", when="@3.8:")
 

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -16,7 +16,9 @@ class PyH5py(PythonPackage):
     maintainers = ["bryanherman", "takluyver"]
 
     version("master", branch="master")
-    version("3.8.0", sha256="6fead82f0c4000cf38d53f9c030780d81bfa0220218aee13b90b7701c937d95f")
+    # Version 3.8.0 seems to be broken or configured incorrectly, it's only building
+    # and installing the cpython extension, but none of the actual Python modules.
+    #version("3.8.0", sha256="6fead82f0c4000cf38d53f9c030780d81bfa0220218aee13b90b7701c937d95f")
     version("3.7.0", sha256="3fcf37884383c5da64846ab510190720027dca0768def34dd8dcb659dbe5cbf3")
     version("3.6.0", sha256="8752d2814a92aba4e2b2a5922d2782d0029102d99caaf3c201a566bc0b40db29")
     version("3.5.0", sha256="77c7be4001ac7d3ed80477de5b6942501d782de1bbe4886597bdfec2a7ab821f")
@@ -62,8 +64,8 @@ class PyH5py(PythonPackage):
     # of API setting)
     depends_on("hdf5@1.8.4:1.11 +hl", when="@:2")
     # https://forum.hdfgroup.org/t/runtimeerror-wrong-file-driver-version/10123
-    depends_on("hdf5@1.8.4:1.12.99 +hl", when="@3:3.7")
-    depends_on("hdf5@1.8.4: +hl", when="@3.8:")
+    depends_on("hdf5@1.8.4:1.12.99 +hl", when="@3:3.6")
+    depends_on("hdf5@1.8.4: +hl", when="@3.7:")
 
     # MPI dependencies
     depends_on("hdf5+mpi", when="+mpi")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ewok-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ewok-env/package.py
@@ -43,7 +43,9 @@ class JediEwokEnv(BundlePackage):
 
     # R2D2 mysql backend
     depends_on("mysql", type="run")
-    depends_on("py-mysql-connector-python", type="run")
+    # Comment out for now until build problems are solved
+    # https://github.com/NOAA-EMC/spack-stack/issues/522
+    #depends_on("py-mysql-connector-python", type="run")
 
     depends_on("solo", when="+solo", type="run")
     depends_on("r2d2", when="+r2d2", type="run")


### PR DESCRIPTION
## Description

Merge release/1.3.0 back into jcsda_emc_spack_stack.

Changes are
- temporarily removing `py-mysql-connector-python`
- bug fixes and updates for `py-h5py`

## Testing

Tested extensively as part of the release with the spack-stack 1.3.0 release branch.

For testing with the updated develop branch of spack-stack, see https://github.com/NOAA-EMC/spack-stack/pull/541