### PR TITLE
Accommodate separate lmod, tcl modules.yaml's

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
@@ -106,6 +106,13 @@ def setup_common_parser_args(subparser):
         help="Include upstream environment (/path/to/spack-stack-x.y.z/envs/unified-env/install)",
     )
 
+    subparser.add_argument(
+        "--modulesys",
+        type=str,
+        choices=["lmod", "tcl"],
+        help="Override choice of tcl vs. lmod config (default is based on site config)",
+    )
+
 
 def setup_ctr_parser(subparser):
     """create container-specific parsing options"""
@@ -168,6 +175,7 @@ def dict_from_args(args):
     dict["base_packages"] = args.packages
     dict["dir"] = args.dir
     dict["upstreams"] = args.upstream
+    dict["modulesys"] = args.modulesys
 
     return dict
 

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -114,6 +114,9 @@ class StackEnv(object):
         with open(site_modules_yaml_path, "r") as f:
             site_modules_yaml = syaml.load_config(f)
         lmod_or_tcl_list = site_modules_yaml["modules"]["default"]["enable"]
+        assert site_modules_yaml["modules"]["default"]["enable"], (
+            "Set 'modules:default:enable' in site modules.yaml, or use --modulesys {tcl,lmod}"
+        )
         if len(set(lmod_or_tcl_list)) > 1:
             logging.warning(
                 "WARNING: Multiple lmod/tcl settings found for %s; using the first"

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -1,4 +1,5 @@
 import copy
+import io
 import logging
 import os
 import re
@@ -163,8 +164,12 @@ class StackEnv(object):
         current_config = site_modules_yaml["modules"]["default"][current_sys]
         site_modules_yaml["modules"]["default"][lmod_or_tcl] = current_config
         del site_modules_yaml["modules"]["default"][current_sys]
+        # Write file, and get rid of annoying single quotes
+        stream = io.StringIO()
+        syaml.dump_config(site_modules_yaml, stream)
         with open(site_modules_yaml_path, "w") as f:
-            syaml.dump_config(site_modules_yaml, f)
+            f.write(stream.getvalue().replace("'enable:':", "enable::"))
+            
 
     def _copy_package_includes(self):
         """Overwrite base packages in environment common dir"""

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -114,9 +114,9 @@ class StackEnv(object):
         with open(site_modules_yaml_path, "r") as f:
             site_modules_yaml = syaml.load_config(f)
         lmod_or_tcl_list = site_modules_yaml["modules"]["default"]["enable"]
-        assert site_modules_yaml["modules"]["default"]["enable"], (
-            "Set 'modules:default:enable' in site modules.yaml, or use --modulesys {tcl,lmod}"
-        )
+        assert (
+            lmod_or_tcl_list
+        ), "Set 'modules:default:enable' in site modules.yaml, or use --modulesys {tcl,lmod}"
         if len(set(lmod_or_tcl_list)) > 1:
             logging.warning(
                 "WARNING: Multiple lmod/tcl settings found for %s; using the first"

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -162,7 +162,7 @@ class StackEnv(object):
         site_modules_yaml["modules"]["default"]["enable"][0] = lmod_or_tcl
         current_config = site_modules_yaml["modules"]["default"][current_sys]
         site_modules_yaml["modules"]["default"][lmod_or_tcl] = current_config
-        del(site_modules_yaml["modules"]["default"][current_sys])
+        del site_modules_yaml["modules"]["default"][current_sys]
         with open(site_modules_yaml_path, "w") as f:
             syaml.dump_config(site_modules_yaml, f)
 

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -115,16 +115,23 @@ class StackEnv(object):
             site_modules_yaml = syaml.load_config(f)
         lmod_or_tcl_list = site_modules_yaml["modules"]["default"]["enable"]
         if len(set(lmod_or_tcl_list)) > 1:
-            logging.warning("WARNING: Multiple lmod/tcl settings found for %s; using the first" % site_modules_yaml_path)
+            logging.warning(
+                "WARNING: Multiple lmod/tcl settings found for %s; using the first"
+                % site_modules_yaml_path
+            )
         lmod_or_tcl = lmod_or_tcl_list[0]
-        assert lmod_or_tcl in ("lmod", "tcl"), "lmod/tcl setting could not be determined for %s" % site_modules_yaml_path
+        assert lmod_or_tcl in ("lmod", "tcl"), (
+            "lmod/tcl setting could not be determined for %s" % site_modules_yaml_path
+        )
         return lmod_or_tcl
 
     def _copy_common_includes(self):
         """Copy common directory into environment"""
         self.includes.append("common")
         env_common_dir = os.path.join(self.env_dir(), "common")
-        shutil.copytree(common_path, env_common_dir, ignore=shutil.ignore_patterns("modules_*.yaml"))
+        shutil.copytree(
+            common_path, env_common_dir, ignore=shutil.ignore_patterns("modules_*.yaml")
+        )
         if not self.modulesys:
             lmod_or_tcl = self.get_lmod_or_tcl(self.site_configs_dir())
         else:

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -169,7 +169,6 @@ class StackEnv(object):
         syaml.dump_config(site_modules_yaml, stream)
         with open(site_modules_yaml_path, "w") as f:
             f.write(stream.getvalue().replace("'enable:':", "enable::"))
-            
 
     def _copy_package_includes(self):
         """Overwrite base packages in environment common dir"""

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -114,19 +114,11 @@ class StackEnv(object):
         with open(site_modules_yaml_path, "r") as f:
             site_modules_yaml = syaml.load_config(f)
         lmod_or_tcl_list = site_modules_yaml["modules"]["default"]["enable"]
-        assert (
-            lmod_or_tcl_list
-        ), "Set 'modules:default:enable' in site modules.yaml, or use --modulesys {tcl,lmod}"
-        if len(set(lmod_or_tcl_list)) > 1:
-            logging.warning(
-                "WARNING: Multiple lmod/tcl settings found for %s; using the first"
-                % site_modules_yaml_path
-            )
-        lmod_or_tcl = lmod_or_tcl_list[0]
-        assert lmod_or_tcl in ("lmod", "tcl"), (
-            "lmod/tcl setting could not be determined for %s" % site_modules_yaml_path
-        )
-        return lmod_or_tcl
+        assert lmod_or_tcl_list and (
+            set(lmod_or_tcl_list) in ({"tcl"}, {"lmod"})
+        ), """Set one and only one value ('lmod' or 'tcl') under 'modules:default:enable'
+           in site modules.yaml, or use '--modulesys {tcl,lmod}'"""
+        return lmod_or_tcl_list[0]
 
     def _copy_common_includes(self):
         """Copy common directory into environment"""

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -160,11 +160,11 @@ class StackEnv(object):
             return
         logging.info("Updating site modules.yaml to reflect env module system override setting\n")
         site_modules_yaml["modules"]["default"]["enable"][0] = lmod_or_tcl
-        site_modules_yaml["modules"]["default"][lmod_or_tcl] = site_modules_yaml["modules"]["default"][current_sys]
+        current_config = site_modules_yaml["modules"]["default"][current_sys]
+        site_modules_yaml["modules"]["default"][lmod_or_tcl] = current_config
         del(site_modules_yaml["modules"]["default"][current_sys])
         with open(site_modules_yaml_path, "w") as f:
             syaml.dump_config(site_modules_yaml, f)
-        
 
     def _copy_package_includes(self):
         """Overwrite base packages in environment common dir"""

--- a/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
+++ b/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
@@ -77,3 +77,24 @@ def test_containers(container):
         return
     container_wo_ext = os.path.splitext(container)[0]
     stack_create("create", "ctr", container_wo_ext, "--dir", test_dir, "--overwrite")
+
+@pytest.mark.extension("stack")
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_modulesys():
+    modsystems = {"lmod", "tcl"}
+    for modulesys in modsystems:
+        stack_create("create", "env", "--site", "hera", "--dir", test_dir, "--overwrite", "--modulesys", modulesys)
+    modules_yaml_path = os.path.join(test_dir, "common", "modules.yaml")
+    with open(modules_yaml_path, "r") as f:
+        modules_yaml_txt = f.read()
+    assert "%s:" % modulesys in modules_yaml_txt
+    assert "%s:" % list(modsystems.difference(modulesys))[0] not in modules_yaml_txt
+
+@pytest.mark.extension("stack")
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_upstream():
+    stack_create("create", "env", "--site", "hera", "--dir", test_dir, "--overwrite", "--upstream", "/test/path/to/upstream/env")
+    spack_yaml_path = os.path.join(test_dir, "spack.yaml")
+    with open(spack_yaml_path, "r") as f:
+        spack_yaml_txt = f.read()
+    assert "install_tree: /test/path/to/upstream/env" in spack_yaml_txt

--- a/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
+++ b/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
@@ -101,6 +101,7 @@ def test_containers(container, spec):
         "--overwrite",
     )
 
+
 @pytest.mark.extension("stack")
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_modulesys():

--- a/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
+++ b/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
@@ -89,13 +89,15 @@ def test_modulesys():
             "env",
             "--site",
             "hera",
+            "--name",
+            "modulesys_test",
             "--dir",
             test_dir,
             "--overwrite",
             "--modulesys",
             modulesys,
         )
-    modules_yaml_path = os.path.join(test_dir, "common", "modules.yaml")
+    modules_yaml_path = os.path.join(test_dir, "modulesys_test", "common", "modules.yaml")
     with open(modules_yaml_path, "r") as f:
         modules_yaml_txt = f.read()
     assert "%s:" % modulesys in modules_yaml_txt
@@ -110,13 +112,15 @@ def test_upstream():
         "env",
         "--site",
         "hera",
+        "--name",
+        "upstream_test",
         "--dir",
         test_dir,
         "--overwrite",
         "--upstream",
         "/test/path/to/upstream/env",
     )
-    spack_yaml_path = os.path.join(test_dir, "spack.yaml")
+    spack_yaml_path = os.path.join(test_dir, "upstream_test", "spack.yaml")
     with open(spack_yaml_path, "r") as f:
         spack_yaml_txt = f.read()
     assert "install_tree: /test/path/to/upstream/env" in spack_yaml_txt

--- a/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
+++ b/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
@@ -93,7 +93,7 @@ def test_modulesys():
             test_dir,
             "--overwrite",
             "--modulesys",
-            modulesys
+            modulesys,
         )
     modules_yaml_path = os.path.join(test_dir, "common", "modules.yaml")
     with open(modules_yaml_path, "r") as f:
@@ -114,7 +114,7 @@ def test_upstream():
         test_dir,
         "--overwrite",
         "--upstream",
-        "/test/path/to/upstream/env"
+        "/test/path/to/upstream/env",
     )
     spack_yaml_path = os.path.join(test_dir, "spack.yaml")
     with open(spack_yaml_path, "r") as f:

--- a/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
+++ b/lib/jcsda-emc/spack-stack/tests/test_stack_create.py
@@ -78,22 +78,44 @@ def test_containers(container):
     container_wo_ext = os.path.splitext(container)[0]
     stack_create("create", "ctr", container_wo_ext, "--dir", test_dir, "--overwrite")
 
+
 @pytest.mark.extension("stack")
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_modulesys():
     modsystems = {"lmod", "tcl"}
     for modulesys in modsystems:
-        stack_create("create", "env", "--site", "hera", "--dir", test_dir, "--overwrite", "--modulesys", modulesys)
+        stack_create(
+            "create",
+            "env",
+            "--site",
+            "hera",
+            "--dir",
+            test_dir,
+            "--overwrite",
+            "--modulesys",
+            modulesys
+        )
     modules_yaml_path = os.path.join(test_dir, "common", "modules.yaml")
     with open(modules_yaml_path, "r") as f:
         modules_yaml_txt = f.read()
     assert "%s:" % modulesys in modules_yaml_txt
     assert "%s:" % list(modsystems.difference(modulesys))[0] not in modules_yaml_txt
 
+
 @pytest.mark.extension("stack")
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_upstream():
-    stack_create("create", "env", "--site", "hera", "--dir", test_dir, "--overwrite", "--upstream", "/test/path/to/upstream/env")
+    stack_create(
+        "create",
+        "env",
+        "--site",
+        "hera",
+        "--dir",
+        test_dir,
+        "--overwrite",
+        "--upstream",
+        "/test/path/to/upstream/env"
+    )
     spack_yaml_path = os.path.join(test_dir, "spack.yaml")
     with open(spack_yaml_path, "r") as f:
         spack_yaml_txt = f.read()


### PR DESCRIPTION
## Description

This PR updates the 'create env' command in order to support the separation of common/modules.yaml into lmod and tcl ones.

## Issue(s) addressed

Addresses https://github.com/JCSDA/spack-stack/issues/703, https://github.com/JCSDA/spack-stack/issues/50

## Dependencies

none

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
