### PR TITLE
Set # of ninja procs to 'make_jobs' for scipy

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -241,6 +241,7 @@ class PyScipy(PythonPackage):
             "-Cbuilddir=build",
             "--no-isolation",
             "--skip-dependency-check",
+            "-Ccompile-args=-j%s" % make_jobs,
             ".",
         ]
         python(*args)


### PR DESCRIPTION
## Description

This PR allows scipy@1.9: to build on Acorn. It was failing with "can't fork process: Resource temporarily unavailable" due to high core counts (which determine default # build jobs for ninja) and low (and unadjustable) ulimit -u values for users.

## Issue(s) addressed

none

## Dependencies

none

## Impact

none

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
