### PR TITLE
For spack-stack 1.6.0: Update eccodes from spack/develop (add 2.31.0, 2.32.0)

### DIFF
--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -48,6 +48,8 @@ class Eccodes(CMakePackage):
     maintainers("skosukhin")
 
     version("develop", branch="develop")
+    version("2.32.0", sha256="b57e8eeb0eba0c05d66fda5527c4ffa84b5ab35c46bcbc9a2227142973ccb8e6")
+    version("2.31.0", sha256="808ecd2c11fbf2c3f9fc7a36f8c2965b343f3151011b58a1d6e7cc2e6b3cac5d")
     version("2.27.0", sha256="ede5b3ffd503967a5eac89100e8ead5e16a881b7585d02f033584ed0c4269c99")
     version("2.25.0", sha256="8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e")
     version("2.24.2", sha256="c60ad0fd89e11918ace0d84c01489f21222b11d6cad3ff7495856a0add610403")
@@ -71,7 +73,7 @@ class Eccodes(CMakePackage):
     )
     variant("png", default=False, description="Enable PNG support for decoding/encoding")
     variant(
-        "aec", default=False, description="Enable Adaptive Entropy Coding for decoding/encoding"
+        "aec", default=True, description="Enable Adaptive Entropy Coding for decoding/encoding"
     )
     variant("pthreads", default=False, description="Enable POSIX threads")
     variant("openmp", default=False, description="Enable OpenMP threads")
@@ -107,6 +109,7 @@ class Eccodes(CMakePackage):
     depends_on("cmake@3.12:", when="@2.19:", type="build")
 
     depends_on("ecbuild", type="build", when="@develop")
+    depends_on("ecbuild@3.7:", type="build", when="@2.25:")
 
     conflicts("+openmp", when="+pthreads", msg="Cannot enable both POSIX threads and OMP")
 


### PR DESCRIPTION
## Description

This PR cherry-picks https://github.com/spack/spack/pull/40770 (had to resolve conflicts because we added 2.27.0 in the past, which is not in spack/develop).

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/911

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
