### PR TITLE
From spack-dev: Fix curl install using Intel compilers (#41380)

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -330,6 +330,12 @@ class Curl(NMakePackage, AutotoolsPackage):
     def command(self):
         return Executable(self.prefix.bin.join("curl-config"))
 
+    def flag_handler(self, name, flags):
+        build_system_flags = []
+        if name == "cflags" and self.spec.compiler.name in ["intel", "oneapi"]:
+            build_system_flags = ["-we147"]
+        return flags, None, build_system_flags
+
 
 class AutotoolsBuilder(AutotoolsBuilder):
     def configure_args(self):


### PR DESCRIPTION
## Description

Cherry-picking https://github.com/spack/spack/pull/41380#event-11127550396: Fix installation issue #27709: curl does not configure/build with Intel compilers spa #41380:  When using Intel to build curl, add 'CFLAGS=-we147' to the configure args to fix error 'compiler does not halt on function prototype mismatch'

## Issue(s) addressed

See https://github.com/spack/spack/issues/27709 and https://github.com/JCSDA/spack-stack/pull/880#issuecomment-1836347452

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
