### PR TITLE
Adding myst-parser to jedi-tools-env

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
@@ -21,8 +21,8 @@ class JediToolsEnv(BundlePackage):
     # Don't install awscli and/or aws-parallelcluster via spack,
     # they are not well maintained packages and have terrible
     # dependencies. Use a venv on top of spack-stack instead.
-    #depends_on("awscli", type="run")
-    #depends_on("aws-parallelcluster", type="run")
+    # depends_on("awscli", type="run")
+    # depends_on("aws-parallelcluster", type="run")
     depends_on("py-click", type="run")
     depends_on("py-openpyxl", type="run")
     depends_on("py-pandas", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
@@ -29,7 +29,8 @@ class JediToolsEnv(BundlePackage):
     depends_on("py-pygithub", type="run")
     depends_on("py-scipy", type="run")
     depends_on("py-sphinx", type="run")
-    depends_on("py-sphinxcontrib-bibtex", when="+latex", type="run")
+    depends_on("py-myst-parser", type="run")
+    depends_on("py-sphinxcontrib-bibtex", type="run")
     depends_on("texlive", when="+latex", type="run")
 
     conflicts("%intel", msg="jedi-tools-env does not build with Intel")


### PR DESCRIPTION
## Description

myst-parser is needed for Sphinx to build the JEDI documentation

## Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/234

## Dependencies

None

## Impact

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
