### PR TITLE
release/1.5.1:  fix py-pandas/py-openpyxl version incompatibility, fix ectrans variants mkl/fftw

### DIFF
--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -46,8 +46,10 @@ class Ectrans(CMakePackage):
     depends_on("mpi", when="+mpi")
     depends_on("blas")
     depends_on("lapack")
-    depends_on("fftw-api", when="+fftw")
+    # ectrans distinguishes between mkl and fftw
+    depends_on("fftw", when="+fftw")
     depends_on("mkl", when="+mkl")
+    conflicts("+mkl", when="+fftw")
 
     depends_on("fiat~mpi", when="~mpi")
     depends_on("fiat+mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/py-openpyxl/package.py
+++ b/var/spack/repos/builtin/packages/py-openpyxl/package.py
@@ -12,6 +12,7 @@ class PyOpenpyxl(PythonPackage):
     homepage = "https://openpyxl.readthedocs.org/"
     pypi = "openpyxl/openpyxl-3.0.3.tar.gz"
 
+    version("3.0.7", sha256="6456a3b472e1ef0facb1129f3c6ef00713cebf62e736cd7a75bcc3247432f251")
     version("3.0.3", sha256="547a9fc6aafcf44abe358b89ed4438d077e9d92e4f182c87e2dc294186dc4b64")
     version("2.4.5", sha256="78c331e819fb0a63a1339d452ba0b575d1a31f09fdcce793a31bec7e9ef4ef21")
     version("2.2.0", sha256="c34e3f7e3106dbe6d792f35d9a2f01c08fdd21a6fe582a2f540e39a70e7443c4")

--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -127,4 +127,7 @@ class PyPandas(PythonPackage):
     # Optional dependencies
     # https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#optional-dependencies
 
+    # https://github.com/spack/spack/issues/40452
+    depends_on("py-openpyxl@3.0.7:", type=("run"), when="@1.5.3:")
+
     skip_modules = ["pandas.tests", "pandas.plotting._matplotlib", "pandas.core._numba.kernels"]


### PR DESCRIPTION
## Description

This time I am doing it the other way round, add to `release/1.5.1` and then merge back to develop by cherry-picking the commits ...

1. Fix https://github.com/JCSDA/spack-stack/issues/818 by adding the required version of `py-openpyxl` and the version requirement in `py-pandas`.
2. Fix https://github.com/JCSDA/spack-stack/issues/820 by explicitly asking for `mkl` (which itself is a virtual provider) or `fftw` (which is a package) instead of `fftw-api` (which is a virtual provider and can be `fftw` or `mkl`). We'll likely want to redo some of this in a cleaner way when we work on https://github.com/JCSDA/spack-stack/issues/759 in the future.

For testing, see https://github.com/JCSDA/spack-stack/pull/821

## Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/818
Resolves https://github.com/JCSDA/spack-stack/issues/820

## Dependencies

n/a

## Impact

None

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
