### PR TITLE
Fix BUFR_INC variables for bufr recipe & add MADIS 4.5

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -90,7 +90,7 @@ class Bufr(CMakePackage):
         lib = find_libraries(libname + append, root=self.prefix, shared=shared, recursive=True)
         lib_envname = "BUFR_LIB{0}".format(suffix) + append
         inc_envname = "BUFR_INC{0}".format(suffix) + append
-        include_dir = "include_{0}".format(suffix)
+        include_dir = "{0}{1}".format(self.prefix.include.bufr, suffix)
 
         env.set(lib_envname, lib[0])
         env.set(inc_envname, include_dir)

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -90,7 +90,7 @@ class Bufr(CMakePackage):
         lib = find_libraries(libname + append, root=self.prefix, shared=shared, recursive=True)
         lib_envname = "BUFR_LIB{0}".format(suffix) + append
         inc_envname = "BUFR_INC{0}".format(suffix) + append
-        include_dir = "{0}{1}".format(self.prefix.include.bufr, suffix)
+        include_dir = "{0}_{1}".format(self.prefix.include.bufr, suffix)
 
         env.set(lib_envname, lib[0])
         env.set(inc_envname, include_dir)

--- a/var/spack/repos/builtin/packages/madis/package.py
+++ b/var/spack/repos/builtin/packages/madis/package.py
@@ -21,6 +21,7 @@ class Madis(MakefilePackage):
 
     maintainers("AlexanderRichert-NOAA")
 
+    version("4.5", sha256="66376c72ade6b06a5392ad8b4b7a338efbf4d82ff6f7f33648ca316738808e6f")
     version("4.3", sha256="5d1ee9800c84e623dcf4271653aa66d17a744143e58354e70f8a0646cd6b246c")
 
     variant("pic", default=True, description="Build with position-independent code (PIC)")
@@ -32,20 +33,21 @@ class Madis(MakefilePackage):
     def setup_build_environment(self, env):
         fflags = []
         if self.spec.satisfies("%gcc@10:"):
-            fflags += ["-fallow-argument-mismatch"]
+            fflags.append("-fallow-argument-mismatch")
 
         if self.spec.satisfies("+pic"):
-            fflags += ["-fPIC"]
+            fflags.append("-fPIC")
 
         env.set("FFLAGS", " ".join(fflags))
 
         ldflags = []
-        libs = []
 
         if self.spec.satisfies("+pnetcdf"):
+            libs = []
             pnetcdf = self.spec["parallel-netcdf"]
             ldflags.append(pnetcdf.libs.ld_flags)
             libs.append(pnetcdf.libs.link_flags)
+            env.set("LIBS", " ".join(libs))
 
         nfconfig = which(os.path.join(self.spec["netcdf-fortran"].prefix.bin, "nf-config"))
         ldflags.append(nfconfig("--flibs", output=str).strip())
@@ -53,7 +55,6 @@ class Madis(MakefilePackage):
         env.set("NETCDF_INC", netcdf_f.prefix.include)
 
         env.set("NETCDF_LIB", " ".join(ldflags))
-        env.set("LIBS", " ".join(libs))
 
     def build(self, spec, prefix):
         with working_dir("src"):


### PR DESCRIPTION
Currently the BUFR_INC variables set in setup_run_environment are incorrect. This PR corrects them (needs the full path, not just the word "include"...), and also adds madis@4.5.