### PR TITLE
release/1.6.0: bugfix - repair dockerfile template

### DIFF
--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -43,6 +43,9 @@ RUN find -L {{ paths.view }}/* -type f -exec readlink -f '{}' \; | \
 RUN cd {{ paths.environment }} && \
     spack env activate --sh -d . > activate.sh
 
+{% if extra_instructions.build %}
+{{ extra_instructions.build }}
+{% endif %}
 {% endblock build_stage %}
 {% endif %}
 
@@ -74,6 +77,10 @@ RUN { \
 RUN {% if os_package_update %}{{ os_packages_final.update }} \
  && {% endif %}{{ os_packages_final.install }} {{ os_packages_final.list | join | replace('\n', ' ') }} \
  && {{ os_packages_final.clean }}
+{% endif %}
+{% if extra_instructions.final %}
+
+{{ extra_instructions.final }}
 {% endif %}
 {% endblock final_stage %}
 {% for label, value in labels.items() %}


### PR DESCRIPTION
## Description

The recent update of our spack fork from spack develop removed important pieces of the Dockerfile template, which broke our containers (we didn't notice, because we only build them but don't run anything in them in CI).

This PR puts the two pieces of code back. I tested this with the spack-stack-1.6.0 release code and the containers are good again.

## Issue(s) addressed

Containers no longer functional since nov2023_spackmerge

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the ~~unit~~ tests before creating the PR
