### PR TITLE
Added odc version 1.4.6 to odc package.py script

### DIFF
--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -14,6 +14,7 @@ class Odc(CMakePackage):
 
     maintainers = ["skosukhin"]
 
+    version("1.4.6", sha256="ff99d46175e6032ddd0bdaa3f6a5e2c4729d24b698ba0191a2a4aa418f48867c")
     version("1.4.5", sha256="8532d0453531d62e1f15791d1c5c96540b842913bd211a8ef090211eaf4cccae")
     version("1.4.4", sha256="65cb7b491566d3de14b66741544360f20eaaf1a6d5a24af7d8b939dd50e26431")
     version("1.4.2", sha256="19572e93238c1531bcf0f7966f0d2342a0400f5fe9deb934a384228f895909c9")


### PR DESCRIPTION
This PR sets the stage for moving to odc version 1.4.6 by adding the necessary version statement (with checksum) to the odc package.py script.

This partially addresses noaa-emc/spack-stack/issues/542