### PR TITLE
Enable awscli-v2 in ewok-env/jedi-tools-env, update gmao-swell-env (includes PR https://github.com/JCSDA/spack/pull/332)

### DIFF
--- a/var/spack/repos/builtin/packages/py-awscrt/package.py
+++ b/var/spack/repos/builtin/packages/py-awscrt/package.py
@@ -16,6 +16,8 @@ class PyAwscrt(PythonPackage):
 
     version("0.16.16", sha256="13075df2c1d7942fe22327b6483274517ee0f6ae765c4e6b6ae9ef5b4c43a827")
 
+    depends_on("cmake", type=("build"))
+    depends_on("openssl", type=("build"), when="platform=linux")
     depends_on("py-setuptools", type=("build"))
 
     # On Linux, tell aws-crt-python to use libcrypto from spack (openssl)

--- a/var/spack/repos/jcsda-emc-bundles/packages/ewok-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ewok-env/package.py
@@ -31,7 +31,7 @@ class EwokEnv(BundlePackage):
     )
 
     depends_on("jedi-base-env +python", type="run")
-    depends_on("awscli", type="run")
+    depends_on("awscli-v2", type="run")
     depends_on("py-boto3", type="run")
     depends_on("py-cartopy", type="run")
     depends_on("py-gitpython", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
@@ -56,6 +56,7 @@ class GmaoSwellEnv(BundlePackage):
     # depends_on("py-isodate", type="run")
     # depends_on("py-questionary", type="run")
     # depends_on("py-scikit-learn", type="run")
+    # depends_on("py-seaborn", type="run")
 
     conflicts(
         "%gcc platform=darwin",

--- a/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
@@ -20,7 +20,10 @@ class GmaoSwellEnv(BundlePackage):
     # Main JEDI modules
     depends_on("jedi-base-env +python", type="run")
 
-    # Jedi interfaces to build
+    # Add CRTM 2.4.0
+    depends_on("crtm@v2.4-jedi.2", type="run")
+
+    # JEDI interfaces used by swell
     depends_on("jedi-fv3-env", type="run")
     depends_on("soca-env", type="run")
 

--- a/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
@@ -60,7 +60,7 @@ class GmaoSwellEnv(BundlePackage):
 
     conflicts(
         "%gcc platform=darwin",
-        msg="ewok-env does " + "not build with gcc (11?) on macOS (12), use apple-clang",
+        msg="gmao-swell-env does " + "not build with gcc (11?) on macOS (12), use apple-clang",
     )
 
     # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
@@ -1,0 +1,65 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class GmaoSwellEnv(BundlePackage):
+    """Development environment for swell"""
+
+    homepage = "https://geos-esm.github.io/swell/"
+    git = "https://github.com/GEOS-ESM/swell"
+
+    maintainers("climbfuji", "danholdaway", "mathomp4")
+
+    # Current version
+    version("1.0.0")
+
+    # Main JEDI modules
+    depends_on("jedi-base-env +python", type="run")
+
+    # Jedi interfaces to build
+    depends_on("jedi-fv3-env", type="run")
+    depends_on("soca-env", type="run")
+
+    # GEOS
+    # depends_on("geos-dev-env", type="run")  # We should have the modules needed to build GEOSgcm
+
+    # Python packages for swell, eva, and other utilities
+    depends_on("py-cartopy", type="run")
+    depends_on("py-click", type="run")
+    depends_on("py-contourpy", type="run")
+    depends_on("py-gitpython", type="run")
+    depends_on("py-jinja2", type="run")
+    depends_on("py-matplotlib", type="run")
+    depends_on("py-numpy", type="run")
+    depends_on("py-pip", type="run")
+    depends_on("py-pkgconfig", type="run")
+    depends_on("py-requests", type="run")
+    depends_on("py-urllib3", type="run")
+    depends_on("py-wheel", type="run")
+    depends_on("py-setuptools", type="run")
+
+    # Different versions than other bundles
+    depends_on("py-pycodestyle@2.10:", type="run")
+    depends_on("py-pyyaml@6:", type="run")
+
+    # Future dependencies needed
+    # depends_on("py-bokeh", type="run")
+    # depends_on("py-cylc-flow", type="run")
+    # depends_on("py-cylc-uiserver", type="run")
+    # depends_on("py-flake8", type="run")
+    # depends_on("py-hvplot", type="run")
+    # depends_on("py-holoviews", type="run")
+    # depends_on("py-isodate", type="run")
+    # depends_on("py-questionary", type="run")
+    # depends_on("py-scikit-learn", type="run")
+
+    conflicts(
+        "%gcc platform=darwin",
+        msg="ewok-env does " + "not build with gcc (11?) on macOS (12), use apple-clang",
+    )
+
+    # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
@@ -23,9 +23,9 @@ class GmaoSwellEnv(BundlePackage):
     # Add CRTM 2.4.0
     depends_on("crtm@v2.4-jedi.2", type="run")
 
-    # JEDI interfaces used by swell
-    depends_on("jedi-fv3-env", type="run")
-    depends_on("soca-env", type="run")
+    # Additional dependencies for JEDI used by swell
+    depends_on("fms@release-jcsda", type="run")
+    depends_on("nco", type="run")
 
     # GEOS
     # depends_on("geos-dev-env", type="run")  # We should have the modules needed to build GEOSgcm

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-tools-env/package.py
@@ -18,10 +18,10 @@ class JediToolsEnv(BundlePackage):
 
     variant("latex", default=False, description="Enable building LaTeX documentation with Sphinx")
 
-    # Don't install awscli and/or aws-parallelcluster via spack,
-    # they are not well maintained packages and have terrible
-    # dependencies. Use a venv on top of spack-stack instead.
-    # depends_on("awscli", type="run")
+    depends_on("awscli-v2", type="run")
+    # Don't install aws-parallelcluster via spack, this is
+    # not well maintained package with strict dependencies.
+    # Use a venv on top of spack-stack instead.
     # depends_on("aws-parallelcluster", type="run")
     depends_on("py-click", type="run")
     depends_on("py-openpyxl", type="run")


### PR DESCRIPTION
## Description

- Bug fix in `py-awscrt`, adding missing dependencies on `cmake` (all platforms) and `openssl` (Linux)
- Replace `awscli` with `awscli-v2` in `ewok-env` and `jedi-tools-env`
- Bug fixes in `gmao-swell-env`: simplify dependency trees

This PR includes #332 (cherry-picked), i.e. when it gets closed it will automatically close #332 as completed, too.

## Testing

See https://github.com/JCSDA/spack-stack/pull/813

Note that the "CI failure" below is a codecov error with minimal changes that we should ignore.

## Issues

See https://github.com/JCSDA/spack-stack/pull/813