### PR TITLE
Bug fix for py-awscrt on Linux (use spack openssl/libcrypto)

### DIFF
--- a/var/spack/repos/builtin/packages/py-awscrt/package.py
+++ b/var/spack/repos/builtin/packages/py-awscrt/package.py
@@ -17,3 +17,8 @@ class PyAwscrt(PythonPackage):
     version("0.16.16", sha256="13075df2c1d7942fe22327b6483274517ee0f6ae765c4e6b6ae9ef5b4c43a827")
 
     depends_on("py-setuptools", type=("build"))
+
+    # On Linux, tell aws-crt-python to use libcrypto from spack (openssl)
+    def setup_build_environment(self, env):
+        with when("platform=linux"):
+            env.set("AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO", 1)


### PR DESCRIPTION
## Description

This PR is a tiny bug fix for `py-awscrt` on Linux. We need to tell the pip builder to use use libcrypto from spack (art of openssl, whether that is an internal or external package doesn't matter). This doesn't apply to macOS or Windows, see https://github.com/awslabs/aws-crt-python/blob/main/README.md.

## Issue(s) addressed

Currently, `awscli-v2` doesn't build on Linux due to missing symbols from `libcrypto` in `py-awscrt`'s Python extension.

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR: Built `py-awscrt` and `awscli-v2` on the Ubuntu CI system, no build errors for `py-awscli-v2`. Ran `aws s3 ls` to make sure the utility works.
