### PR TITLE
Add Boost 1.83.0

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -27,6 +27,7 @@ class Boost(Package):
     maintainers("hainest")
 
     version("develop", branch="develop", submodules=True)
+    version("1.83.0", sha256="6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e")
     version("1.82.0", sha256="a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6")
     version("1.81.0", sha256="71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa")
     version("1.80.0", sha256="1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0")


### PR DESCRIPTION
## Description

This PR adds the version statement in the boost package.py script for the latest Boost version: 1.83.0. This change was formed by cherry picking the commit from the authoritative spack repo.

## Issue(s) addressed

Partial resolution of jcsda/spack-stack/issues/874

## Dependencies

List the other PRs that this PR is dependent on:
None

## Impact

Expected impact on downstream repositories:
This PR needs to be merged before: jcsda/spack-stack/pull/875

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [ ] I have run the unit tests before creating the PR
