### PR TITLE
Patches necessary to get met 11.x to compile using apple clang 14.x

### DIFF
--- a/var/spack/repos/builtin/packages/met/apple-clang-no-register.patch
+++ b/var/spack/repos/builtin/packages/met/apple-clang-no-register.patch
@@ -1,0 +1,11 @@
+--- a/src/basic/vx_util/main.cc	2023-03-31 10:07:46
++++ b/src/basic/vx_util/main.cc	2023-06-02 16:26:38
+@@ -157,7 +157,7 @@
+ 
+ void set_user_id() {
+    met_user_id = geteuid ();
+-   register struct passwd *pw;
++   struct passwd *pw;
+    pw = getpwuid (met_user_id);
+    if (pw) met_user_name = string(pw->pw_name);
+ }

--- a/var/spack/repos/builtin/packages/met/apple-clang-string-cast-operator.patch
+++ b/var/spack/repos/builtin/packages/met/apple-clang-string-cast-operator.patch
@@ -1,0 +1,20 @@
+--- a/src/basic/vx_log/concat_string.h	2023-03-31 10:07:46
++++ b/src/basic/vx_log/concat_string.h	2023-06-02 16:26:06
+@@ -146,7 +146,7 @@
+ 
+       void chomp(const char *);   //  removes trailing suffix, if possible
+ 
+-      operator const std::string () const;
++      operator std::string () const;
+ 
+       bool startswith(const char *) const;
+       bool   endswith(const char *) const;
+@@ -205,7 +205,7 @@
+ inline bool         ConcatString::empty()        const { return ( s ?  s->empty() : true ); }
+ inline bool         ConcatString::nonempty()     const { return ( s ? !s->empty() : false ); }
+ 
+-inline              ConcatString::operator const std::string () const { return ( s ? *s : 0 ); }
++inline              ConcatString::operator std::string () const { return ( s ? *s : 0 ); }
+ 
+ 
+ ////////////////////////////////////////////////////////////////////////

--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -18,6 +18,7 @@ class Met(AutotoolsPackage):
 
     maintainers('AlexanderRichert-NOAA')
 
+    version("11.0.2", sha256="f720d15e1d6c235c9a41fd97dbeb0eb1082fb8ae99e1bcdcb5e51be9b50bdfbf")
     version('11.0.1', sha256='48d471ad4634f1b969d9358c51925ce36bf0a1cec5312a6755203a4794b81646')
     version('11.0.0', sha256='648ebb54d07ca099680f4fc23b7ef5095c1a8ac5537c0a5d0e8587bf15991cff')
     version('10.1.1', sha256='9827e65fbd1c64e776525bae072bc2d37d14465e85a952778dcc32a26d8b5c9e')
@@ -58,6 +59,12 @@ class Met(AutotoolsPackage):
     depends_on('py-pandas', when='+python', type=('build', 'run'))
 
     patch('openmp_shape_patch.patch', when='@10.1.0')
+
+    # https://github.com/JCSDA/spack-stack/issues/615
+    # TODO(srherbener) Apple clang 14.x is getting pickier! When these updates are
+    # merged into the MET code base, the following two patches can be removed.
+    patch("apple-clang-string-cast-operator.patch", when="@10.1.1: %apple-clang@14:")
+    patch("apple-clang-no-register.patch", when="@10.1.1: %apple-clang@14:") 
 
     def url_for_version(self, version):
 
@@ -172,6 +179,8 @@ class Met(AutotoolsPackage):
         if '+graphics' in spec:
             args.append('--enable-mode_graphics')
 
+        if self.spec.satisfies("%apple-clang@14:"):
+            args.append('CXXFLAGS=-std=gnu++17')
         return args
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
## Description

This PR provides patches in the met package.py file that enable compilation on apple clang 14.x to successfully complete.

## Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/615

## Dependencies

None

## Impact

We may want to update https://github.com/JCSDA/spack-stack/pull/617 to use met@11.0.2 as the default package version.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR (tested on my Mac and successfully built met@11.0.2)
