### PR TITLE
Add gsi-ncdiag version 1.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
+++ b/var/spack/repos/builtin/packages/gsi-ncdiag/package.py
@@ -14,6 +14,7 @@ class GsiNcdiag(CMakePackage):
 
     maintainers("ulmononian")
 
+    version("1.1.2", sha256="085884106be1f8fd94a70292102e9351c0efdf1e619a233831fafcd9ed32cd99")
     version("1.1.1", sha256="26fc10cf448dd62daa1385e38921d338778416342956c478337e6c6d1b20bf8c")
     version("1.1.0", sha256="9195801301209d6f93890944d58ffee4e24a4e35502ab27560a8c440ee53df4c")
     version("1.0.0", sha256="7251d6139c2bc1580db5f7f019e10a4c73d188ddd52ccf21ecc9e39d50a6af51")


### PR DESCRIPTION
## Description

Add tag v1.1.2 of gsi-ncdiag to the list of available packages.

## Impact

Expected impact on downstream repositories: Required for the GSI, GSI-utils, and GSI-monitor repositories.

## Checklist

- [x] I have performed a self-review of my own code