### PR TITLE
Ensure proper setting for BOOST_NO_CXX98_FUNCTION_BASE control when building ecflow with C++17

### DIFF
--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -111,7 +111,7 @@ class Ecflow(CMakePackage):
 
         if "cxxstd" in spec.variants:
             cxxstd = spec.variants["cxxstd"].value
-            if ((cxxstd == "17") or (cxxstd == "20")):
+            if (cxxstd == "17") or (cxxstd == "20"):
                 args.append("-DCMAKE_CXX_FLAGS=-DBOOST_NO_CXX98_FUNCTION_BASE")
 
         return args

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -24,6 +24,7 @@ class Ecflow(CMakePackage):
     maintainers("climbfuji")
 
     # https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.8.3-Source.tar.gz?api=v2
+    version("5.11.4", sha256="4836a876277c9a65a47a3dc87cae116c3009699f8a25bab4e3afabf160bcf212")
     version("5.8.4", sha256="bc628556f8458c269a309e4c3b8d5a807fae7dfd415e27416fe9a3f544f88951")
     version("5.8.3", sha256="1d890008414017da578dbd5a95cb1b4d599f01d5a3bb3e0297fe94a87fbd81a6")
     version("4.13.0", sha256="c743896e0ec1d705edd2abf2ee5a47f4b6f7b1818d8c159b521bdff50a403e39")
@@ -36,6 +37,14 @@ class Ecflow(CMakePackage):
     )
     variant("ui", default=False, description="Enable ecflow_ui")
     variant("pic", default=False, description="Enable position-independent code (PIC)")
+
+    variant(
+        "cxxstd",
+        default="default",
+        values=("default", "98", "11", "14", "17", "20"),
+        multi=False,
+        description="Use the specified C++ standard when building.",
+    )
 
     extends("python")
 
@@ -99,6 +108,11 @@ class Ecflow(CMakePackage):
             ssl_libs = [os.path.join(spec["openssl"].prefix.lib, "libcrypto.a")]
             ssl_libs.extend(spec["zlib"].libs)
             args.append(self.define("OPENSSL_CRYPTO_LIBRARY", ";".join(ssl_libs)))
+
+        if "cxxstd" in spec.variants:
+            cxxstd = spec.variants["cxxstd"].value
+            if ((cxxstd == "17") or (cxxstd == "20")):
+                args.append("-DCMAKE_CXX_FLAGS=-DBOOST_NO_CXX98_FUNCTION_BASE")
 
         return args
 

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -37,14 +37,6 @@ class Ecflow(CMakePackage):
     variant("ui", default=False, description="Enable ecflow_ui")
     variant("pic", default=False, description="Enable position-independent code (PIC)")
 
-    variant(
-        "cxxstd",
-        default="default",
-        values=("default", "98", "11", "14", "17", "20"),
-        multi=False,
-        description="Use the specified C++ standard when building.",
-    )
-
     extends("python")
 
     depends_on("python@3:", type=("build", "run"))
@@ -108,10 +100,8 @@ class Ecflow(CMakePackage):
             ssl_libs.extend(spec["zlib"].libs)
             args.append(self.define("OPENSSL_CRYPTO_LIBRARY", ";".join(ssl_libs)))
 
-        if "cxxstd" in spec.variants:
-            cxxstd = spec.variants["cxxstd"].value
-            if (cxxstd == "17") or (cxxstd == "20"):
-                args.append("-DCMAKE_CXX_FLAGS=-DBOOST_NO_CXX98_FUNCTION_BASE")
+        if self.spec.satisfies("@5.8.3:"):
+            args.append("-DCMAKE_CXX_FLAGS=-DBOOST_NO_CXX98_FUNCTION_BASE")
 
         return args
 

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -23,7 +23,6 @@ class Ecflow(CMakePackage):
 
     maintainers("climbfuji")
 
-    # https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.8.3-Source.tar.gz?api=v2
     version("5.11.4", sha256="4836a876277c9a65a47a3dc87cae116c3009699f8a25bab4e3afabf160bcf212")
     version("5.8.4", sha256="bc628556f8458c269a309e4c3b8d5a807fae7dfd415e27416fe9a3f544f88951")
     version("5.8.3", sha256="1d890008414017da578dbd5a95cb1b4d599f01d5a3bb3e0297fe94a87fbd81a6")


### PR DESCRIPTION
## Description

This PR properly defines BOOST_NO_CXX98_FUNCTION_BASE when building ecflow with the C++17 standard. The ecflow CMake configuration has been setting the C++17 standard since version 5.8.3 (ie, using the `-std=gnu++17` compiler option). When using C++17, the boost executor.hpp include file needs to have BOOST_NO_CXX98_FUNCTION_BASE defined to build successfully.

I have a PR in the authoritative spack repo (https://github.com/spack/spack/pull/41120)  with corresponding updates. The changes in this PR were made by cherry picking the commits from https://github.com/spack/spack/pull/41120.

I've tested these changes on my Mac and verified that building ecflow (5.11.4) works when using apple-clang@15.0.0 compilers.

## Issue(s) addressed

Partially resolves  jcsda/spack-stack/issues/877

## Dependencies

List the other PRs that this PR is dependent on:
None

## Impact

Expected impact on downstream repositories:
None

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [ ] I have run the unit tests before creating the PR
