### PR TITLE
Check user umask when running 'spack stack create env' and issue a wa…

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
@@ -172,6 +172,7 @@ def env_create(args):
     logging.debug('Creating environment from command-line args')
     stack_env = StackEnv(**stack_settings)
     stack_env.write()
+    stack_env.check_umask()
     tty.msg('Created environment {}'.format(env_dir))
 
 

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -216,3 +216,22 @@ class StackEnv(object):
         ev.deactivate()
 
         logging.info('Successfully wrote environment at {}'.format(env_file))
+
+    def check_umask(self):
+        """Check if the user's umask will create environments that are not readable
+        by group or others and if so, issue a warning.
+        """
+
+        # os.mask requires a new value for the mask and returns the old mask.
+        # The new value doesn't matter, since it is forgotten when the Python
+        # script terminates. See https://www.geeksforgeeks.org/python-os-umask-method/
+        newmask = 18 # decimal, same as 0o022 in octal
+        oldmask = os.umask(newmask)
+        if oldmask ==  18:
+            # 18 = 0o022
+            logging.info('\nChecked user umask and found no issues (0022)\n')
+        elif oldmask ==  23:
+            # 23 = 0o027
+            logging.warning('\nWARNING! User umask only allows owner and group to read the env (0027)\n')
+        else:
+            logging.warning('\nWARNING! User umask is neither 0022 nor 0027, check before proceeding\n')


### PR DESCRIPTION


## Description

Check user umask when running `spack stack create env` and issue a warning if it's not `0x022` (= `rwxr-xr-x`). No action is being taken, it's just a warning to remind the user.

## Issue(s) addressed

No issue was created for this. It should help to solve the problem of environments being created that aren't readable by users not in the group (which is what we often need due to the collaborative nature of this project) or aren't even readable by the group.

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
