### PR TITLE
Update esmf, fms, & hdf5 versions

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -29,6 +29,7 @@ class Esmf(MakefilePackage):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with spack checksum esmf@x.y.z
+    version("8.4.2", sha256="969304efa518c7859567fa6e65efd960df2b4f6d72dbf2c3f29e39e4ab5ae594")
     version("8.4.1", sha256="1b54cee91aacaa9df400bd284614cbb0257e175f6f3ec9977a2d991ed8aa1af6")
     version(
         "8.4.0",

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -18,6 +18,7 @@ class Fms(CMakePackage):
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett", "rem1776")
 
+    version("2023.01", sha256="6079ea885e9365513b453c77aadfc7c305bf413b840656bb333db1eabba0f18e")
     version("2022.04", sha256="f741479128afc2b93ca8291a4c5bcdb024a8cbeda1a26bf77a236c0f629e1b03")
     version("2022.03", sha256="42d2ac53d3c889a8177a6d7a132583364c0f6e5d5cbde0d980443b6797ad4838")
     version("2022.02", sha256="ad4978302b219e11b883b2f52519e1ee455137ad947474abb316c8654f72c874")

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -44,6 +44,11 @@ class Hdf5(CMakePackage):
 
     # Even versions are maintenance versions
     version(
+        "1.14.1-2", 
+         sha256="cbe93f275d5231df28ced9549253793e40cd2b555e3d288df09d7b89a9967b07",
+         preferred=True,
+    )
+    version(
         "1.14.0",
         sha256="a571cc83efda62e1a51a0a912dd916d01895801c5025af91669484a1575a6ef4",
         preferred=True,

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
@@ -17,7 +17,7 @@ class JediUfsEnv(BundlePackage):
     version("1.0.0")
 
     depends_on("jedi-base-env", type="run")
-    depends_on("fms@2022.04+fpic", type="run")
+    depends_on("fms@2023.01+pic", type="run")
 
     depends_on("bacio", type="run")
     depends_on("g2", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-srw-app-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-srw-app-env/package.py
@@ -25,7 +25,7 @@ class UfsSrwAppEnv(BundlePackage):
     depends_on("netcdf-fortran")
     depends_on("parallelio")
     depends_on("esmf")
-    depends_on("fms@2022.04")
+    depends_on("fms@2023.01")
     depends_on("bacio")
     depends_on("crtm@2.4.0")
     depends_on("g2")

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
@@ -26,7 +26,7 @@ class UfsWeatherModelEnv(BundlePackage):
     depends_on("base-env", type="run")
     depends_on("ufs-pyenv", type="run", when="+python")
 
-    depends_on("fms@2022.04", type="run")
+    depends_on("fms@2023.01", type="run")
     depends_on("bacio", type="run")
     depends_on("crtm@2.4.0", type="run")
     depends_on("g2", type="run")


### PR DESCRIPTION
## Description

Please see https://github.com/JCSDA/spack-stack/pull/587 and https://github.com/JCSDA/spack-stack/issues/586.

Add checksums for esmf/8.4.2, fms/2023.01, and hdf5/1.14.1(-2).

Update fms version in ufs-weather-model-env package

## Definition of Done

checksums for esmf/8.4.2, fms/2023.01, and hdf5/1.14.1(-2) are added; fms version in ufs-weather-model-env package added.

### Issue(s) addressed
[spack-stack #586](https://github.com/JCSDA/spack-stack/issues/586)

## Dependencies
None




