### PR TITLE
Updates after move to JCSDA

### DIFF
--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -185,7 +185,7 @@ class Cdo(AutotoolsPackage):
     conflicts("%gcc@9:", when="@:1.9.6", msg="GCC 9 changed OpenMP data sharing behavior")
 
     # Internal compiler error when building with Intel 2022.1.2
-    # https://github.com/NOAA-EMC/spack-stack/issues/248
+    # https://github.com/jcsda/spack-stack/issues/248
     patch("intel-compare.patch", when="%intel")
 
     def configure_args(self):
@@ -279,7 +279,7 @@ class Cdo(AutotoolsPackage):
             flags["CPPFLAGS"].append("-DOMPI_SKIP_MPICXX -DMPICH_SKIP_MPICXX")
 
         # Workaround compiler issues
-        # https://github.com/NOAA-EMC/spack-stack/issues/468
+        # https://github.com/jcsda/spack-stack/issues/468
         if self.spec.satisfies("%intel"):
             flags["CFLAGS"].append("-O1")
             flags["CXXFLAGS"].append("-O1")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -291,7 +291,7 @@ class Esmf(MakefilePackage):
         if "+mpi" in spec:
             if "^cray-mpich" in self.spec:
                 env.set("ESMF_COMM", "mpi")
-                # https://github.com/NOAA-EMC/spack-stack/issues/517
+                # https://github.com/jcsda/spack-stack/issues/517
                 if self.spec.satisfies("@:8.4.1"):
                     env.set("ESMF_CXXLINKLIBS", "-lmpifort -lmpi")
             elif "^mvapich2" in spec:

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -93,7 +93,7 @@ class Hdf(AutotoolsPackage):
         sha256="49733dd6143be7b30a28d386701df64a72507974274f7e4c0a9e74205510ea72",
         when="@4.2.15:",
     )
-    # https://github.com/NOAA-EMC/spack-stack/issues/317
+    # https://github.com/jcsda/spack-stack/issues/317
     patch("hdfi_h_apple_m1.patch", when="@4.2.15: target=aarch64: platform=darwin")
 
     @property

--- a/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
@@ -11,8 +11,8 @@ from spack.package import *
 class BaseEnv(BundlePackage):
     """Basic development environment used by other environments"""
 
-    homepage = "https://github.com/noaa-emc/spack-stack"
-    git = "https://github.com/noaa-emc/spack-stack.git"
+    homepage = "https://github.com/jcsda/spack-stack"
+    git = "https://github.com/jcsda/spack-stack.git"
 
     maintainers("climbfuji", "AlexanderRichert-NOAA")
 

--- a/var/spack/repos/jcsda-emc-bundles/packages/ewok-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ewok-env/package.py
@@ -44,7 +44,7 @@ class EwokEnv(BundlePackage):
     # R2D2 mysql backend
     depends_on("mysql", type="run")
     # Comment out for now until build problems are solved
-    # https://github.com/NOAA-EMC/spack-stack/issues/522
+    # https://github.com/jcsda/spack-stack/issues/522
     #depends_on("py-mysql-connector-python", type="run")
 
     depends_on("solo", when="+solo", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -9,8 +9,8 @@ from spack.package import *
 class JediBaseEnv(BundlePackage):
     """Basic development environment for JEDI applications"""
 
-    homepage = "https://github.com/noaa-emc/spack-stack"
-    git = "https://github.com/noaa-emc/spack-stack.git"
+    homepage = "https://github.com/jcsda/spack-stack"
+    git = "https://github.com/jcsda/spack-stack.git"
 
     maintainers("climbfuji", "srherbener")
 


### PR DESCRIPTION
## Description

Update URL from `https://github.com/noaa-emc/spack*` to `https://github.…com/jcsda/spack*` where needed. Should be straightforward.