### PR TITLE
Add boto3 to Swell Python Packages

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/gmao-swell-env/package.py
@@ -31,6 +31,7 @@ class GmaoSwellEnv(BundlePackage):
     # depends_on("geos-dev-env", type="run")  # We should have the modules needed to build GEOSgcm
 
     # Python packages for swell, eva, and other utilities
+    depends_on("py-boto3", type="run")
     depends_on("py-cartopy", type="run")
     depends_on("py-click", type="run")
     depends_on("py-contourpy", type="run")


### PR DESCRIPTION
## Description

Adds the boto3 package to swell, a dependency of the old version of r2d2 we are using.

## Issue(s) addressed

N/A

## Dependencies

N/A

## Impact

N/A

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have run the unit tests before creating the PR
