### PR TITLE
Detect external libiconv on macOS, make non-buildable

### DIFF
--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -51,7 +51,7 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
         version = None
         if match:
             version = match.group(1)
-        return version # Executable(exe)("--version", output=str, error=str)
+        return version
 
     def configure_args(self):
         args = ["--enable-extra-encodings"]

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import re
 
 from spack.package import *
 
@@ -42,10 +43,9 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
 
     @classmethod
     def determine_version(cls, exe):
-        import re
         # We only need to find libiconv on macOS to avoid problems with _iconv vs _libiconv - see
         # https://stackoverflow.com/questions/57734434/libiconv-or-iconv-undefined-symbol-on-mac-osx
-        macos_pattern = re.compile("\(GNU libiconv (\w+\.\w+)\)")
+        macos_pattern = re.compile("\(GNU libiconv (\w+\.\w+)\)")  # noqa: W605
         version_string = Executable(exe)("--version", output=str, error=str)
         match = macos_pattern.search(version_string)
         version = None

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -33,6 +33,26 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
 
     conflicts("@1.14", when="%gcc@5:")
 
+    # Don't build on Darwin to avoid problems with _iconv vs _libiconv; use native package - see
+    # https://stackoverflow.com/questions/57734434/libiconv-or-iconv-undefined-symbol-on-mac-osx
+    conflicts("platform=darwin")
+
+    # For spack external find
+    executables = ["^iconv$"]
+
+    @classmethod
+    def determine_version(cls, exe):
+        import re
+        # We only need to find libiconv on macOS to avoid problems with _iconv vs _libiconv - see
+        # https://stackoverflow.com/questions/57734434/libiconv-or-iconv-undefined-symbol-on-mac-osx
+        macos_pattern = re.compile("\(GNU libiconv (\w+\.\w+)\)")
+        version_string = Executable(exe)("--version", output=str, error=str)
+        match = macos_pattern.search(version_string)
+        version = None
+        if match:
+            version = match.group(1)
+        return version # Executable(exe)("--version", output=str, error=str)
+
     def configure_args(self):
         args = ["--enable-extra-encodings"]
 


### PR DESCRIPTION
This PR addresses the discussion in https://github.com/JCSDA/spack-stack/pull/672#issuecomment-1677523132 - if we detect an external libiconv on macOS, we can remove the hardcoded entry in the macos.default config - but need to update the macos new site instructions to include
```
spack external find libiconv
spack config add "packages:libiconv:buildable:False"
```
and possible also
```
spack config add "packages:git:buildable:False"
```
(or add the buildable-false parts to the macos.default packages yaml and only run the first command)