### PR TITLE
Add jedi-neptune-env

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-neptune-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-neptune-env/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class JediNeptuneEnv(BundlePackage):
+    """Development environment for neptune-bundle"""
+
+    # Fake URL
+    homepage = "https://github.com/JCSDA-internal/neptune-bundle"
+    git = "https://github.com/JCSDA-internal/neptune-bundle.git"
+
+    maintainers("climbfuji", "areineke")
+
+    version("1.0.0")
+
+    depends_on("jedi-base-env", type="run")
+
+    depends_on("libyaml", type="run")
+    depends_on("p4est", type="run")
+    depends_on("w3emc", type="run")
+    depends_on("esmf~debug", type="run")
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-neptune-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-neptune-env/package.py
@@ -22,6 +22,6 @@ class JediNeptuneEnv(BundlePackage):
     depends_on("libyaml", type="run")
     depends_on("p4est", type="run")
     depends_on("w3emc", type="run")
-    depends_on("esmf~debug", type="run")
+    depends_on("esmf", type="run")
 
     # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
@@ -27,8 +27,7 @@ class JediUfsEnv(BundlePackage):
     depends_on("sigio", type="run")
     depends_on("w3emc", type="run")
     depends_on("w3nco", type="run")
-
-    depends_on("esmf~debug", type="run")
-    depends_on("mapl~debug", type="run")
+    depends_on("esmf", type="run")
+    depends_on("mapl", type="run")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
## Description

Add `jedi-neptune-env` to support build of Navy's NEPTUNE model with JEDI.

## Testing

See https://github.com/NOAA-EMC/spack-stack/pull/575