### PR TITLE
Add shared variant for platform=cray to openssl

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -351,6 +351,9 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
         "shared", default=True, description="Build shared library version", when="platform=darwin"
     )
     variant(
+        "shared", default=True, description="Build shared library version", when="platform=cray"
+    )
+    variant(
         "shared",
         default=False,
         description="Build shared library version",


### PR DESCRIPTION
## Description

Add shared variant for `platform=cray` to `var/spack/repos/builtin/packages/openssl/package.py`.

## Issue(s) addressed

This fixes an issue when trying to build packages dependent on `openssl`, for example `curl`:
```
rocess Process-2:
Traceback (most recent call last):
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/lib/spack/spack/build_environment.py", line 1048, in _setup_pkg_and_run
    pkg, dirty=kwargs.get("dirty", False), context=context
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/lib/spack/spack/build_environment.py", line 779, in setup_package
    set_wrapper_variables(pkg, env_mods)
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/lib/spack/spack/build_environment.py", line 522, in set_wrapper_variables
    update_compiler_args_for_dep(dspec)
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/lib/spack/spack/build_environment.py", line 494, in update_compiler_args_for_dep
    dep_link_dirs.extend(query.libs.directories)
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/lib/spack/spack/spec.py", line 1236, in __get__
    value = f()
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/lib/spack/spack/spec.py", line 1225, in <lambda>
    callbacks_chain.append(lambda: getattr(pkg, self.attribute_name))
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/var/spack/repos/builtin/packages/openssl/package.py", line 386, in libs
    )
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/lib/spack/llnl/util/lang.py", line 486, in __getitem__
    return self.dict[key]
KeyError: 'shared'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/lib/spack/spack/build_environment.py", line 1067, in _setup_pkg_and_run
    package_context = get_package_context(tb)
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/lib/spack/spack/build_environment.py", line 1256, in get_package_context
    func = getattr(obj, tb.tb_frame.f_code.co_name, "")
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/var/spack/repos/builtin/packages/openssl/package.py", line 386, in libs
    )
  File "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c4/spack-stack-1.5.0/spack/lib/spack/llnl/util/lang.py", line 486, in __getitem__
    return self.dict[key]
KeyError: 'shared'
```

Tested on Gaea.

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
