### PR TITLE
Fix macOS rpath for parallelio, add sfcio to jedi-ufs-env, add gsibec@1.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/gsibec/package.py
+++ b/var/spack/repos/builtin/packages/gsibec/package.py
@@ -18,6 +18,7 @@ class Gsibec(CMakePackage):
     maintainers("mathomp4", "danholdaway")
 
     version("develop", branch="develop")
+    version("1.1.3", sha256="9cac000562250487c16608e8245d97457cc1663b1793b3833be5a76ebccb4b47")
     version("1.1.2", sha256="8bdcdf1663e6071b6ad9e893a76307abc70a6de744fb75a13986e70242993ada")
     version("1.0.7", sha256="53912f1f19d46f4941b377803cc2fce89a2b50d2ece7562f8fd65215a8908158")
     version("1.0.6", sha256="10e2561685156bcfba35c7799732c77f9c05bd180888506a339540777db833dd")
@@ -40,7 +41,5 @@ class Gsibec(CMakePackage):
     depends_on("sp", type=("build"))
 
     def cmake_args(self):
-        args = [
-            self.define_from_variant("ENABLE_MKL", "mkl"),
-        ]
+        args = [self.define_from_variant("ENABLE_MKL", "mkl")]
         return args

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -105,3 +105,9 @@ class Parallelio(CMakePackage):
             if self.spec.satisfies("+pnetcdf"):
                 valid_values += ",pnetcdf"
         env.set("PIO_TYPENAME_VALID_VALUES", valid_values)
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
@@ -24,6 +24,7 @@ class JediUfsEnv(BundlePackage):
     depends_on("g2tmpl", type="run")
     depends_on("ip", type="run")
     depends_on("nemsio", type="run")
+    depends_on("sfcio", type="run")
     depends_on("sigio", type="run")
     depends_on("w3emc", type="run")
     depends_on("w3nco", type="run")


### PR DESCRIPTION
## Description

Fix macOS `rpath` for `parallelio` using spack internals, add `sfcio` to `jedi-ufs-env` for building `UFS-UTILS`, and add latest release of `gsibec` (1.1.3).

## Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/730
Resolves https://github.com/JCSDA/spack-stack/issues/551

## Dependencies

n/a

## Impact

The parallelio update fixes a problem on macOS that occurred whenever parallelio was linked into an application. The jedi-ufs-env changes are trivial and mean that it is no longer required to load sfcio manually after jedi-ufs-env was loaded.

For parallelio: I checked the builds before and after (just showing `libpiof.dylib` here, but it's the same for the C library).

**Before**
```
> otool -L /Users/heinzell/work/spack-stack/spack-stack-update-from-spack-dev-20230710/envs/unified-env-arch64/install/apple-clang/13.1.6/parallelio-2.5.9-6luhvew/lib/libpiof.dylib 
/Users/heinzell/work/spack-stack/spack-stack-update-from-spack-dev-20230710/envs/unified-env-arch64/install/apple-clang/13.1.6/parallelio-2.5.9-6luhvew/lib/libpiof.dylib:
	libpiof.dylib (compatibility version 0.0.0, current version 0.0.0)
	libpioc.dylib (compatibility version 0.0.0, current version 0.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-update-from-spack-dev-20230710/envs/unified-env-arch64/install/apple-clang/13.1.6/netcdf-fortran-4.6.0-75oz7dx/lib/libnetcdff.7.dylib (compatibility version 9.0.0, current version 9.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-update-from-spack-dev-20230710/envs/unified-env-arch64/install/apple-clang/13.1.6/netcdf-c-4.9.2-24wbze4/lib/libnetcdf.19.dylib (compatibility version 22.0.0, current version 22.2.0)
	/Users/heinzell/work/spack-stack/spack-stack-update-from-spack-dev-20230710/envs/unified-env-arch64/install/apple-clang/13.1.6/parallel-netcdf-1.12.2-4bp4iay/lib/libpnetcdf.4.dylib (compatibility version 5.0.0, current version 5.2.0)
	/Users/heinzell/work/spack-stack/spack-stack-update-from-spack-dev-20230710/envs/unified-env-arch64/install/apple-clang/13.1.6/openmpi-4.1.5-gdavfot/lib/libmpi_usempif08.40.dylib (compatibility version 71.0.0, current version 71.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-update-from-spack-dev-20230710/envs/unified-env-arch64/install/apple-clang/13.1.6/openmpi-4.1.5-gdavfot/lib/libmpi_usempi_ignore_tkr.40.dylib (compatibility version 71.0.0, current version 71.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-update-from-spack-dev-20230710/envs/unified-env-arch64/install/apple-clang/13.1.6/openmpi-4.1.5-gdavfot/lib/libmpi_mpifh.40.dylib (compatibility version 71.0.0, current version 71.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-update-from-spack-dev-20230710/envs/unified-env-arch64/install/apple-clang/13.1.6/openmpi-4.1.5-gdavfot/lib/libmpi.40.dylib (compatibility version 71.0.0, current version 71.5.0)
	/opt/homebrew/opt/gcc@12/lib/gcc/12/libgfortran.5.dylib (compatibility version 6.0.0, current version 6.0.0)
	/opt/homebrew/opt/gcc@12/lib/gcc/12/libquadmath.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
```
**After**
```
> otool -L /Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/parallelio-2.5.10-6oajinw/lib/libpiof.dylib 
/Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/parallelio-2.5.10-6oajinw/lib/libpiof.dylib:
	/Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/parallelio-2.5.10-6oajinw/lib/libpiof.dylib (compatibility version 0.0.0, current version 0.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/parallelio-2.5.10-6oajinw/lib/libpioc.dylib (compatibility version 0.0.0, current version 0.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/netcdf-fortran-4.6.0-myzkp7r/lib/libnetcdff.7.dylib (compatibility version 9.0.0, current version 9.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/netcdf-c-4.9.2-yar3nps/lib/libnetcdf.19.dylib (compatibility version 22.0.0, current version 22.2.0)
	/Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/parallel-netcdf-1.12.2-suwuzsl/lib/libpnetcdf.4.dylib (compatibility version 5.0.0, current version 5.2.0)
	/Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/openmpi-4.1.5-2ljd2ep/lib/libmpi_usempif08.40.dylib (compatibility version 71.0.0, current version 71.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/openmpi-4.1.5-2ljd2ep/lib/libmpi_usempi_ignore_tkr.40.dylib (compatibility version 71.0.0, current version 71.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/openmpi-4.1.5-2ljd2ep/lib/libmpi_mpifh.40.dylib (compatibility version 71.0.0, current version 71.0.0)
	/Users/heinzell/work/spack-stack/spack-stack-sfcio-piolib/envs/unified-env/install/apple-clang/13.1.6/openmpi-4.1.5-2ljd2ep/lib/libmpi.40.dylib (compatibility version 71.0.0, current version 71.5.0)
	/opt/homebrew/opt/gcc@12/lib/gcc/12/libgfortran.5.dylib (compatibility version 6.0.0, current version 6.0.0)
	/opt/homebrew/opt/gcc@12/lib/gcc/12/libquadmath.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
