### PR TITLE
Add 'create env --modify-pkg' option for in-environment repos

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
@@ -165,7 +165,7 @@ def setup_env_parser(subparser):
     subparser.add_argument(
         "--modify-pkg",
         action="append",
-        help="Modify selected package's and place in an environment-specific repository",
+        help="Modify selected package and place in an environment-specific repository",
     )
 
 

--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/create.py
@@ -162,6 +162,12 @@ def setup_env_parser(subparser):
                 modules (not the spack environment).""",
     )
 
+    subparser.add_argument(
+        "--modify-pkg",
+        action="append",
+        help="Modify selected package's and place in an environment-specific repository",
+    )
+
 
 def setup_create_parser(subparser):
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="env_type")
@@ -201,6 +207,7 @@ def dict_from_args(args):
     dict["dir"] = args.dir
     dict["upstreams"] = args.upstream
     dict["modulesys"] = args.modulesys
+    dict["modifypkg"] = args.modify_pkg
 
     return dict
 

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -98,6 +98,7 @@ class StackEnv(object):
         self.mirror = kwargs.get("mirror", None)
         self.upstreams = kwargs.get("upstreams", None)
         self.modulesys = kwargs.get("modulesys", None)
+        self.modifypkg = kwargs.get("modifypkg", None)
 
         if not self.name:
             # site = self.site if self.site else 'default'
@@ -263,6 +264,29 @@ class StackEnv(object):
                 upstream = "upstreams:%s:install_tree:'%s'" % (name, upstream_path)
                 logging.info("Adding upstream path '%s'" % upstream_path)
                 spack.config.add(upstream, scope=env_scope)
+        if self.modifypkg:
+            logging.info("Creating custom repo with packages %s" % ", ".join(self.modifypkg))
+            env_repo_path = os.path.join(env_dir, "envrepo")
+            env_pkgs_path = os.path.join(env_repo_path, "packages")
+            os.makedirs(env_pkgs_path, exist_ok=False)
+            with open(os.path.join(env_repo_path, "repo.yaml"), "w") as f:
+                f.write("repo:\n  namespace: envrepo")
+            repo_paths = spack.config.get("repos", scope=spack.config.default_list_scope())
+            repo_paths = [p.replace("$spack/", spack.paths.spack_root+"/") for p in repo_paths]
+            for pkg_name in self.modifypkg:
+                pkg_found = False
+                for repo_path in repo_paths:
+                    pkg_path = os.path.join(repo_path, "packages", pkg_name)
+                    if os.path.exists(pkg_path):
+                        shutil.copytree(pkg_path, os.path.join(env_pkgs_path, pkg_name))
+                        pkg_found = True
+                        # Use the first repo where the package exists:
+                        break
+                if not pkg_found:
+                    logging.warning(f"WARNING: package '{pkg_name}' could not be found")
+            logging.info("Adding custom repo 'envrepo' to env config")
+            repo_cfg = "repos:[$env/envrepo]"
+            spack.config.add(repo_cfg, scope=env_scope)
 
         # Merge the original spack.yaml template back in
         # so it has the higest precedence

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -272,7 +272,7 @@ class StackEnv(object):
             with open(os.path.join(env_repo_path, "repo.yaml"), "w") as f:
                 f.write("repo:\n  namespace: envrepo")
             repo_paths = spack.config.get("repos", scope=spack.config.default_list_scope())
-            repo_paths = [p.replace("$spack/", spack.paths.spack_root+"/") for p in repo_paths]
+            repo_paths = [p.replace("$spack/", spack.paths.spack_root + "/") for p in repo_paths]
             for pkg_name in self.modifypkg:
                 pkg_found = False
                 for repo_path in repo_paths:

--- a/lib/jcsda-emc/spack-stack/stack/stack_env.py
+++ b/lib/jcsda-emc/spack-stack/stack/stack_env.py
@@ -278,7 +278,11 @@ class StackEnv(object):
                 for repo_path in repo_paths:
                     pkg_path = os.path.join(repo_path, "packages", pkg_name)
                     if os.path.exists(pkg_path):
-                        shutil.copytree(pkg_path, os.path.join(env_pkgs_path, pkg_name))
+                        shutil.copytree(
+                            pkg_path,
+                            os.path.join(env_pkgs_path, pkg_name),
+                            ignore=shutil.ignore_patterns("__pycache__"),
+                        )
                         pkg_found = True
                         # Use the first repo where the package exists:
                         break


### PR DESCRIPTION
## Description
As discussed in the last spack-stack meeting, this PR adds an option to the `spack stack create env` command called `--modify-pkg`. Invoking `spack stack create env --modify-pkg hdf5` will copy the hdf5 repo dir into the following directory structure: `$SPACK_ENV/envrepo/packages/hdf5/` (with package.py+patches etc.). It will automatically generate a repo.yaml under `$SPACK_ENV/envrepo` and update spack.yaml appropriately.

## Issue(s) addressed
--

## Dependencies
--

## Impact
--

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
