### PR TITLE
release/1.6.0: bug fix for in py-gevent to build with Intel / oneAPI compilers

### DIFF
--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -54,4 +54,6 @@ class PyGevent(PythonPackage):
         if name == "cflags":
             if self.spec.satisfies("%oneapi@2023:"):
                 flags.append("-Wno-error=incompatible-function-pointer-types")
+            if self.spec.compiler.name in ["intel", "oneapi"]:
+                flags.append("-we147")
         return (flags, None, None)


### PR DESCRIPTION
## Description

See spack mainline PR for a description: https://github.com/spack/spack/pull/41896
> py-gevent fails to build with some versions of Intel / oneAPI compilers (we've observed this on some but not all systems, with Intel versions ranging from intel@18.x.y to the latest oneAPI (classic) compilers.
> I recently fixed a similar build error for curl (https://github.com/spack/spack/pull/41380), and conveniently the same method works for py-gevent. I tested this successfully on one of the Navy's HPCs.
