### PR TITLE
Update udunits, nco, zstd, glib, libxpm

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -310,6 +310,12 @@ class MesonBuilder(BaseBuilder, spack.build_systems.meson.MesonBuilder):
                     args.append("-Diconv=external")
                 else:
                     args.append("-Diconv=gnu")
+
+        if self.spec.satisfies("^gettext ~shared"):
+            libs = self.spec["iconv"].libs.search_flags + " " + self.spec["iconv"].libs.link_flags
+            args.append(f"-Dc_link_args={libs}")
+            args.append(f"-Dcpp_link_args={libs}")
+
         return args
 
 

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -30,3 +30,10 @@ class Libxpm(AutotoolsPackage, XorgPackage):
         if name == "ldflags" and "intl" in self.spec["gettext"].libs.names:
             flags.append("-lintl")
         return env_flags(name, flags)
+
+    def configure_args(self):
+        args = []
+        if self.spec.satisfies("^gettext ~shared"):
+            libs = self.spec["iconv"].libs.search_flags + " " + self.spec["iconv"].libs.link_flags
+            args.append(f"LIBS={libs}")
+        return args

--- a/var/spack/repos/builtin/packages/nco/package.py
+++ b/var/spack/repos/builtin/packages/nco/package.py
@@ -66,6 +66,10 @@ class Nco(AutotoolsPackage):
             config_args.append("CFLAGS=-O1")
             config_args.append("CXXFLAGS=-O1")
 
+        ncconfig = which("nc-config")
+        nc_libs = ncconfig("--static", "--libs", output=str).strip()
+        config_args.append(f"LIBS={nc_libs}")
+
         return config_args
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/udunits/package.py
+++ b/var/spack/repos/builtin/packages/udunits/package.py
@@ -35,10 +35,24 @@ class Udunits(AutotoolsPackage):
     depends_on("expat")
 
     variant("shared", default=True, description="Build shared library")
+    variant(
+        "pic",
+        default=True,
+        description="Enable position-independent code (PIC)",
+        when="~shared",
+    )
 
     @property
     def libs(self):
-        return find_libraries(["libudunits2"], root=self.prefix, recursive=True, shared=True)
+        return find_libraries(
+            "libudunits2",
+            root=self.prefix,
+            recursive=True,
+            shared=self.spec.satisfies("+shared")
+        )
 
     def configure_args(self):
-        return self.enable_or_disable("shared")
+        config_args = []
+        config_args.extend(self.enable_or_disable("shared"))
+        config_args.extend(self.with_or_without("pic"))
+        return config_args

--- a/var/spack/repos/builtin/packages/udunits/package.py
+++ b/var/spack/repos/builtin/packages/udunits/package.py
@@ -36,19 +36,13 @@ class Udunits(AutotoolsPackage):
 
     variant("shared", default=True, description="Build shared library")
     variant(
-        "pic",
-        default=True,
-        description="Enable position-independent code (PIC)",
-        when="~shared",
+        "pic", default=True, description="Enable position-independent code (PIC)", when="~shared"
     )
 
     @property
     def libs(self):
         return find_libraries(
-            "libudunits2",
-            root=self.prefix,
-            recursive=True,
-            shared=self.spec.satisfies("+shared")
+            "libudunits2", root=self.prefix, recursive=True, shared=self.spec.satisfies("+shared")
         )
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -52,11 +52,7 @@ class Zstd(CMakePackage, MakefilePackage):
         values=any_combination_of("zlib", "lz4", "lzma"),
         description="Enable support for additional compression methods in programs",
     )
-    variant(
-        "pic",
-        default=True,
-        description="Enable position-independent code (PIC)",
-    )
+    variant("pic", default=True, description="Enable position-independent code (PIC)")
 
     depends_on("zlib", when="compression=zlib")
     depends_on("lz4", when="compression=lz4")

--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -52,6 +52,11 @@ class Zstd(CMakePackage, MakefilePackage):
         values=any_combination_of("zlib", "lz4", "lzma"),
         description="Enable support for additional compression methods in programs",
     )
+    variant(
+        "pic",
+        default=True,
+        description="Enable position-independent code (PIC)",
+    )
 
     depends_on("zlib", when="compression=zlib")
     depends_on("lz4", when="compression=lz4")
@@ -60,6 +65,8 @@ class Zstd(CMakePackage, MakefilePackage):
     # +programs builds vendored xxhash, which uses unsupported builtins
     # (last tested: nvhpc@22.3)
     conflicts("+programs %nvhpc")
+
+    conflicts("+pic libs=shared")
 
     build_system("cmake", "makefile", default="makefile")
 
@@ -77,6 +84,7 @@ class CMakeBuilder(CMakeBuilder):
             [
                 self.define("ZSTD_BUILD_STATIC", self.spec.satisfies("libs=static")),
                 self.define("ZSTD_BUILD_SHARED", self.spec.satisfies("libs=shared")),
+                self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
             ]
         )
         if "compression=zlib" in spec:


### PR DESCRIPTION
## Description

This PR adds a pic variant for udunits, correct the find_libraries() call in udunits, adds static netcdf-c support to nco, and pic variant for zstd. No changes to default variants etc. w.r.t. spack-stack.

## Issue(s) addressed

--

## Dependencies

--

## Impact

--

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
