### PR TITLE
Update ECMWF libraries from spack develop, add ecmwf-atlas@0.35.0 and update variants for ecmwf-atlas

### DIFF
--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -34,7 +34,6 @@ class Eckit(CMakePackage):
         values=("Debug", "Release", "RelWithDebInfo"),
     )
 
-    variant("shared", default=True, description="Build shared libraries")
     variant("tools", default=True, description="Build the command line tools")
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
@@ -158,9 +157,7 @@ class Eckit(CMakePackage):
 
         # Static build of eckit not working, many places in eckit's build
         # system have SHARED hardcoded (in several CMakeLists.txt files).
-        if "~shared" in self.spec:
-            # args.append("-DBUILD_SHARED_LIBS=OFF")
-            raise InstallError("eckit static build not supported")
+        args.append("-DBUILD_SHARED_LIBS=ON")
 
         if "linalg=mkl" not in self.spec:
             # ENABLE_LAPACK is ignored if MKL backend is enabled

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -76,10 +76,10 @@ class EcmwfAtlas(CMakePackage):
             "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec["python"].command.path,
         ]
         if self.spec.satisfies("@0.31:0.34"):
-            self.define_from_variant("ENABLE_TRANS", "ectrans")
+            args.append(self.define_from_variant("ENABLE_TRANS", "ectrans"))
         if self.spec.satisfies("@0.35:"):
-            self.define_from_variant("ENABLE_ECTRANS", "ectrans")
-            self.define_from_variant("ENABLE_TESSELATION", "tesselation"),
+            args.append(self.define_from_variant("ENABLE_ECTRANS", "ectrans"))
+            args.append(self.define_from_variant("ENABLE_TESSELATION", "tesselation"))
         if "~shared" in self.spec:
             args.append("-DBUILD_SHARED_LIBS=OFF")
         return args

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -59,8 +59,6 @@ class EcmwfAtlas(CMakePackage):
     depends_on("eigen", when="+eigen")
     variant("fftw", default=True, description="Enable fftw")
     depends_on("fftw-api", when="+fftw")
-    variant("cgal", default=False, description="Enable cgal")
-    depends_on("cgal", when="+cgal")
     variant("tesselation", default=False, description="Enable tesselation", when="@0.35.0:")
     depends_on("qhull", when="+tesselation")
 
@@ -72,7 +70,6 @@ class EcmwfAtlas(CMakePackage):
             self.define_from_variant("ENABLE_FCKIT", "fckit"),
             self.define_from_variant("ENABLE_EIGEN", "eigen"),
             self.define_from_variant("ENABLE_FFTW", "fftw"),
-            self.define_from_variant("ENABLE_CGAL", "cgal"),
             "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec["python"].command.path,
         ]
         if self.spec.satisfies("@0.31:0.34"):

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -31,7 +31,7 @@ class EcmwfAtlas(CMakePackage):
     depends_on("eckit@1.24:", when="@0.34:")
     depends_on("boost cxxstd=14 visibility=hidden", when="@0.26.0:0.33.99", type=("build", "run"))
     depends_on("boost cxxstd=17 visibility=hidden", when="@0.34.0:", type=("build", "run"))
-    variant("fckit", default=True)
+    variant("fckit", default=True, description="Enable fckit")
     depends_on("fckit@:0.10", when="@:0.33 +fckit")
     depends_on("fckit@0.11:", when="@0.34: +fckit")
     depends_on("python")
@@ -48,18 +48,15 @@ class EcmwfAtlas(CMakePackage):
         values=("Debug", "Release", "RelWithDebInfo"),
     )
 
-    variant("openmp", default=True, description="Use OpenMP?")
+    variant("openmp", default=True, description="Use OpenMP")
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
-    variant("shared", default=True)
+    variant("shared", default=True, description="Build shared libraries")
 
-    variant("trans", default=False)
-    depends_on("ectrans@:1.0.0", when="@:0.30.0 +trans")
+    variant("trans", default=False, description="Enable trans")
     depends_on("ectrans@1.1.0:", when="@0.31.0: +trans")
-    # variant('cgal', default=False)
-    # depends_on('cgal', when='+cgal')
-    variant("eigen", default=True)
+    variant("eigen", default=True, description="Enable eigen")
     depends_on("eigen", when="+eigen")
-    variant("fftw", default=True)
+    variant("fftw", default=True, description="Enable fftw")
     depends_on("fftw-api", when="+fftw")
 
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -20,6 +20,7 @@ class EcmwfAtlas(CMakePackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.35.0", sha256="5a4f898ffb4a33c738b6f86e4e2a4c8e26dfd56d3c3399018081487374e29e97")
     version("0.34.0", sha256="48536742cec0bc268695240843ac0e232e2b5142d06b19365688d9ea44dbd9ba")
     version("0.33.0", sha256="a91fffe9cecb51c6ee8549cbc20f8279e7b1f67dd90448e6c04c1889281b0600")
     version("0.32.1", sha256="3d1a46cb7f50e1a6ae9e7627c158760e132cc9f568152358e5f78460f1aaf01b")

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -53,12 +53,16 @@ class EcmwfAtlas(CMakePackage):
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant("shared", default=True, description="Build shared libraries")
 
-    variant("trans", default=False, description="Enable trans")
-    depends_on("ectrans@1.1.0:", when="@0.31.0: +trans")
+    variant("ectrans", default=False, description="Enable ectrans", when="@0.31.0:")
+    depends_on("ectrans@1.1.0:", when="+ectrans")
     variant("eigen", default=True, description="Enable eigen")
     depends_on("eigen", when="+eigen")
     variant("fftw", default=True, description="Enable fftw")
     depends_on("fftw-api", when="+fftw")
+    variant("cgal", default=False, description="Enable cgal")
+    depends_on("cgal", when="+cgal")
+    variant("tesselation", default=False, description="Enable tesselation", when="@0.35.0:")
+    depends_on("qhull", when="+tesselation")
 
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
 
@@ -66,11 +70,16 @@ class EcmwfAtlas(CMakePackage):
         args = [
             self.define_from_variant("ENABLE_OMP", "openmp"),
             self.define_from_variant("ENABLE_FCKIT", "fckit"),
-            self.define_from_variant("ENABLE_TRANS", "trans"),
             self.define_from_variant("ENABLE_EIGEN", "eigen"),
             self.define_from_variant("ENABLE_FFTW", "fftw"),
+            self.define_from_variant("ENABLE_CGAL", "cgal"),
             "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec["python"].command.path,
         ]
+        if self.spec.satisfies("@0.31:0.34"):
+            self.define_from_variant("ENABLE_TRANS", "ectrans")
+        if self.spec.satisfies("@0.35:"):
+            self.define_from_variant("ENABLE_ECTRANS", "ectrans")
+            self.define_from_variant("ENABLE_TESSELATION", "tesselation"),
         if "~shared" in self.spec:
             args.append("-DBUILD_SHARED_LIBS=OFF")
         return args

--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -31,16 +31,16 @@ class Ectrans(CMakePackage):
         values=("Debug", "Release", "RelWithDebInfo"),
     )
 
-    variant("mpi", default=True, description="Use MPI?")
-    variant("openmp", default=True, description="Use OpenMP?")
+    variant("mpi", default=True, description="Use MPI")
+    variant("openmp", default=True, description="Use OpenMP")
 
-    variant("double_precision", default=True, description="Support for double precision?")
-    variant("single_precision", default=True, description="Support for single precision?")
+    variant("double_precision", default=True, description="Support for double precision")
+    variant("single_precision", default=True, description="Support for single precision")
 
-    variant("mkl", default=False, description="Use MKL?")
-    variant("fftw", default=True, description="Use FFTW?")
+    variant("mkl", default=False, description="Use MKL")
+    variant("fftw", default=True, description="Use FFTW")
 
-    variant("transi", default=True, description="Compile TransI C-interface to trans?")
+    variant("transi", default=True, description="Compile TransI C-interface to trans")
 
     depends_on("ecbuild", type="build")
     depends_on("mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -36,13 +36,13 @@ class Fckit(CMakePackage):
         values=("Debug", "Release", "RelWithDebInfo"),
     )
 
-    variant("eckit", default=True)
+    variant("eckit", default=True, description="Enable eckit")
     depends_on("eckit@:1.23 +mpi", when="@:0.10 +eckit")
     depends_on("eckit@1.24: +mpi", when="@0.11: +eckit")
 
     variant("openmp", default=True, description="Use OpenMP?")
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
-    variant("shared", default=True)
+    variant("shared", default=True, description="Build shared libraries")
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
     variant(
         "finalize_ddts",

--- a/var/spack/repos/builtin/packages/fiat/package.py
+++ b/var/spack/repos/builtin/packages/fiat/package.py
@@ -28,12 +28,9 @@ class Fiat(CMakePackage):
         values=("Debug", "Release", "RelWithDebInfo"),
     )
 
-    variant("mpi", default=True, description="Use MPI?")
-    variant("openmp", default=True, description="Use OpenMP?")
-    variant("fckit", default=True, description="Use fckit?")
-    # variant("dr_hook_multi_precision_handles", default=False,
-    #    description="Use deprecated single precision handles for DR_HOOK?")
-    # variant("warnings", default=True, description="Enable compiler warnings")
+    variant("mpi", default=True, description="Use MPI")
+    variant("openmp", default=True, description="Use OpenMP")
+    variant("fckit", default=True, description="Use fckit")
 
     depends_on("ecbuild", type=("build"))
     depends_on("mpi", when="+mpi")
@@ -47,10 +44,7 @@ class Fiat(CMakePackage):
         args = [
             self.define_from_variant("ENABLE_OMP", "openmp"),
             self.define_from_variant("ENABLE_MPI", "mpi"),
-            self.define_from_variant("ENABLE_FCKIT", "fckit")
-            # self.define_from_variant("ENABLE_DR_HOOK_MULTI_PRECISION_HANDLES",
-            #   "dr_hook_multi_precision_handles")
-            # self.define_from_variant("ENABLE_WARNINGS, "warnings")
+            self.define_from_variant("ENABLE_FCKIT", "fckit"),
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/texinfo/package.py
+++ b/var/spack/repos/builtin/packages/texinfo/package.py
@@ -69,6 +69,13 @@ class Texinfo(AutotoolsPackage, GNUMirrorPackage):
 
     @classmethod
     def determine_version(cls, exe):
+        # On CentOS and Ubuntu, the OS package texinfo installs "info",
+        # which satisfies spack external find, but "makeinfo" comes from
+        # texi2html and may not be installed (and vice versa).
+        info = which("info")
+        makeinfo = which("makeinfo")
+        if info is None or makeinfo is None:
+            return None
         output = Executable(exe)("--version", output=str, error=str)
         match = re.search(r"info \(GNU texinfo\)\s+(\S+)", output)
         return match.group(1) if match else None


### PR DESCRIPTION
## Description

A recent PR to spack develop added all our ECMWF libraries (https://github.com/spack/spack/pull/40136). As part of this, a few updated were made that we need to bring down to our fork. Any changes in this PR to packages other than `ecmwf-atlas` are from the spack develop PR.

For `ecmwf-atlas`, on top of the changes coming from spack develop, this PR adds `ecmwf-atlas@0.35.0` and updates the variants for the package. In particular, it configures the variants that existed as comments only in the package previously and that got removed in https://github.com/spack/spack/pull/40136.

An additional bug fix is needed for package `texinfo`:  On CentOS and Ubuntu, the OS package `texinfo` installs `info`, which satisfies `spack external find`, but `makeinfo` comes from `texi2html` and may not be installed (and vice versa). Both are needed, especially with the new build options for `ecmwf-atlas`.

A subset of these changes needs to be merged back into release/1.5.1.

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/783

## Dependencies

n/a

## Impact

spack-stack builds of the unified environment and the skylab environment

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
