### PR TITLE
Request at least bison@3.4 in base-env instead of any bison in jedi-base-env

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/base-env/package.py
@@ -21,6 +21,7 @@ class BaseEnv(BundlePackage):
     # Basic utilities
     if sys.platform == "darwin":
         depends_on("libbacktrace", type="run")
+    depends_on("bison@3.4:", type="run")
     depends_on("cmake", type="run")
     depends_on("git", type="run")
     depends_on("wget", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-base-env/package.py
@@ -23,7 +23,6 @@ class JediBaseEnv(BundlePackage):
     variant("python", default=True, description="Build Python libraries")
 
     depends_on("base-env", type="run")
-    depends_on("bison", type="run")
     depends_on("blas", type="run")
     depends_on("boost", type="run")
     depends_on("bufr", type="run")


### PR DESCRIPTION
## Description

Request at least bison@3.4 in base-env instead of any bison in jedi-base-env. This should help with the duplicate versions of bison being used in spack-stack environments.
