### PR TITLE
Enable use of tcl modules on lmod systems, especially on macOS

### DIFF
--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -38,7 +38,14 @@ class TestTcl:
         content = modulefile_content(mpileaks_spec_string)
 
         assert (
-            len([x for x in content if "if {![info exists ::env(LMOD_VERSION_MAJOR)]} {" in x])
+            len(
+                [
+                    x
+                    for x in content
+                    if "if {![info exists ::env(LMOD_VERSION_MAJOR)] && ![info exists ::env(LMOD_VERSION)]} {"  # noqa: E501
+                    in x
+                ]
+            )
             == 1
         )
         assert len([x for x in content if "depends-on " in x]) == 2
@@ -52,7 +59,14 @@ class TestTcl:
         content = modulefile_content("dtbuild1")
 
         assert (
-            len([x for x in content if "if {![info exists ::env(LMOD_VERSION_MAJOR)]} {" in x])
+            len(
+                [
+                    x
+                    for x in content
+                    if "if {![info exists ::env(LMOD_VERSION_MAJOR)] && ![info exists ::env(LMOD_VERSION)]} {"  # noqa: E501
+                    in x
+                ]
+            )
             == 1
         )
         assert len([x for x in content if "depends-on " in x]) == 2
@@ -69,7 +83,14 @@ class TestTcl:
         content = modulefile_content(mpileaks_spec_string)
 
         assert (
-            len([x for x in content if "if {![info exists ::env(LMOD_VERSION_MAJOR)]} {" in x])
+            len(
+                [
+                    x
+                    for x in content
+                    if "if {![info exists ::env(LMOD_VERSION_MAJOR)] && ![info exists ::env(LMOD_VERSION)]} {"  # noqa: E501
+                    in x
+                ]
+            )
             == 1
         )
         assert len([x for x in content if "depends-on " in x]) == 5
@@ -83,7 +104,14 @@ class TestTcl:
         content = modulefile_content("dtbuild1")
 
         assert (
-            len([x for x in content if "if {![info exists ::env(LMOD_VERSION_MAJOR)]} {" in x])
+            len(
+                [
+                    x
+                    for x in content
+                    if "if {![info exists ::env(LMOD_VERSION_MAJOR)] && ![info exists ::env(LMOD_VERSION)]} {"  # noqa: E501
+                    in x
+                ]
+            )
             == 1
         )
         assert len([x for x in content if "depends-on " in x]) == 2
@@ -476,7 +504,14 @@ class TestTcl:
         # Test the mpileaks that should NOT have the autoloaded dependencies
         content = modulefile_content("mpileaks ^mpich")
         assert (
-            len([x for x in content if "if {![info exists ::env(LMOD_VERSION_MAJOR)]} {" in x])
+            len(
+                [
+                    x
+                    for x in content
+                    if "if {![info exists ::env(LMOD_VERSION_MAJOR)] && ![info exists ::env(LMOD_VERSION)]} {"  # noqa: E501
+                    in x
+                ]
+            )
             == 0
         )
         assert len([x for x in content if "depends-on " in x]) == 0

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -27,7 +27,7 @@ proc ModulesHelp { } {
 
 {% block autoloads %}
 {% if autoload|length > 0 %}
-if {![info exists ::env(LMOD_VERSION_MAJOR)]} {
+if {![info exists ::env(LMOD_VERSION_MAJOR)] && ![info exists ::env(LMOD_VERSION)]} {
 {% for module in autoload %}
     module load {{ module }}
 {% endfor %}


### PR DESCRIPTION
## Description

See https://github.com/JCSDA/spack-stack/issues/761 for background. Some systems running `lmod`, including my macOS, have only the environment variable `LMOD_VERSION` set, not `LMOD_VERSION_MAJOR`. The change to share/spack/templates/modules/modulefile.tcl allows to detect both. I will send this change up to mainline spack as well.

- n/a ~~spack PR: https://github.com/spack/spack/pull/39859~~ - based on the discussion in the PR, the change to the spack tcl modulefile template isn't necessary, the bug fix for the `setup-meta-modules` extension was sufficient.

The change in `lib/jcsda-emc/spack-stack/stack/meta_modules.py` enables `tcl` modules on macOS and simplifies the code.

## Testing

See https://github.com/JCSDA/spack-stack/pull/762