### PR TITLE
madis: allow arg mismatch for apple-clang

### DIFF
--- a/var/spack/repos/builtin/packages/madis/package.py
+++ b/var/spack/repos/builtin/packages/madis/package.py
@@ -32,7 +32,7 @@ class Madis(MakefilePackage):
 
     def setup_build_environment(self, env):
         fflags = []
-        if self.spec.satisfies("%gcc@10:"):
+        if self.spec.satisfies("%gcc@10:") or self.spec.satisfies("%apple-clang"):
             fflags.append("-fallow-argument-mismatch")
 
         if self.spec.satisfies("+pic"):

--- a/var/spack/repos/builtin/packages/madis/package.py
+++ b/var/spack/repos/builtin/packages/madis/package.py
@@ -32,8 +32,16 @@ class Madis(MakefilePackage):
 
     def setup_build_environment(self, env):
         fflags = []
-        if self.spec.satisfies("%gcc@10:") or self.spec.satisfies("%apple-clang"):
-            fflags.append("-fallow-argument-mismatch")
+
+        if self.compiler.name in ["gcc", "clang", "apple-clang"]:
+            with self.compiler.compiler_environment():
+                gfortran_major_version = int(
+                    spack.compiler.get_compiler_version_output(
+                        self.compiler.fc, "-dumpversion"
+                    ).split(".")[0]
+                )
+            if gfortran_major_version >= 10:
+                fflags.append("-fallow-argument-mismatch")
 
         if self.spec.satisfies("+pic"):
             fflags.append("-fPIC")


### PR DESCRIPTION
Allow arg mismatch when compiling madis with apple-clang. For https://github.com/JCSDA/spack-stack/pull/743 (where it's been successfully tested)