### PR TITLE
Add genf90 resource for cprnc to allow offline builds

### DIFF
--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -22,3 +22,17 @@ class Cprnc(CMakePackage):
 
     depends_on("netcdf-fortran")
     depends_on("cmake@3:", type="build")
+
+    resource(
+        name="genf90",
+        git="https://github.com/PARALLELIO/genf90",
+        tag="genf90_200608",
+        destination="genf90-resource",
+    )
+
+    def cmake_args(self):
+        args = [
+            self.define("GENF90_PATH", join_path(self.stage.source_path, "genf90-resource/genf90"))
+        ]
+
+        return args


### PR DESCRIPTION
## Description
This PR, based on main spack commit f552dbd19918b6c928dd482e1de92d920902f1f3 (spack/spack#42015), add a genf90 resource for cprnc to allow pre-fetching for offline builds.

## Issue(s) addressed

Addresses https://github.com/JCSDA/spack-stack/issues/934

## Dependencies

none

## Impact

none

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
