### PR TITLE
mapl: Fix pflogger dependency (cherry-picking #39683 from spack/develop)

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -204,9 +204,9 @@ class Mapl(CMakePackage):
 
     # pFlogger depends on yaFyaml in the same way. MAPL 2.22 and below uses old
     # yaFyaml so we need to use old pFlogger, but MAPL 2.23+ uses new yaFyaml
-    depends_on("pflogger@:1.6", when="@:2.22+pflogger")
-    depends_on("pflogger@1.9.1:", when="@2.23:2.39+pflogger")
-    depends_on("pflogger@1.9.5:", when="@2.40:+pflogger")
+    depends_on("pflogger@:1.6 +mpi", when="@:2.22+pflogger")
+    depends_on("pflogger@1.9.1: +mpi", when="@2.23:2.39+pflogger")
+    depends_on("pflogger@1.9.5: +mpi", when="@2.40:+pflogger")
 
     # fArgParse v1.4.1 is the first usable version with MAPL
     # we now require 1.5.0 with MAPL 2.40+


### PR DESCRIPTION
## Description

All in the title. Required (but maybe not sufficient?) to fix https://github.com/JCSDA/spack-stack/issues/754. See https://github.com/spack/spack/pull/39683/ for more information.

## Issue(s) addressed

Working towards (?) https://github.com/JCSDA/spack-stack/issues/754

## Dependencies

n/a

## Impact

May be able to enable `pflogger` variant for `mapl` (check CI tests in https://github.com/JCSDA/spack-stack/pull/752).

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
