### PR TITLE
release/1.4.0: add conflict statement for hdf5@1.14.1-2 %intel +fortran

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -211,6 +211,9 @@ class Hdf5(CMakePackage):
     for plat in ["cray", "darwin", "linux"]:
         depends_on("pkgconfig", when="platform=%s" % plat, type="run")
 
+    # https://github.com/spack/spack/issues/37955
+    conflicts("+fortran", when="@1.14.1-2 %intel", msg="Fortran API broken in 1.14.1-2 with Intel")
+
     conflicts("+mpi", "^mpich@4.0:4.0.3")
     conflicts("api=v116", when="@1.6:1.14", msg="v116 is not compatible with this release")
     conflicts(


### PR DESCRIPTION
## Description

See https://github.com/spack/spack/issues/37955. This PR doesn't fix it, but it won't allow you to install hdf5@1.14.1-2 with Intel when the Fortran variant is enabled.

I tested this on a system with both GNU and Intel enabled. I asked for hdf5@1.14.1-2. The concretizer produced hdf5@1.14.1-2  for GNU, and hdf5@1.14.0 for Intel. 

Tested with https://github.com/JCSDA/spack-stack/pull/610


## Issue(s) addressed

Related to https://github.com/spack/spack/issues/37955

## Dependencies

none

## Impact

none

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
