### PR TITLE
Fix bug for Linux in var/spack/repos/builtin/packages/py-shapely/shapely-1.8.0-geos.py.patch

### DIFF
--- a/var/spack/repos/builtin/packages/py-shapely/shapely-1.8.0-geos.py.patch
+++ b/var/spack/repos/builtin/packages/py-shapely/shapely-1.8.0-geos.py.patch
@@ -1,6 +1,6 @@
---- a/shapely/geos.py	2022-08-24 13:21:33.000000000 -0600
-+++ b/shapely/geos.py	2022-08-24 13:23:54.000000000 -0600
-@@ -88,14 +88,21 @@
+--- a/shapely/geos.py	2023-11-29 20:34:39.000000000 -0700
++++ b/shapely/geos.py	2023-11-29 20:35:39.000000000 -0700
+@@ -88,14 +88,26 @@
          if len(geos_pyinstaller_so) >= 1:
              _lgeos = CDLL(geos_pyinstaller_so[0])
              LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
@@ -20,7 +20,12 @@
 -        ]
 +        # Use geos installation if spack geos module is loaded
 +        if 'geos_ROOT' in os.environ:
-+            alt_paths = [os.path.join(os.environ['geos_ROOT'], 'lib', 'libgeos_c.dylib')]
++            alt_paths = [
++                os.path.join(os.environ['geos_ROOT'], 'lib', 'libgeos_c.so'),
++                os.path.join(os.environ['geos_ROOT'], 'lib64', 'libgeos_c.so'),
++                os.path.join(os.environ['geos_ROOT'], 'lib', 'libgeos_c.so.1'),
++                os.path.join(os.environ['geos_ROOT'], 'lib64', 'libgeos_c.so.1'),
++            ]
 +        else:
 +            alt_paths = [
 +                'libgeos_c.so.1',
@@ -29,7 +34,7 @@
          _lgeos = load_dll('geos_c', fallbacks=alt_paths)
  
      # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
-@@ -119,10 +126,12 @@
+@@ -119,10 +131,12 @@
          else:
              _lgeos = CDLL(geos_whl_dylib)
              LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
@@ -46,7 +51,7 @@
      else:
          if hasattr(sys, 'frozen'):
              try:
-@@ -139,6 +148,9 @@
+@@ -139,6 +153,9 @@
                  if hasattr(sys, '_MEIPASS'):
                      alt_paths.append(
                          os.path.join(sys._MEIPASS, 'libgeos_c.1.dylib'))


### PR DESCRIPTION
## Description

Years ago I created a patch for shapely to correct the crude logic in the package's `geos.py` file (which is responsible for finding the `geos` library and dll-open it). The bug fix for macOS was mistakenly copied in for Linux, too. So far it hasn't caused problems ... until today. This bug fix here fixes the bug fix from years ago. It was tested on AWS, Red Hat 8, where the error was reported first. (Some settings in the user environment triggered the wrongly patched branch of the if condition for Linux).

## Issue(s) addressed

See above

## Dependencies

n/a

## Impact

Expected impact on downstream repositories: none

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR - tested installing on macOS, and tested to work on Red Hat Linux
