### PR TITLE
Merge release/1.6.0 into jcsda_emc_spack_stack

### DIFF
--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -43,6 +43,9 @@ RUN find -L {{ paths.view }}/* -type f -exec readlink -f '{}' \; | \
 RUN cd {{ paths.environment }} && \
     spack env activate --sh -d . > activate.sh
 
+{% if extra_instructions.build %}
+{{ extra_instructions.build }}
+{% endif %}
 {% endblock build_stage %}
 {% endif %}
 
@@ -74,6 +77,10 @@ RUN { \
 RUN {% if os_package_update %}{{ os_packages_final.update }} \
  && {% endif %}{{ os_packages_final.install }} {{ os_packages_final.list | join | replace('\n', ' ') }} \
  && {{ os_packages_final.clean }}
+{% endif %}
+{% if extra_instructions.final %}
+
+{{ extra_instructions.final }}
 {% endif %}
 {% endblock final_stage %}
 {% for label, value in labels.items() %}

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -27,13 +27,6 @@ class Crtm(CMakePackage):
     variant(
         "fix", default=False, description='Download CRTM coeffecient or "fix" files (several GBs).'
     )
-    variant(
-        "build_type",
-        default="RelWithDebInfo",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     depends_on("cmake@3.15:", type="build")
     depends_on("git-lfs")
     depends_on("netcdf-fortran", when="@2.4.0:")

--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -41,12 +41,6 @@ class Draco(CMakePackage):
     version("6.20.1", sha256="b1c51000c9557e0818014713fce70d681869c50ed9c4548dcfb2e9219c354ebe")
     version("6.20.0", sha256="a6e3142c1c90b09c4ff8057bfee974369b815122b01d1f7b57888dcb9b1128f6")
 
-    variant(
-        "build_type",
-        default="Release",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
     variant("caliper", default=False, description="Enable caliper timers support")
     variant("cuda", default=False, description="Enable Cuda/GPU support")
     variant("eospac", default=True, description="Enable EOSPAC support")

--- a/var/spack/repos/builtin/packages/libtree/package.py
+++ b/var/spack/repos/builtin/packages/libtree/package.py
@@ -54,12 +54,6 @@ class Libtree(MakefilePackage, CMakePackage):
     with when("build_system=cmake"):
         variant("chrpath", default=False, description="Use chrpath for deployment")
         variant("strip", default=False, description="Use binutils strip for deployment")
-        variant(
-            "build_type",
-            default="RelWithDebInfo",
-            description="CMake build type",
-            values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-        )
         depends_on("googletest", type="test")
         depends_on("cmake@3:", type="build")
         depends_on("chrpath", when="+chrpath", type="run")

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -54,4 +54,6 @@ class PyGevent(PythonPackage):
         if name == "cflags":
             if self.spec.satisfies("%oneapi@2023:"):
                 flags.append("-Wno-error=incompatible-function-pointer-types")
+            if self.spec.compiler.name in ["intel", "oneapi"]:
+                flags.append("-we147")
         return (flags, None, None)


### PR DESCRIPTION
## Description

All in the title. Minimal changes that except for the container template bug fixes are all coming from spack develop.

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/924

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (spack-stack-1.6.0 release documentation)
- [x] I have run the unit tests before creating the PR
