### PR TITLE
Bug fix for building shared ESMF on macOS, bug fix for building pflogger on Ubuntu with Intel (the latter is still WIP)

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -403,6 +403,11 @@ class Esmf(MakefilePackage):
         if "~shared" in spec:
             env.set("ESMF_SHARED_LIB_BUILD", "OFF")
 
+        # https://github.com/JCSDA/spack-stack/issues/956
+        if "+shared" in spec:
+            if sys.platform == "darwin":
+                env.set("ESMF_TRACE_LIB_BUILD", "OFF")
+
     @run_after("install")
     def post_install(self):
         install_tree("cmake", self.prefix.cmake)


### PR DESCRIPTION
## Description

- Bug fix for building ESMF shared on macOS: set ESMF_TRACE_LIB_BUILD=OFF
- Corresponding spack-develop PR (cherry-picked) is https://github.com/spack/spack/pull/42134

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/242

## Dependencies

n/a

## Impact

Expected impact on downstream repositories: n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
