### PR TITLE
Added version 4.1.6 to the openmpi package

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -42,10 +42,13 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
     # Current
     version(
-        "4.1.5", sha256="a640986bc257389dd379886fdae6264c8cfa56bc98b71ce3ae3dfbd8ce61dbe3"
-    )  # libmpi.so.40.30.5
+        "4.1.6", sha256="f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415"
+    )  # libmpi.so.40.30.6
 
     # Still supported
+    version(
+        "4.1.5", sha256="a640986bc257389dd379886fdae6264c8cfa56bc98b71ce3ae3dfbd8ce61dbe3"
+    )  # libmpi.so.40.30.5
     version(
         "4.1.4", sha256="92912e175fd1234368c8730c03f4996fe5942e7479bb1d10059405e7f2b3930d"
     )  # libmpi.so.40.30.4


### PR DESCRIPTION
## Description

This PR adds the version 4.1.6 to the openmpi packge, which was accomplished by cherry picking from the authoritative spack repo.

## Issue(s) addressed

Partially addresses jcsda/spack-stack#829

## Dependencies

List the other PRs that this PR is dependent on:
- [x] Testing in jcsda/spack-stack/pull/846

## Impact

Expected impact on downstream repositories:
None - simply making openmpi@4.1.6 available (configuration has not been updated)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] I have run the unit tests before creating the PR
