### PR TITLE
Bug fixes for libjpeg-turbo, hdf (hdf4), and hdf-eos2 to enable graphics variants in MET

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -197,6 +197,10 @@ class Hdf(AutotoolsPackage):
 
     extra_install_tests = join_path("hdf", "util", "testfiles")
 
+    # Filter h4cc compiler wrapper to substitute the Spack compiler
+    # wrappers with the path of the underlying compilers.
+    filter_compiler_wrappers("h4cc", relative_root="bin")
+
     @property
     def cached_tests_work_dir(self):
         """The working directory for cached test sources."""

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -96,5 +96,5 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     @run_after("install")
     def darwin_fix(self):
         # The shared library is not installed correctly on Darwin; fix this
-        if self.spec.satisfies("platform=darwin"):
+        if self.spec.satisfies("platform=darwin") and ("+shared" in self.spec):
             fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -92,3 +92,9 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         ]
 
         return args
+
+    @run_after("install")
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies("platform=darwin"):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
## Description

Three small bug fixes that I will cherry-pick and send to spack upstream separately:
- Fix the wrong install name on macOS systems in `libjpeg-turbo` as we've done multiple times for other packages.
- Replace spack compiler wrappers with underlying compilers in `h4cc` wrapper in `hdf` (solution stolen from another package). Turns out this opens a can of worms for poorly configured packages using `h4cc`, see next item.
- Fix permissions for file `configure` in `hdf-eos2` so that `filter_file` can operate on the file (solution stolen from another package), and make the dependencies match those hard-coded in `hdf` (necessary, because of the way `hdf-eos2` is built using the `h4cc` compiler wrapper).

spack PRs:
- [x] https://github.com/spack/spack/pull/39834
- [x] https://github.com/spack/spack/pull/39870
- [x] https://github.com/spack/spack/pull/39877

## Testing

Tested as part of https://github.com/JCSDA/spack-stack/pull/760

## Issues

See https://github.com/JCSDA/spack-stack/pull/760