### PR TITLE
Add ability to forcibly disable automatic finalization in fckit

### DIFF
--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -39,7 +39,9 @@ class Fckit(CMakePackage):
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant('shared', default=True)
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
-    variant('badfinal', default=False, description='Forcibly disable automatic finalization of derived types')
+    variant("finalize_ddts", default="auto",
+            description="Enable / disable automatic finalization of derived types",
+            values=("auto", "no", "yes"))
 
     def cmake_args(self):
         args = [
@@ -52,8 +54,8 @@ class Fckit(CMakePackage):
         if '~shared' in self.spec:
             args.append('-DBUILD_SHARED_LIBS=OFF')
         
-        if 'badfinal' in self.spec:
-            args.append('-DENABLE_FINAL:BOOL=OFF')
+        if 'finalize_ddts=auto' not in self.spec:
+            args.append(self.define_from_variant('ENABLE_FINAL', 'finalize_ddts'))
 
         if self.spec.satisfies('%intel') or self.spec.satisfies('%gcc'):
             cxxlib = 'stdc++'

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -39,6 +39,7 @@ class Fckit(CMakePackage):
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant('shared', default=True)
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
+    variant('badfinal', default=False, description='Forcibly disable automatic finalization of derived types')
 
     def cmake_args(self):
         args = [
@@ -50,6 +51,9 @@ class Fckit(CMakePackage):
 
         if '~shared' in self.spec:
             args.append('-DBUILD_SHARED_LIBS=OFF')
+        
+        if 'badfinal' in self.spec:
+            args.append('-DENABLE_FINAL:BOOL=OFF')
 
         if self.spec.satisfies('%intel') or self.spec.satisfies('%gcc'):
             cxxlib = 'stdc++'


### PR DESCRIPTION
## Description

fckit has an feature, `FINAL`, that enables / disables automatic finalisation for derived types (destructors). fckit normally detects if a compiler properly supports this feature, and enables / disables appropriately. Unfortunately, fckit's auto-detection logic doesn't seem to work properly with Intel's classic ifort compiler version 2021.9.0 (packaged as part of OneAPI 2023.1). `ENABLE_FINAL` defaults to ON when it should be OFF. This causes odd segmentation faults downstream in fckit-dependent code, like saber and fv3-jedi.

This PR lets you forcibly disable the `FINAL` option.

This should probably be raised as an issue in the fckit repository, but since it affects multiple versions I figure a spack patch is also helpful.