### PR TITLE
Add ip 4.3.0 for constants_mod issue

### DIFF
--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -16,6 +16,9 @@ class Ip(CMakePackage):
 
     maintainers("t-brown", "AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
 
+    version("4.3.0", sha256="799308a868dea889d2527d96a0405af7b376869581410fe4cff681205e9212b4")
+    # Note that versions 4.0-4.2 contain constants_mod module, and should not be used when
+    # also compiling with packages containing Fortran modules of the same name, namely, FMS.
     version("4.1.0", sha256="b83ca037d9a5ad3eb0fb1acfe665c38b51e01f6bd73ce9fb8bb2a14f5f63cdbe")
     version("4.0.0", sha256="a2ef0cc4e4012f9cb0389fab6097407f4c623eb49772d96eb80c44f804aa86b8")
     version(


### PR DESCRIPTION
## Description

This PR adds ip v4.3.0, which renames constants_mod to ip_constants_mod.

## Issue(s) addressed

Related to https://github.com/NOAA-EMC/NCEPLIBS-ip/issues/197

## Dependencies

none

## Impact

--

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
