### PR TITLE
Subversion: pic variant & static openssl

### DIFF
--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -38,6 +38,7 @@ class Subversion(AutotoolsPackage):
     variant("perl", default=False, description="Build with Perl bindings")
     variant("apxs", default=True, description="Build with APXS")
     variant("nls", default=True, description="Enable Native Language Support")
+    variant("pic", default=False, description="Enable position-independent code")
 
     depends_on("apr")
     depends_on("apr-util")
@@ -77,6 +78,7 @@ class Subversion(AutotoolsPackage):
             "--without-kwallet",
             "--without-jdk",
             "--without-boost",
+            self.with_or_without("pic")[0],
         ]
 
         if spec.satisfies("@1.10:"):

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -38,7 +38,7 @@ class Subversion(AutotoolsPackage):
     variant("perl", default=False, description="Build with Perl bindings")
     variant("apxs", default=True, description="Build with APXS")
     variant("nls", default=True, description="Enable Native Language Support")
-    variant("pic", default=False, description="Enable position-independent code")
+    variant("pic", default=True, description="Enable position-independent code")
 
     depends_on("apr")
     depends_on("apr-util")

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -107,13 +107,18 @@ class Subversion(AutotoolsPackage):
 
         if "+nls" in spec:
             args.append("--enable-nls")
-            if "intl" in spec["gettext"].libs.names:
-                # Using .libs.link_flags is the canonical way to add these arguments,
-                # but since libintl is much smaller than the rest and also the only
-                # necessary one, we would specify it by hand here
-                args.append("LIBS=-lintl")
-                if not is_system_path(spec["gettext"].prefix):
-                    args.append("LDFLAGS={0}".format(spec["gettext"].libs.search_flags))
+            ldflags = []
+            if not is_system_path(spec["gettext"].prefix):
+                ldflags.append(spec["gettext"].libs.search_flags)
+            # Using .libs.link_flags is the canonical way to add these arguments,
+            # but since libintl is much smaller than the rest and also the only
+            # necessary one, we specify it by hand here.
+            libs = ["-lintl"]
+            if spec["gettext"].satisfies("~shared"):
+                ldflags.append(spec["iconv"].libs.search_flags)
+                libs.append(spec["iconv"].libs.link_flags)
+            args.append("LDFLAGS=%s" % " ".join(ldflags))
+            args.append("LIBS=%s" % " ".join(libs))
         else:
             args.append("--disable-nls")
 


### PR DESCRIPTION
## Description

Somehow the pic variant and static openssl support for subversion got lost along the way. This PR restores them.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
