### PR TITLE
release/1.5.0: bug fix for ESMF: turn off OpenMP for both clang and apple-clang

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -222,6 +222,11 @@ class Esmf(MakefilePackage):
         elif self.compiler.name == "intel" or self.compiler.name == "oneapi":
             env.set("ESMF_COMPILER", "intel")
         elif self.compiler.name in ["clang", "apple-clang"]:
+            # Turn off OpenMP with both versions of clang compilers
+            # to avoid having to add clang OpenMP libraries to the
+            # Fortran linker command.
+            env.set("ESMF_OPENMP", "OFF")
+            #
             env.set("ESMF_COMPILER", "gfortranclang")
             with self.compiler.compiler_environment():
                 gfortran_major_version = int(


### PR DESCRIPTION
## Description

Compiling in a Ubuntu container with the Clang C/C++ compiler and the GNU Fortran compiler leads to the following error:
```
     4717    /opt/mpich-4.1.1/bin/mpif90     -m64 -mcmodel=small -pthread -Wl,--no-as-needed  -fopenmp -L/opt/software/linux-ubuntu20.04-x86_64/clang-10.0.0/esmf-8.5.0-i5ehyuwegkljye4334sazsoxmdljmbye/lib -L/opt/software/linux-ubuntu20.0
             4-x86_64/clang-10.0.0/netcdf-c-4.9.2-kb2svf7fbkatgiq4d6zue2ytagtij3pq/lib -L/opt/software/linux-ubuntu20.04-x86_64/clang-10.0.0/netcdf-fortran-4.6.0-xy3iku7aq6sq2xrrqmekaodik447vzns/lib -L/opt/software/linux-ubuntu20.04-x86_
             64/clang-10.0.0/parallelio-2.5.10-5cwpzpf65ptuqrrh2xo77gziuwijbech/lib -L/usr/bin/../lib/gcc/x86_64-linux-gnu/10/ -Wl,-rpath,/opt/software/linux-ubuntu20.04-x86_64/clang-10.0.0/esmf-8.5.0-i5ehyuwegkljye4334sazsoxmdljmbye/lib
              -Wl,-rpath,/opt/software/linux-ubuntu20.04-x86_64/clang-10.0.0/netcdf-c-4.9.2-kb2svf7fbkatgiq4d6zue2ytagtij3pq/lib -Wl,-rpath,/opt/software/linux-ubuntu20.04-x86_64/clang-10.0.0/netcdf-fortran-4.6.0-xy3iku7aq6sq2xrrqmekaodi
             k447vzns/lib  -Wl,-rpath,/opt/software/linux-ubuntu20.04-x86_64/clang-10.0.0/parallelio-2.5.10-5cwpzpf65ptuqrrh2xo77gziuwijbech/lib -Wl,-rpath,/usr/bin/../lib/gcc/x86_64-linux-gnu/10/ -o /opt/software/linux-ubuntu20.04-x86_6
             4/clang-10.0.0/esmf-8.5.0-i5ehyuwegkljye4334sazsoxmdljmbye/bin/ESMF_PrintInfo /tmp/root/spack-stage/spack-stage-esmf-8.5.0-i5ehyuwegkljye4334sazsoxmdljmbye/spack-src/obj/objO/Linux.gfortranclang.64.mpich.default/src/apps/ESM
             F_PrintInfo/ESMF_PrintInfo.o -lesmf  -lrt -lstdc++ -ldl -lnetcdf -lnetcdff -lnetcdf -lnetcdf -ldl -lm -lpioc
     4718    /usr/bin/ld: /opt/software/linux-ubuntu20.04-x86_64/clang-10.0.0/esmf-8.5.0-i5ehyuwegkljye4334sazsoxmdljmbye/lib/libesmf.a(ESMCI_VMKernel.o): in function `ESMCI::VMK::setAffinities(void*)':
  >> 4719    ESMCI_VMKernel.C:(.text+0x1829): undefined reference to `__kmpc_fork_call'
```
Apparently, the Fortran linker command is missing the necessary flags to link against the Clang OpenMP library, because `-fopenmp` for `gfortran` only includes the GNU OpenMP library automatically.

I checked my macOS build and saw that on macOS, `ESMF_OPENMP` is automatically set to `OFF`, so I am suggesting to do the same for `clanggfortran` on Linux at least for this release. We can think about a better solution for develop if that is preferred.