### PR TITLE
For jcsda_emc_spack_stack: Add metis to virtual package jedi-mpas-env

### DIFF
--- a/var/spack/repos/jcsda-emc-bundles/packages/jedi-mpas-env/package.py
+++ b/var/spack/repos/jcsda-emc-bundles/packages/jedi-mpas-env/package.py
@@ -17,7 +17,6 @@ class JediMpasEnv(BundlePackage):
     version("1.0.0")
 
     depends_on("jedi-base-env", type="run")
-
-    # Anything missing?
+    depends_on("metis", type="run")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
## Description

All in the title. I tested this on aws-pcluster with Intel and GNU. It installs without problems and doesn't introduce any new dependencies.

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/915

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
