### PR TITLE
Add yafyaml to srw env

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-srw-app-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-srw-app-env/package.py
@@ -48,5 +48,6 @@ class UfsSrwAppEnv(BundlePackage):
     depends_on("metplus")
     depends_on("mapl")
     depends_on("ncio")
+    depends_on("yafyaml")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
title says it all (thanks to @climbfuji + @mark-a-potts for pointing this out)

yafyaml was only being built as a dependency of the ufs-wm, but it is actually required by the srw, so it should be added to the virtual env.