### PR TITLE
Bug fix for building odc@1.4.6 with apple-clang@14.0.3

### DIFF
--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -37,4 +37,7 @@ class Odc(CMakePackage):
         # https://github.com/JCSDA/spack-stack/issues/585
         if self.spec.satisfies("%apple-clang@14.0.3"):
             args.append(self.define("CMAKE_C_FLAGS_RELEASE", "-O1"))
+            args.append(self.define("CMAKE_CXX_FLAGS_RELEASE", "-O1"))
+            args.append(self.define("CMAKE_C_FLAGS_RELWITHDEBINFO", "-O1"))
+            args.append(self.define("CMAKE_CXX_FLAGS_RELWITHDEBINFO", "-O1"))
         return args

--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -34,4 +34,7 @@ class Odc(CMakePackage):
             # The tests download additional data (~650MB):
             self.define("ENABLE_TESTS", self.run_tests),
         ]
+        # https://github.com/JCSDA/spack-stack/issues/585
+        if self.spec.satisfies("%apple-clang@14.0.3"):
+            args.append(self.define("CMAKE_C_FLAGS_RELEASE", "-O1"))
         return args


### PR DESCRIPTION
## Description

Fixes https://github.com/JCSDA/spack-stack/issues/585 by lowering the optimization from `-O2` to `-O1` when using `apple-clang@14.0.3`.

## Definition of Done

Tested by @srherbener on his macOS laptop (without the update, his build failed like in the issue)

### Issue(s) addressed

Fixes https://github.com/JCSDA/spack-stack/issues/585

## Dependencies

none

## Impact

none