### PR TITLE
Added -DPNG_ARM_NEON=off to cmake arguments for the darwin arm64 case.

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
-
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
@@ -48,6 +46,6 @@ class CMakeBuilder(CMakeBuilder):
             self.define("PNG_SHARED", "shared" in self.spec.variants["libs"].value),
             self.define("PNG_STATIC", "static" in self.spec.variants["libs"].value),
             ]
-        if platform.system() == "Darwin" and platform.machine() == "arm64":
+        if self.spec.satisfies("platform=darwin target=aarch64:"):
             args.append("-DPNG_ARM_NEON=off")
         return args

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import platform
+
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
@@ -38,12 +40,14 @@ class Libpng(CMakePackage):
         description="Build shared libs, static libs or both",
     )
 
-
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
-        return [
+        args = [
             self.define("CMAKE_CXX_FLAGS", self.spec["zlib"].headers.include_flags),
             self.define("ZLIB_ROOT", self.spec["zlib"].prefix),
             self.define("PNG_SHARED", "shared" in self.spec.variants["libs"].value),
             self.define("PNG_STATIC", "static" in self.spec.variants["libs"].value),
-        ]
+            ]
+        if platform.system() == "Darwin" and platform.machine() == "arm64":
+            args.append("-DPNG_ARM_NEON=off")
+        return args


### PR DESCRIPTION
The PNG_ARM_NEON feature on the Mac arm64 architecture does not compile successfully so this PR shuts that feature off but only when on the Mac arm64 architecture. Note that the PNG_ARM_NEON feature is not relevant to the Mac x86_64 (intel) architecture.

This fixes an issue (NOAA-EMC/spack-stack/issues/572) that surfaced when the NOAA-EMC/spack repo was recently sync'd up with the authoritative spack repo. This is because the libpng package.py script was changed from using Autotools to CMake, and the Autotools configuration had PNG_ARM_NEON off by default whereas the CMake configuration has PNG_ARM_NEON on by default.

Fixes NOAA-EMC/spack-stack/issues/572