### PR TITLE
Add symlinks for hdf5 library names when built in debug mode (cherry-picked from spack #40965)

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -702,6 +702,16 @@ class Hdf5(CMakePackage):
                     if not os.path.exists(tgt_filename):
                         symlink(src_filename, tgt_filename)
 
+    @run_after("install")
+    def link_debug_libs(self):
+        # When build_type is Debug, the hdf5 build appends _debug to all library names.
+        # Dependents of hdf5 (netcdf-c etc.) can't handle those, thus make symlinks.
+        libs = find(self.prefix.lib, "libhdf5*_debug.*", recursive=False)
+        with working_dir(self.prefix.lib):
+            for lib in libs:
+                libname = os.path.split(lib)[1]
+                os.symlink(libname, libname.replace("_debug", ""))
+
     @property
     @llnl.util.lang.memoized
     def _output_version(self):

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -706,11 +706,12 @@ class Hdf5(CMakePackage):
     def link_debug_libs(self):
         # When build_type is Debug, the hdf5 build appends _debug to all library names.
         # Dependents of hdf5 (netcdf-c etc.) can't handle those, thus make symlinks.
-        libs = find(self.prefix.lib, "libhdf5*_debug.*", recursive=False)
-        with working_dir(self.prefix.lib):
-            for lib in libs:
-                libname = os.path.split(lib)[1]
-                os.symlink(libname, libname.replace("_debug", ""))
+        if "build_type=Debug" in self.spec:
+            libs = find(self.prefix.lib, "libhdf5*_debug.*", recursive=False)
+            with working_dir(self.prefix.lib):
+                for lib in libs:
+                    libname = os.path.split(lib)[1]
+                    os.symlink(libname, libname.replace("_debug", ""))
 
     @property
     @llnl.util.lang.memoized


### PR DESCRIPTION
## Description

See https://github.com/spack/spack/pull/40965 for details, and https://github.com/JCSDA/spack-stack/issues/865 for some background information

## Issue(s) addressed

None created

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
