### PR TITLE
Minor bug fixes for new '--upstream' option of 'spack stack create env' extension

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
@@ -103,7 +103,7 @@ def setup_common_parser_args(subparser):
         "--upstream",
         nargs="*",
         action="append",
-        help="Include upstream environment (/path/to/spack-stack-x.y.z/envs/unified-env)",
+        help="Include upstream environment (/path/to/spack-stack-x.y.z/envs/unified-env/install)",
     )
 
 

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -201,9 +201,11 @@ class StackEnv(object):
         if self.upstreams:
             for upstream_path in self.upstreams:
                 upstream_path = upstream_path[0]
-                if not re.match(".+/install/*$", upstream_path):
+                # spack doesn't handle "~/" correctly, this fixes it:
+                upstream_path = os.path.expanduser(upstream_path)
+                if not os.path.basename(os.path.normpath(upstream_path)) == 'install':
                     logging.warning(
-                        "WARNING: Upstream path '%s' is not an 'install/' directory!"
+                        "WARNING: Upstream path '%s' is not an 'install' directory!"
                         % upstream_path
                     )
                 if not os.path.isdir(upstream_path):

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -203,7 +203,7 @@ class StackEnv(object):
                 upstream_path = upstream_path[0]
                 # spack doesn't handle "~/" correctly, this fixes it:
                 upstream_path = os.path.expanduser(upstream_path)
-                if not os.path.basename(os.path.normpath(upstream_path)) == 'install':
+                if not os.path.basename(os.path.normpath(upstream_path)) == "install":
                     logging.warning(
                         "WARNING: Upstream path '%s' is not an 'install' directory!"
                         % upstream_path


### PR DESCRIPTION
## Description

Minor bug fixes for new '--upstream' option of 'spack stack create env' extension to expand `~` correcrlt, suppress erroneous warnings that the upstream directory does not exist, and fix inconsistencies between the help message and what the argument should be (must have the `/install` included).

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation - **Not yet, documentation updates (which are necessary anyway, even w/o the changes in this PR) will be made in a spack-stack PR that handles the submodule pointer update for this PR**
- [ ] I have run the unit tests before creating the PR
