### PR TITLE
release/1.5.1: Cherry-pick ecmwf-atlas@0.35.0 version+variant updates from jcsda_emc_spack_stack

### DIFF
--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -59,8 +59,6 @@ class EcmwfAtlas(CMakePackage):
     depends_on("eigen", when="+eigen")
     variant("fftw", default=True)
     depends_on("fftw-api", when="+fftw")
-    variant("cgal", default=False, description="Enable cgal")
-    depends_on("cgal", when="+cgal")
     variant("tesselation", default=False, description="Enable tesselation", when="@0.35.0:")
     depends_on("qhull", when="+tesselation")
 
@@ -72,7 +70,6 @@ class EcmwfAtlas(CMakePackage):
             self.define_from_variant("ENABLE_FCKIT", "fckit"),
             self.define_from_variant("ENABLE_EIGEN", "eigen"),
             self.define_from_variant("ENABLE_FFTW", "fftw"),
-            self.define_from_variant("ENABLE_CGAL", "cgal"),
             "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec["python"].command.path,
         ]
         if self.spec.satisfies("@0.31:0.34"):

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -53,15 +53,16 @@ class EcmwfAtlas(CMakePackage):
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant("shared", default=True)
 
-    variant("trans", default=False)
-    depends_on("ectrans@:1.0.0", when="@:0.30.0 +trans")
-    depends_on("ectrans@1.1.0:", when="@0.31.0: +trans")
-    # variant('cgal', default=False)
-    # depends_on('cgal', when='+cgal')
+    variant("ectrans", default=False, description="Enable ectrans", when="@0.31.0:")
+    depends_on("ectrans@1.1.0:", when="+ectrans")
     variant("eigen", default=True)
     depends_on("eigen", when="+eigen")
     variant("fftw", default=True)
     depends_on("fftw-api", when="+fftw")
+    variant("cgal", default=False, description="Enable cgal")
+    depends_on("cgal", when="+cgal")
+    variant("tesselation", default=False, description="Enable tesselation", when="@0.35.0:")
+    depends_on("qhull", when="+tesselation")
 
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
 
@@ -69,11 +70,16 @@ class EcmwfAtlas(CMakePackage):
         args = [
             self.define_from_variant("ENABLE_OMP", "openmp"),
             self.define_from_variant("ENABLE_FCKIT", "fckit"),
-            self.define_from_variant("ENABLE_TRANS", "trans"),
             self.define_from_variant("ENABLE_EIGEN", "eigen"),
             self.define_from_variant("ENABLE_FFTW", "fftw"),
+            self.define_from_variant("ENABLE_CGAL", "cgal"),
             "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec["python"].command.path,
         ]
+        if self.spec.satisfies("@0.31:0.34"):
+            self.define_from_variant("ENABLE_TRANS", "ectrans")
+        if self.spec.satisfies("@0.35:"):
+            self.define_from_variant("ENABLE_ECTRANS", "ectrans")
+            self.define_from_variant("ENABLE_TESSELATION", "tesselation"),
         if "~shared" in self.spec:
             args.append("-DBUILD_SHARED_LIBS=OFF")
         return args

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -20,6 +20,7 @@ class EcmwfAtlas(CMakePackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.35.0", sha256="5a4f898ffb4a33c738b6f86e4e2a4c8e26dfd56d3c3399018081487374e29e97")
     version("0.34.0", sha256="48536742cec0bc268695240843ac0e232e2b5142d06b19365688d9ea44dbd9ba")
     version("0.33.0", sha256="a91fffe9cecb51c6ee8549cbc20f8279e7b1f67dd90448e6c04c1889281b0600")
     version("0.32.1", sha256="3d1a46cb7f50e1a6ae9e7627c158760e132cc9f568152358e5f78460f1aaf01b")

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -73,10 +73,10 @@ class EcmwfAtlas(CMakePackage):
             "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec["python"].command.path,
         ]
         if self.spec.satisfies("@0.31:0.34"):
-            self.define_from_variant("ENABLE_TRANS", "ectrans")
+            args.append(self.define_from_variant("ENABLE_TRANS", "ectrans"))
         if self.spec.satisfies("@0.35:"):
-            self.define_from_variant("ENABLE_ECTRANS", "ectrans")
-            self.define_from_variant("ENABLE_TESSELATION", "tesselation"),
+            args.append(self.define_from_variant("ENABLE_ECTRANS", "ectrans"))
+            args.append(self.define_from_variant("ENABLE_TESSELATION", "tesselation"))
         if "~shared" in self.spec:
             args.append("-DBUILD_SHARED_LIBS=OFF")
         return args


### PR DESCRIPTION
## Description

This PR cherry-picks the necessary commits from the jcsda_emc_spack_stack branch to add `ecmwf-atlas@0.35.0` and the new variant `tesselation` required for the 1.5.1 release. I've left all the other updates of ECMWF packages, including those for `ecmwf-atlas`, out.

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

Applications using `ecmwf-atlas` now have access to the `tesselation` functionality (using `qhull` as an additional dependency).

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
