### PR TITLE
release/1.5.1: Add fms@2023.03

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -18,6 +18,7 @@ class Fms(CMakePackage):
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett", "rem1776", "climbfuji")
 
+    version("2023.03", sha256="008a9ff394efe6a8adbcf37dd45ca103e00ae25748fc2960b7bc54f2f3b08d85")
     version(
         "2023.02.01", sha256="1597f7a485d02e401ce76444b2401060d74bd032cbb060cef917f001b4ff14bc"
     )


### PR DESCRIPTION
## Description

Add checksum for `fms@2023.03`. Required for https://github.com/ufs-community/ufs-weather-model/issues/1874.

Already installed in addition to existing fms versions in 1.5.0 on Hercules with Intel and GNU, tested with ufs-weather-model on that platform and also in CI in parent PR https://github.com/JCSDA/spack-stack/pull/855.

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/860

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
