### PR TITLE
Fix test settings for proj (no googletest)

### DIFF
--- a/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/setup_meta_modules.py
+++ b/lib/jcsda-emc/spack-stack/stack/cmd/stack_cmds/setup_meta_modules.py
@@ -1,5 +1,3 @@
-import spack.cmd.common.arguments
-import spack.cmd.modules
 from spack.extensions.stack.meta_modules import setup_meta_modules
 
 description = "Create meta-modules"

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -85,6 +85,9 @@ class Proj(CMakePackage, AutotoolsPackage):
         when="@7:7.2.1",
     )
 
+    patch("proj.cmakelists.5.0.patch", when="@5.0")
+    patch("proj.cmakelists.5.1.patch", when="@5.1:5.2")
+
     # https://proj.org/install.html#build-requirements
     with when("build_system=cmake"):
         depends_on("cmake@3.9:", when="@6:", type="build")
@@ -137,6 +140,13 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         ]
         if self.spec.satisfies("@6:") and self.pkg.run_tests:
             args.append(self.define("USE_EXTERNAL_GTEST", True))
+        if self.spec.satisfies("@7:"):
+            test_flag = "BUILD_TESTING"
+        elif self.spec.satisfies("@5.1:"):
+            test_flag = "PROJ_TESTS"
+        else:
+            test_flag = "PROJ4_TESTS"
+        args.append(self.define(test_flag, self.pkg.run_tests))
         return args
 
 

--- a/var/spack/repos/builtin/packages/proj/proj.cmakelists.5.0.patch
+++ b/var/spack/repos/builtin/packages/proj/proj.cmakelists.5.0.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -149,5 +149,6 @@ add_subdirectory(nad)
+ add_subdirectory(src)
+ add_subdirectory(man)
+ add_subdirectory(cmake)
+-add_subdirectory(test)
+-
++if(PROJ4_TESTS)
++  add_subdirectory(test)
++endif(PROJ4_TESTS)

--- a/var/spack/repos/builtin/packages/proj/proj.cmakelists.5.1.patch
+++ b/var/spack/repos/builtin/packages/proj/proj.cmakelists.5.1.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -159,5 +159,6 @@ add_subdirectory(nad)
+ add_subdirectory(src)
+ add_subdirectory(man)
+ add_subdirectory(cmake)
+-add_subdirectory(test)
+-
++if(PROJ_TESTS)
++  add_subdirectory(test)
++endif(PROJ_TESTS)


### PR DESCRIPTION
## Description

This PR pulls in commit 013f0d3a13b4996fbfac17d0d02999ef0c248ffd from main Spack, which fixes the proj recipe by disabling the googletest-based tests when we're not using self.run_tests. This will allow us to install proj from source cache without an internet connection.

## Issue(s) addressed
Address #934

## Dependencies

none

## Impact

none

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
