### PR TITLE
release/1.5.0: Bug fix for spack stack setup-meta-modules extension when no Python is built/used

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/meta_modules.py
+++ b/lib/jcsda-emc/spack-stack/stack/meta_modules.py
@@ -750,10 +750,21 @@ Python, list the correct version in the package config"""
                     python_dict = get_matched_dict(compiler_install_dir, python_candidate_list)
             logging.info(" ... stack python providers: '{}'".format(python_dict))
             if not python_dict:
-                raise Exception(
-                    """No matching Python version found. Make sure that the
-Python version in the package config matches what spack installed."""
+                user_input = input(
+                    "No matching Python version found found, proceed without creating Python modules? (yes/no): "
                 )
+                if not user_input.lower() in ["yes", "y"]:
+                    raise Exception(
+                        """"No matching Python version found. Make sure that the
+Python version in the package config matches what spack installed."""
+                    )
+                else:
+                    logging.info(
+                        "Metamodule generation completed successfully in {}".format(
+                            meta_module_dir
+                        )
+                    )
+                    return
 
     for compiler_name in compiler_dict.keys():
         for compiler_version in compiler_dict[compiler_name]:


### PR DESCRIPTION
## Description

This bug fix for the `spack stack setup-meta-modules` extension allows the user to proceed when no Python is built/used. This is becoming relevant for us when using spack environment chaining for testing/installing new packages for the UFS, for example.

Tested on my macOS.

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
