### PR TITLE
Apply patch for fms@2023.03 with gcc10: and *mpich*

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -45,6 +45,13 @@ class Fms(CMakePackage):
         "2020.04.01", sha256="2c409242de7dea0cf29f8dbf7495698b6bcac1eeb5c4599a728bdea172ffe37c"
     )
 
+    # https://github.com/NOAA-GFDL/FMS/issues/1417
+    patch(
+        "https://github.com/NOAA-GFDL/FMS/pull/1418/commits/c9bba516ba1115d4a7660fba92f9d67cf3fd32ad.patch?full_index=1",
+        sha256="f835c54b2898c980a4cc2a9786134af91a8b1e8b1f11b1734227c6dea26c3b79",
+        when="@2023.03",
+    )
+
     # DH* 20220602
     # These versions were adapated by JCSDA and are only meant to be
     # used temporarily, until the JCSDA changes have found their way


### PR DESCRIPTION
## Description

See https://github.com/NOAA-GFDL/FMS/issues/1417. This is needed to build fms@2023.03 on Derecho with gcc@12 and cray-mpich. I had to make this modification manually when rolling out spack-stack-1.5.1 and then forgot to submit the bug fix. Tested on Derecho, and the FMS team also tested this on their systems. See https://github.com/NOAA-GFDL/FMS/pull/1418.

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

Expected impact on downstream repositories: n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
