### PR TITLE
Add bufr version 12.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -43,7 +43,7 @@ class Bufr(CMakePackage):
     # C test does not explicity link to -lm causing DSO error when building shared libs
     patch("c-tests-libm.patch", when="@11.5.0:11.7.0")
     # Patch to identify Python version correctly
-    patch("python-version.patch", when="+python")
+    patch("python-version.patch", when="+python @:12.0.0")
 
     variant("python", default=False, description="Enable Python interface?")
     variant("shared", default=True, description="Build shared libraries", when="@11.5:")

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -17,16 +17,26 @@ class Bufr(CMakePackage):
     """
 
     homepage = "https://noaa-emc.github.io/NCEPLIBS-bufr"
-    url = "https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags/bufr_v11.5.0.tar.gz"
+    url = "https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags/v12.0.1.tar.gz"
 
     maintainers("t-brown", "AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA", "jbathegit")
 
+    version("12.0.1", sha256="525f26238dba6511a453fc71cecc05f59e4800a603de2abbbbfb8cbb5adf5708")
     version("12.0.0", sha256="d01c02ea8e100e51fd150ff1c4a1192ca54538474acb1b7f7a36e8aeab76ee75")
     version("11.7.1", sha256="6533ce6eaa6b02c0cb5424cfbc086ab120ccebac3894980a4daafd4dfadd71f8")
     version("11.7.0", sha256="6a76ae8e7682bbc790321bf80c2f9417775c5b01a5c4f10763df92e01b20b9ca")
     version("11.6.0", sha256="af4c04e0b394aa9b5f411ec5c8055888619c724768b3094727e8bb7d3ea34a54")
     version("11.5.0", sha256="d154839e29ef1fe82e58cf20232e9f8a4f0610f0e8b6a394b7ca052e58f97f43")
     version("11.4.0", sha256="946482405e675b99e8e0c221d137768f246076f5e9ba92eed6cae47fb68b7a26")
+
+    # tar file name depends on version
+    def url_for_version(self, version):
+        url = "https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags"
+        if (version >= Version("12.0.1")):
+            url += "/v{0}.tar.gz".format(version)
+        else:
+            url += "/bufr_v{0}.tar.gz".format(version)
+        return url
 
     # Patch to not add "-c" to ranlib flags when using llvm-ranlib on Apple systems
     patch("cmakelists-apple-llvm-ranlib.patch", when="@11.5.0:11.6.0")

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -32,7 +32,7 @@ class Bufr(CMakePackage):
     # tar file name depends on version
     def url_for_version(self, version):
         url = "https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags"
-        if (version >= Version("12.0.1")):
+        if version >= Version("12.0.1"):
             url += "/v{0}.tar.gz".format(version)
         else:
             url += "/bufr_v{0}.tar.gz".format(version)


### PR DESCRIPTION
## Description

This PR adds in the version statment for bufr@12.0.1, plus a new url_for_version function to form the correct url address. This was done since the naming of the url changed between 12.0.0 and 12.0.1.

I tested on my Mac and bufr@12.0.1 successfully built. However during the `spack install` command I got the following prompt:
```
Reversed (or previously applied) patch detected!  Assume -R? [y]
```
I responded 'y' and the install continued to completion.

Is this and indication that something is missing in this PR, or is there a configuration that says to automatically answer this prompt?

Thanks!

## Issue(s) addressed

Partially addresses jcsda/spack-stack/issues/778

## Dependencies

List the other PRs that this PR is dependent on:
None

## Impact

Expected impact on downstream repositories:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
