### PR TITLE
release/1.5.1: cherry-pick bufr@12.0.1 PR from jcsda_emc_spack_stack

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -43,7 +43,7 @@ class Bufr(CMakePackage):
     # C test does not explicity link to -lm causing DSO error when building shared libs
     patch("c-tests-libm.patch", when="@11.5.0:11.7.0")
     # Patch to identify Python version correctly
-    patch("python-version.patch", when="+python")
+    patch("python-version.patch", when="+python @:12.0.0")
 
     variant("python", default=False, description="Enable Python interface?")
     variant("shared", default=True, description="Build shared libraries", when="@11.5:")

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -17,16 +17,26 @@ class Bufr(CMakePackage):
     """
 
     homepage = "https://noaa-emc.github.io/NCEPLIBS-bufr"
-    url = "https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags/bufr_v11.5.0.tar.gz"
+    url = "https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags/v12.0.1.tar.gz"
 
     maintainers("t-brown", "AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA", "jbathegit")
 
+    version("12.0.1", sha256="525f26238dba6511a453fc71cecc05f59e4800a603de2abbbbfb8cbb5adf5708")
     version("12.0.0", sha256="d01c02ea8e100e51fd150ff1c4a1192ca54538474acb1b7f7a36e8aeab76ee75")
     version("11.7.1", sha256="6533ce6eaa6b02c0cb5424cfbc086ab120ccebac3894980a4daafd4dfadd71f8")
     version("11.7.0", sha256="6a76ae8e7682bbc790321bf80c2f9417775c5b01a5c4f10763df92e01b20b9ca")
     version("11.6.0", sha256="af4c04e0b394aa9b5f411ec5c8055888619c724768b3094727e8bb7d3ea34a54")
     version("11.5.0", sha256="d154839e29ef1fe82e58cf20232e9f8a4f0610f0e8b6a394b7ca052e58f97f43")
     version("11.4.0", sha256="946482405e675b99e8e0c221d137768f246076f5e9ba92eed6cae47fb68b7a26")
+
+    # tar file name depends on version
+    def url_for_version(self, version):
+        url = "https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags"
+        if (version >= Version("12.0.1")):
+            url += "/v{0}.tar.gz".format(version)
+        else:
+            url += "/bufr_v{0}.tar.gz".format(version)
+        return url
 
     # Patch to not add "-c" to ranlib flags when using llvm-ranlib on Apple systems
     patch("cmakelists-apple-llvm-ranlib.patch", when="@11.5.0:11.6.0")

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -32,7 +32,7 @@ class Bufr(CMakePackage):
     # tar file name depends on version
     def url_for_version(self, version):
         url = "https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags"
-        if (version >= Version("12.0.1")):
+        if version >= Version("12.0.1"):
             url += "/v{0}.tar.gz".format(version)
         else:
             url += "/bufr_v{0}.tar.gz".format(version)


### PR DESCRIPTION
## Description

This PR cherry-picks the three commits that went into jcsda_emc_spack_stack in PR https://github.com/JCSDA/spack/pull/330 (add `bufr@12.0.1`).

After this is merged, I'll create the corresponding spack-stack PR from @srherbener's PR to spack-stack develop. No need to do the `.gitmodules` and submodule pointer dance here, it's all been tested going into develop and the two branches are almost identical.