### PR TITLE
Version updates for spack-stack-1.6.0: eckit@1.24.5, ecmwf-atlas@0.35.1, esmf@8.6.0, fms@2023.04

### DIFF
--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -89,8 +89,8 @@ def test_which_with_slash_ignores_path(tmpdir, working_env):
         assert exe.path == path
 
 
-def test_which(tmpdir):
-    os.environ["PATH"] = str(tmpdir)
+def test_which(tmpdir, monkeypatch):
+    monkeypatch.setenv("PATH", str(tmpdir))
     assert ex.which("spack-test-exe") is None
 
     with pytest.raises(ex.CommandNotFoundError):

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -18,6 +18,7 @@ class Eckit(CMakePackage):
 
     maintainers("skosukhin", "climbfuji")
 
+    version("1.24.5", sha256="2fd74e04c20a59f9e13635828d9da880e18f8a2cb7fd3bfd0201e07071d6ec41")
     version("1.24.4", sha256="b6129eb4f7b8532aa6905033e4cf7d09aadc8547c225780fea3db196e34e4671")
     version("1.23.1", sha256="cd3c4b7a3a2de0f4a59f00f7bab3178dd59c0e27900d48eaeb357975e8ce2f15")
     version("1.23.0", sha256="3cac55ddf7036ecd32cb0974a1ec3a2d347de574ab3a2c0bb6c6f8982e5a7a09")

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -20,6 +20,7 @@ class EcmwfAtlas(CMakePackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.35.1", sha256="7a344aaa8a1378d989a7bb883eb741852c5fa494630be6d8c88e477e4b9c5be1")
     version("0.35.0", sha256="5a4f898ffb4a33c738b6f86e4e2a4c8e26dfd56d3c3399018081487374e29e97")
     version("0.34.0", sha256="48536742cec0bc268695240843ac0e232e2b5142d06b19365688d9ea44dbd9ba")
     version("0.33.0", sha256="a91fffe9cecb51c6ee8549cbc20f8279e7b1f67dd90448e6c04c1889281b0600")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -28,7 +28,8 @@ class Esmf(MakefilePackage):
 
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
-    # generate chksum with spack checksum esmf@x.y.z
+    # generate chksum with 'spack checksum esmf@x.y.z'
+    version("8.6.0", sha256="ed057eaddb158a3cce2afc0712b49353b7038b45b29aee86180f381457c0ebe7")
     version("8.5.0", sha256="acd0b2641587007cc3ca318427f47b9cae5bfd2da8d2a16ea778f637107c29c4")
     version("8.4.2", sha256="969304efa518c7859567fa6e65efd960df2b4f6d72dbf2c3f29e39e4ab5ae594")
     version("8.4.1", sha256="1b54cee91aacaa9df400bd284614cbb0257e175f6f3ec9977a2d991ed8aa1af6")

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -18,6 +18,7 @@ class Fms(CMakePackage):
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett", "rem1776", "climbfuji")
 
+    version("2023.04", sha256="feb895ea2b3269ca66df296199a36af335f0dc281e2dab2f1bfebb19fd9c22c4")
     version("2023.03", sha256="008a9ff394efe6a8adbcf37dd45ca103e00ae25748fc2960b7bc54f2f3b08d85")
     version(
         "2023.02.01", sha256="1597f7a485d02e401ce76444b2401060d74bd032cbb060cef917f001b4ff14bc"

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-ufs-env/package.py
@@ -17,7 +17,7 @@ class JediUfsEnv(BundlePackage):
     version("1.0.0")
 
     depends_on("jedi-base-env", type="run")
-    depends_on("fms@2023.01+pic", type="run")
+    depends_on("fms@2023.04+pic", type="run")
 
     depends_on("bacio", type="run")
     depends_on("g2", type="run")

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-srw-app-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-srw-app-env/package.py
@@ -25,7 +25,7 @@ class UfsSrwAppEnv(BundlePackage):
     depends_on("netcdf-fortran")
     depends_on("parallelio")
     depends_on("esmf")
-    depends_on("fms@2023.01")
+    depends_on("fms@2023.04")
     depends_on("bacio")
     depends_on("crtm@2.4.0")
     depends_on("g2")

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
@@ -26,7 +26,7 @@ class UfsWeatherModelEnv(BundlePackage):
     depends_on("base-env", type="run")
     depends_on("ufs-pyenv", type="run", when="+python")
 
-    depends_on("fms@2023.03", type="run")
+    depends_on("fms@2023.04", type="run")
     depends_on("bacio", type="run")
     depends_on("crtm@2.4.0", type="run")
     depends_on("g2", type="run")


### PR DESCRIPTION
## Description

Various version updates for spack-stack-1.6.0:
- eckit@1.24.5 (need to cherry-pick and send to spack develop: https://github.com/spack/spack/pull/41547)
- ecmwf-atlas@0.35.1 (need to cherry-pick and send to spack develop: https://github.com/spack/spack/pull/41547)
- esmf@8.6.0 (cherry-picked from spack develop)
- fms@2023.04 (need to cherry-pick from spack after merging https://github.com/spack/spack/pull/41550 and resolve conflicts, because someone else added it to spack mainline in the meantime, too)

Also:
- bump fms in ufs-weather-model-env, ufs-srw-app-env, jedi-ufs-env to 2023.04
- cherry-pick https://github.com/spack/spack/pull/41215 to hopefully fix the failing macOS unit tests (and even if not, it's good to have this bug fix)

## Testing

See https://github.com/JCSDA/spack-stack/pull/897

## Issue(s) addressed

See https://github.com/JCSDA/spack-stack/pull/897

## Dependencies

n/a

## Impact

Everything that will be using spack-stack-1.6.1

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
