### PR TITLE
Add prod-util@2.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/prod-util/package.py
+++ b/var/spack/repos/builtin/packages/prod-util/package.py
@@ -19,6 +19,7 @@ class ProdUtil(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("2.1.1", sha256="2f7507fa378a44f42b971f60de8152387c311bfa9c5c05a274c87b43a143aacd")
     version("2.1.0", sha256="fa7df4a82dae269ffb347b9007376fb0d9979c17c4974814ea82204b12d70ea5")
 
     depends_on("w3emc")


### PR DESCRIPTION
## Description

See title. Testing: see https://github.com/JCSDA/spack-stack/pull/906

@AlexanderRichert-NOAA I saw that there are quite a few differences between prod-util in spack mainline and our fork, therefore didn't attempt to cherry-pick the commit here (413840a18074cc779085ba68448c056c73e3d8fd) and send it upstream.

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
