### PR TITLE
New package MCT (Model Coupling Toolkit), cherry-pick cprnc from spack develop, add to relevant meta packages, fix esmf.mk compiler paths on Cray

### DIFF
--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Cprnc(CMakePackage):
+    """CPRNC is a netcdf file comparison tool used by CESM
+    and other scientific programs."""
+
+    url = "https://github.com/ESMCI/cprnc/archive/refs/tags/v1.0.1.tar.gz"
+    homepage = "https://github.com/ESMCI/cprnc"
+
+    maintainers("jedwards4b", "billsacks")
+
+    version("1.0.1", sha256="19517b52688f5ce40c385d7a718e06bf88a8731335943bc32e2b8410c489d6eb")
+
+    depends_on("netcdf-fortran")
+    depends_on("cmake@3:", type="build")

--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -15,7 +15,10 @@ class Cprnc(CMakePackage):
 
     maintainers("jedwards4b", "billsacks")
 
-    version("1.0.1", sha256="19517b52688f5ce40c385d7a718e06bf88a8731335943bc32e2b8410c489d6eb")
+    version("1.0.3", sha256="3e7400f9a13d5de01964d7dd95151d08e6e30818d2a1efa9a9c7896cf6646d69")
+    version("1.0.2", sha256="02edfa8050135ac0dc4a74aea05d19b0823d769b22cafa88b9352e29723d4179")
+    version("1.0.1", sha256="b8a8fd4ad7e2716968dfa60f677217c55636580807b1309276f4c062ee432ccd")
+    version("1.0.0", sha256="70ff75bbf01a0cef885db3074c78f39a8890949ca505530c0407398b8803552c")
 
     depends_on("netcdf-fortran")
     depends_on("cmake@3:", type="build")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -136,6 +136,14 @@ class Esmf(MakefilePackage):
     # https://github.com/spack/spack/issues/35957
     patch("esmf_cpp_info.patch")
 
+    # This is strictly required on Cray systems that use
+    # the Cray compiler wrappers, where we need to swap
+    # out the spack compiler wrappers in esmf.mk with the
+    # Cray wrappers. It doesn't hurt/have any effect on
+    # other systems where the logic in setup_build_environment
+    # below sets the compilers to the MPI wrappers.
+    filter_compiler_wrappers("esmf.mk", relative_root="lib")
+
     # Make script from mvapich2.patch executable
     @when("@:7.0")
     @run_before("build")

--- a/var/spack/repos/builtin/packages/mct/package.py
+++ b/var/spack/repos/builtin/packages/mct/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Mct(AutotoolsPackage):
+    """Model Coupling Toolkit (MCT): toolkit to support the construction
+    of highly portable and extensible high-performance couplers for
+    distributed memory parallel coupled models."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://github.com/MCSclimate/MCT"
+    url = "https://github.com/MCSclimate/MCT/archive/refs/tags/MCT_2.11.0.tar.gz"
+
+    maintainers("climbfuji")
+
+    # This is a custom license that doesn't match any of the ones listed
+    # in https://spdx.org/licenses/, but similar to Creative Commons?
+    license("https://github.com/MCSclimate/MCT/blob/master/LICENSE")
+
+    version("2.11.0", sha256="1b2a30bcba0081226ff1f1f5152e82afa3a2bb911215883965e669f776dcb365")
+    version("2.10.0", sha256="42f32e3ab8bba31d16a1c6c9533f717a9d950e42c9b03b864b3436335d4e1b71")
+
+    variant("mpi", default=True, description="Enable MPI support")
+
+    depends_on("mpi", when="+mpi")
+
+    def configure_args(self):
+        args = []
+        if self.spec.satisfies("~mpi"):
+            args.append("--enable-mpiserial")
+        return args

--- a/var/spack/repos/builtin/packages/mct/package.py
+++ b/var/spack/repos/builtin/packages/mct/package.py
@@ -16,9 +16,9 @@ class Mct(AutotoolsPackage):
 
     maintainers("climbfuji")
 
-    # This is a custom license that doesn't match any of the ones listed
-    # in https://spdx.org/licenses/, but similar to Creative Commons?
-    license("https://github.com/MCSclimate/MCT/blob/master/LICENSE")
+    # TODO: MCT uses a custom license not representable by an SPDX identifier.
+    # Once there is a consensus and documentation on how to represent custom
+    # licenses, add a license annotation here.
 
     version("2.11.0", sha256="1b2a30bcba0081226ff1f1f5152e82afa3a2bb911215883965e669f776dcb365")
     version("2.10.0", sha256="42f32e3ab8bba31d16a1c6c9533f717a9d950e42c9b03b864b3436335d4e1b71")

--- a/var/spack/repos/builtin/packages/mct/package.py
+++ b/var/spack/repos/builtin/packages/mct/package.py
@@ -11,7 +11,6 @@ class Mct(AutotoolsPackage):
     of highly portable and extensible high-performance couplers for
     distributed memory parallel coupled models."""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://github.com/MCSclimate/MCT"
     url = "https://github.com/MCSclimate/MCT/archive/refs/tags/MCT_2.11.0.tar.gz"
 

--- a/var/spack/repos/builtin/packages/mct/package.py
+++ b/var/spack/repos/builtin/packages/mct/package.py
@@ -24,12 +24,4 @@ class Mct(AutotoolsPackage):
     version("2.11.0", sha256="1b2a30bcba0081226ff1f1f5152e82afa3a2bb911215883965e669f776dcb365")
     version("2.10.0", sha256="42f32e3ab8bba31d16a1c6c9533f717a9d950e42c9b03b864b3436335d4e1b71")
 
-    variant("mpi", default=True, description="Enable MPI support")
-
-    depends_on("mpi", when="+mpi")
-
-    def configure_args(self):
-        args = []
-        if self.spec.satisfies("~mpi"):
-            args.append("--enable-mpiserial")
-        return args
+    depends_on("mpi")

--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-neptune-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-neptune-env/package.py
@@ -25,5 +25,6 @@ class JediNeptuneEnv(BundlePackage):
     depends_on("w3nco", type="run")
     depends_on("esmf", type="run")
     depends_on("nco", type="run")
+    depends_on("mct", type="run")
 
     # There is no need for install() since there is no code.

--- a/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/ufs-weather-model-env/package.py
@@ -35,6 +35,7 @@ class UfsWeatherModelEnv(BundlePackage):
     depends_on("sp", type="run")
     depends_on("w3emc", type="run")
     depends_on("scotch", type="run")
+    depends_on("cprnc", type="run")
 
     depends_on("esmf~debug", type="run", when="~debug")
     depends_on("esmf+debug", type="run", when="+debug")


### PR DESCRIPTION
## Description

1. Add new package `mct` (Model Coupling Toolkit). Corresponding spack PR: https://github.com/spack/spack/pull/41564 - merged
2. Cherry-pck `cprnc` from spack develop (including the bug fix for the checksums)
3. Add `mct` to `jedi-neptune-env`
4. Add `cprnc` to `ufs-weather-model-env`
5. Fix spack compiler wrappers in `esmf.mk` on Cray systems where `cc`, `CC`, `ftn` are used. See spack PR https://github.com/spack/spack/pull/41640 - @sking112 @michalakes FYI

## Testing

- [x] Installed on macOS with apple-clang@13.1.6 and openmpi@4.1.6
- [x] Installed on Narwhal with intel@2021.4.0, verified that the fix for ESMF in 5. is working as expected

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/885
Working towards https://github.com/JCSDA/spack-stack/issues/845
Fixes https://github.com/JCSDA/spack-stack/issues/892

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
