### PR TITLE
Update py-globus-cli package.py

### DIFF
--- a/var/spack/repos/builtin/packages/py-globus-cli/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-cli/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 
 class PyGlobusCli(PythonPackage):
-    """Globus CLI is a standalone application that can be installed on the user’s machine
+    """Globus CLI is a standalone application that can be installed on the user's machine
     and is used to access the Globus service. The CLI provides an interface to Globus
     services from the shell, and is suited to both interactive and simple scripting use cases."""
 


### PR DESCRIPTION
The apostrophe in the package description is not a valid ascii character and, interestingly, causes concretization to fail on my machine when it's part of a spec :)