### PR TITLE
(release/1.5.0) Add grib_util 1.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/grib-util/package.py
+++ b/var/spack/repos/builtin/packages/grib-util/package.py
@@ -27,6 +27,7 @@ class GribUtil(CMakePackage):
     depends_on("libpng")
     depends_on("zlib")
     depends_on("w3emc", when="@1.2.4:")
+    depends_on("w3emc@2.10:", when="@1.3:")
     depends_on("w3nco", when="@:1.2.3")
     depends_on("g2")
     depends_on("bacio")

--- a/var/spack/repos/builtin/packages/grib-util/package.py
+++ b/var/spack/repos/builtin/packages/grib-util/package.py
@@ -13,9 +13,11 @@ class GribUtil(CMakePackage):
 
     homepage = "https://github.com/NOAA-EMC/NCEPLIBS-grib_util"
     url = "https://github.com/NOAA-EMC/NCEPLIBS-grib_util/archive/refs/tags/v1.2.3.tar.gz"
+    git = "https://github.com/NOAA-EMC/NCEPLIBS-grib_util"
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
+    version("1.3.0", commit="9d3c68a")
     version("1.2.4", sha256="f021d6df3186890b0b1781616dabf953581d71db63e7c2913360336985ccaec7")
     version("1.2.3", sha256="b17b08e12360bb8ad01298e615f1b4198e304b0443b6db35fe990a817e648ad5")
 
@@ -28,7 +30,8 @@ class GribUtil(CMakePackage):
     depends_on("w3nco", when="@:1.2.3")
     depends_on("g2")
     depends_on("bacio")
-    depends_on("ip@:3.3.3")
+    depends_on("ip")
+    depends_on("ip@:3.3.3", when="@:1.2")
     depends_on("sp")
 
     def cmake_args(self):


### PR DESCRIPTION
This PR adds grib-util v1.3.0 and updates the dependencies. We can change the commit to a sha256sum once the official release is out. Tested installing on personal machine with g2@3.4.5 and ip@4.1.0; unit tests pass.