### PR TITLE
Add py-globus-cli package, new version py-globus-sdk, fix 'spack stack setup-meta-modules' for no MPI

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/meta_modules.py
+++ b/lib/jcsda-emc/spack-stack/stack/meta_modules.py
@@ -297,8 +297,13 @@ def setup_meta_modules():
     # Then, check for mpi providers - recursively for compilers
     mpi_dict = get_matched_dict(module_dir, mpi_candidate_list, compiler_candidate_list)
     if not mpi_dict:
-        raise Exception("No matching MPI providers found")
-    logging.info(" ... stack mpi providers: '{}'".format(mpi_dict))
+        user_input = input(
+            "No matching MPI providers found, proceed without creating MPI module hierarchy? (yes/no): "
+        )
+        if not user_input.lower() in ["yes", "y"]:
+            raise Exception("No matching MPI providers found")
+    else:
+        logging.info(" ... stack mpi providers: '{}'".format(mpi_dict))
 
     # For some environments, there are only compiler+mpi-dependent modules,
     # and therefore the compiler itself is not recorded in compiler_dict.
@@ -698,7 +703,10 @@ def setup_meta_modules():
                         f.write(module_content)
                     logging.info("  ... writing {}".format(mpi_module_file))
 
-    del package_name
+    try:
+        del package_name
+    except:
+        pass
     # Create python modules. Need to accommodate both external
     # Python distributions and spack-built Python distributions.
     # If there is no package config info for Python, then we are

--- a/var/spack/repos/builtin/packages/py-globus-cli/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-cli/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyGlobusCli(PythonPackage):
+    """Globus CLI is a standalone application that can be installed on the user’s machine and is used to access the Globus service. The CLI provides an interface to Globus services from the shell, and is suited to both interactive and simple scripting use cases."""
+
+    homepage = "https://docs.globus.org/cli"
+    git = "https://github.com/globus/globus-cli.git"
+    url = "https://github.com/globus/globus-cli/archive/refs/tags/3.16.0.zip"
+
+    maintainers("climbfuji")
+
+    version("3.16.0", sha256="0ef721060870d9346505e52b9bf30c7bed6ae136cc08762deb2f8893bd25d8c5")
+
+    depends_on("python@3.7:3.10", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-globus-sdk@3.25.0", type=("build", "run"))
+    depends_on("py-click@8", type=("build", "run"))
+    depends_on("py-jmespath@1.0.1", type=("build", "run"))
+    depends_on("py-packaging@17:", type=("build", "run"))
+    # According to the developers, these requirements are implicit
+    # for py-globus-sdk, but they are listed explicitly "in case
+    # the underlying lib ever changes"
+    depends_on("py-requests@2.19.1:2", type=("build", "run"))
+    depends_on("py-pyjwt@2.0.0:2+crypto", type=("build", "run"))
+    depends_on("py-cryptography@3.3.1:", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-globus-cli/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-cli/package.py
@@ -8,7 +8,9 @@ from spack.package import *
 
 
 class PyGlobusCli(PythonPackage):
-    """Globus CLI is a standalone application that can be installed on the user’s machine and is used to access the Globus service. The CLI provides an interface to Globus services from the shell, and is suited to both interactive and simple scripting use cases."""
+    """Globus CLI is a standalone application that can be installed on the user’s machine
+    and is used to access the Globus service. The CLI provides an interface to Globus
+    services from the shell, and is suited to both interactive and simple scripting use cases."""
 
     homepage = "https://docs.globus.org/cli"
     git = "https://github.com/globus/globus-cli.git"

--- a/var/spack/repos/builtin/packages/py-globus-sdk/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-sdk/package.py
@@ -15,8 +15,9 @@ class PyGlobusSdk(PythonPackage):
     homepage = "https://github.com/globus/globus-sdk-python"
     pypi = "globus-sdk/globus-sdk-3.0.2.tar.gz"
 
-    maintainers("hategan")
+    maintainers("hategan", "climbfuji")
 
+    version("3.25.0", sha256="d9be275d4ec18054db04732f75649c4227800c79b31fbcfb3f4f31eccfa5f4f7")
     version("3.10.1", sha256="c20fec55fc7e099f4d0c8224a36e194604577539445c5985cb465b23779baee8")
     version("3.10.0", sha256="7a7e7cd5cfbc40c6dc75bdb92b050c4191f992b5f7081cd08895bf119fd97bbf")
     version("3.9.0", sha256="456f707b25a8c502607134f1d699b5970ef1aa9d17877474db73fc6d87c711e9")
@@ -30,3 +31,4 @@ class PyGlobusSdk(PythonPackage):
     depends_on("py-pyjwt@2.0.0:2+crypto", type=("build", "run"))
     depends_on("py-cryptography@3.3.1:3.3,3.4.1:", when="@3.7:", type=("build", "run"))
     depends_on("py-cryptography@2:3.3,3.4.1:3.6", when="@:3.0", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", when="@3.25:", type=("build", "run"))

--- a/var/spack/repos/jcsda-emc-bundles/packages/ewok-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ewok-env/package.py
@@ -34,6 +34,7 @@ class EwokEnv(BundlePackage):
     depends_on("py-boto3", type="run")
     depends_on("py-cartopy", type="run")
     depends_on("py-gitpython", type="run")
+    depends_in("py-globus-cli", type="run")
     depends_on("py-jinja2", type="run")
     depends_on("py-ruamel-yaml", type="run")
     depends_on("py-ruamel-yaml-clib", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/ewok-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ewok-env/package.py
@@ -34,7 +34,7 @@ class EwokEnv(BundlePackage):
     depends_on("py-boto3", type="run")
     depends_on("py-cartopy", type="run")
     depends_on("py-gitpython", type="run")
-    depends_in("py-globus-cli", type="run")
+    depends_on("py-globus-cli", type="run")
     depends_on("py-jinja2", type="run")
     depends_on("py-ruamel-yaml", type="run")
     depends_on("py-ruamel-yaml-clib", type="run")
@@ -46,7 +46,7 @@ class EwokEnv(BundlePackage):
     depends_on("mysql", type="run")
     # Comment out for now until build problems are solved
     # https://github.com/jcsda/spack-stack/issues/522
-    #depends_on("py-mysql-connector-python", type="run")
+    # depends_on("py-mysql-connector-python", type="run")
 
     depends_on("solo", when="+solo", type="run")
     depends_on("r2d2", when="+r2d2", type="run")


### PR DESCRIPTION
## Description

- Add `py-globus-cli` package and add a new version `py-globus-sdk`, required by `py-globus-cli`; add `py-globus-cli` to `ewok-env`
- Fix `spack stack setup-meta-modules` when environment contains no MPI libraries

Tested as part of https://github.com/JCSDA/spack-stack/pull/744.

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/665
Fixes https://github.com/JCSDA/spack-stack/issues/742

## Dependencies

n/a

## Impact

We need to test this on a few platforms to make sure that the new packages build everywhere and don't break existing code / lead to duplicate packages.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
