### PR TITLE
Add handling of the removal of std::unary_function in C++17

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -177,6 +177,7 @@ class Boost(Package):
             conditional("17", when="@1.63.0:"),
             # C++20/2a is not support by Boost < 1.73.0
             conditional("2a", when="@1.73.0:"),
+            conditional("20", when="@1.77.0:"),
         ),
         multi=False,
         description="Use the specified C++ standard when building.",

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -175,9 +175,11 @@ class Boost(Package):
             "14",
             # C++17 is not supported by Boost < 1.63.0.
             conditional("17", when="@1.63.0:"),
-            # C++20/2a is not support by Boost < 1.73.0
+            # C++20/2a is not supported by Boost < 1.73.0
             conditional("2a", when="@1.73.0:"),
             conditional("20", when="@1.77.0:"),
+            conditional("23", when="@1.79.0:"),
+            conditional("26", when="@1.79.0:"),
         ),
         multi=False,
         description="Use the specified C++ standard when building.",

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -590,10 +590,10 @@ class Boost(Package):
         cxxflags = []
 
         # Deal with C++ standard.
+        cxxstd = spec.variants["cxxstd"].value
         if spec.satisfies("@1.66:"):
             options.append("cxxstd={0}".format(spec.variants["cxxstd"].value))
         else:  # Add to cxxflags for older Boost.
-            cxxstd = spec.variants["cxxstd"].value
             flag = getattr(self.compiler, "cxx{0}_flag".format(cxxstd))
             if flag:
                 cxxflags.append(flag)
@@ -606,6 +606,12 @@ class Boost(Package):
 
         if not spec.satisfies("@:1.70 %intel"):
             cxxflags.append("-DBOOST_PARAMETER_DISABLE_PERFECT_FORWARDING")
+
+        # std::unary_function was removed in C++17 so need to set the following
+        # flag for building boost
+        if (cxxstd == "17") or (cxxstd == "2a") or (cxxstd == "20") or
+           (cxxstd == "23") or (cxxstd == "26"):
+            cxxflags.append("-DBOOST_NO_CXX98_FUNCTION_BASE")
 
         # clang is not officially supported for pre-compiled headers
         # and at least in clang 3.9 still fails to build

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -609,7 +609,7 @@ class Boost(Package):
 
         # std::unary_function was removed in C++17 so need to set the following
         # flag for building boost
-        if (cxxstd == "17") or (cxxstd == "2a") or (cxxstd == "20") or
+        if (cxxstd == "17") or (cxxstd == "2a") or (cxxstd == "20") or \
            (cxxstd == "23") or (cxxstd == "26"):
             cxxflags.append("-DBOOST_NO_CXX98_FUNCTION_BASE")
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -609,8 +609,13 @@ class Boost(Package):
 
         # std::unary_function was removed in C++17 so need to set the following
         # flag for building boost
-        if (cxxstd == "17") or (cxxstd == "2a") or (cxxstd == "20") or \
-           (cxxstd == "23") or (cxxstd == "26"):
+        if (
+            (cxxstd == "17")
+            or (cxxstd == "2a")
+            or (cxxstd == "20")
+            or (cxxstd == "23")
+            or (cxxstd == "26")
+        ):
             cxxflags.append("-DBOOST_NO_CXX98_FUNCTION_BASE")
 
         # clang is not officially supported for pre-compiled headers


### PR DESCRIPTION
## Description

The C++17 standard specifies that std::unary_function is to be removed. Boost has `#define` directives to handle this, but this requires defining the cxxflag `BOOST_NO_CXX98_FUNCTION_BASE` on the build (b2) command line. This PR adds in a check for C++17 or newer and adds in the define mentioned above.

This was discovered when trying to build on the Mac using the new apple-clang@15.0.0 version. Apparently Apple did not remove std::unary_function until version 15.0.0 was released.

## Issue(s) addressed

None

## Dependencies

List the other PRs that this PR is dependent on:
None

## Impact

Expected impact on downstream repositories:
None

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] I have run the unit tests before creating the PR (tested manually on my Mac)
