### PR TITLE
release/1.6.0: change crtm build type to release (from spack develop)

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -27,13 +27,6 @@ class Crtm(CMakePackage):
     variant(
         "fix", default=False, description='Download CRTM coeffecient or "fix" files (several GBs).'
     )
-    variant(
-        "build_type",
-        default="RelWithDebInfo",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     depends_on("cmake@3.15:", type="build")
     depends_on("git-lfs")
     depends_on("netcdf-fortran", when="@2.4.0:")

--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -41,12 +41,6 @@ class Draco(CMakePackage):
     version("6.20.1", sha256="b1c51000c9557e0818014713fce70d681869c50ed9c4548dcfb2e9219c354ebe")
     version("6.20.0", sha256="a6e3142c1c90b09c4ff8057bfee974369b815122b01d1f7b57888dcb9b1128f6")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
     variant("caliper", default=False, description="Enable caliper timers support")
     variant("cuda", default=False, description="Enable Cuda/GPU support")
     variant("eospac", default=True, description="Enable EOSPAC support")

--- a/var/spack/repos/builtin/packages/libtree/package.py
+++ b/var/spack/repos/builtin/packages/libtree/package.py
@@ -54,12 +54,6 @@ class Libtree(MakefilePackage, CMakePackage):
     with when("build_system=cmake"):
         variant("chrpath", default=False, description="Use chrpath for deployment")
         variant("strip", default=False, description="Use binutils strip for deployment")
-        variant(
-            "build_type",
-            default="RelWithDebInfo",
-            description="CMake build type",
-            values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-        )
         depends_on("googletest", type="test")
         depends_on("cmake@3:", type="build")
         depends_on("chrpath", when="+chrpath", type="run")


### PR DESCRIPTION
## Description

Cherry-picking Simplify a few CMakePackages by removing redundant directives (https://github.com/spack/spack/pull/41163), which sets the CRTM build type to the default (`Release`). Needed for release/1.6.0

The other packages that are affected by pulling the change from spack develop are of no relevance for our environments.

For CI testing, see https://github.com/JCSDA/spack-stack/pull/919

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/827

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
