### PR TITLE
Clean up CRTM for JEDI environments (load manually)

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -52,8 +52,6 @@ class Crtm(CMakePackage):
     depends_on("ecbuild", type=("build"), when="@v2.4.1-jedi")
     depends_on("ecbuild", type=("build"), when="@v3.0.0-rc.1")
 
-    version("v3.0.0-rc.1", sha256="b7f8c251168bcc3c29586ee281ed456e3115735d65167adcbcf4f69be76b933c")
-
     version("v2.4.1-jedi", sha256="fd8bf4db4f2a3b420b4186de84483ba2a36660519dffcb1e0ff14bfe8c6f6a14")
     # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
     version("2.4.0", commit="5ddd0d6")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -27,7 +27,8 @@ class JediBaseEnv(BundlePackage):
     depends_on("blas", type="run")
     depends_on("boost", type="run")
     depends_on("bufr", type="run")
-    depends_on("crtm@v2.4.1-jedi", type="run")
+    # Force users to load manually
+    #depends_on("crtm@v2.4.1-jedi", type="run")
     depends_on("ecbuild", type="run")
     depends_on("eccodes", type="run")
     depends_on("eckit", type="run")


### PR DESCRIPTION
## Description

- Remove incomplete release candidate `crtm@v3.0.0-rc.1` from package
- Remove `crtm` from `jedi-base-env`, force users to build and load separately

Tested together with https://github.com/JCSDA/spack-stack/pull/650

## Issue(s) addressed

Part of https://github.com/JCSDA/spack-stack/issues/642

## Dependencies

n/a

## Impact

See https://github.com/JCSDA/spack-stack/pull/650

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
