### PR TITLE
Rename the amsua_metop-c CRTM-fix file on copying

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -58,21 +58,27 @@ class CrtmFix(Package):
         # Little_Endian amsua_metop-c_v2.SpcCoeff.bin is what it's supposed to be.
         # Remove the incorrect file, and install it as noACC,, then install
         # correct file under new name.
-        if "+big_endian" in spec and spec.version == Version("2.4.0_emc"):
-            remove_path = join_path(
-                os.getcwd(), "fix", "SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin"
-            )
+        if "+big_endian" in spec and spec.version in [Version("2.4.0_emc"), Version("2.4.0.1_emc")]:
+            amc_sc_path = join_path("SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin")
+            amc_sc_v2_path = join_path("SpcCoeff", "Little_Endian", "amsua_metop-c_v2.SpcCoeff.bin")
+            # In 2.4.0_emc, the path is prefixed by 'fix/'
+            if spec.version == Version("2.4.0_emc"):
+                amc_sc_path = join_path("fix", amc_sc_path)
+                amc_sc_v2_path = join_path("fix", amc_sc_v2_path)
+
+            remove_path = join_path(os.getcwd(), amc_sc_path)
+
             fix_files.remove(remove_path)
 
             # This file is incorrect, install it as a different name.
             install(
-                join_path("fix", "SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin"),
+                amc_sc_path,
                 join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.noACC.bin"),
             )
 
             # This "Little_Endian" file is actually the correct one.
             install(
-                join_path("fix", "SpcCoeff", "Little_Endian", "amsua_metop-c_v2.SpcCoeff.bin"),
+                amc_sc_v2_path,
                 join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.bin"),
             )
 

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -58,7 +58,8 @@ class CrtmFix(Package):
         # Little_Endian amsua_metop-c_v2.SpcCoeff.bin is what it's supposed to be.
         # Remove the incorrect file, and install it as noACC,, then install
         # correct file under new name.
-        if "+big_endian" in spec and spec.version in [Version("2.4.0_emc"),Version("2.4.0.1_emc")]:
+        if "+big_endian" in spec and (
+            spec.version in [Version("2.4.0_emc"), Version("2.4.0.1_emc")]):
             amc_sc_path = join_path("SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin")
             amc_sc_v2_path = join_path(
                 "SpcCoeff", "Little_Endian", "amsua_metop-c_v2.SpcCoeff.bin"

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -58,9 +58,11 @@ class CrtmFix(Package):
         # Little_Endian amsua_metop-c_v2.SpcCoeff.bin is what it's supposed to be.
         # Remove the incorrect file, and install it as noACC,, then install
         # correct file under new name.
-        if "+big_endian" in spec and spec.version in [Version("2.4.0_emc"), Version("2.4.0.1_emc")]:
+        if "+big_endian" in spec and spec.version in [Version("2.4.0_emc"),Version("2.4.0.1_emc")]:
             amc_sc_path = join_path("SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin")
-            amc_sc_v2_path = join_path("SpcCoeff", "Little_Endian", "amsua_metop-c_v2.SpcCoeff.bin")
+            amc_sc_v2_path = join_path(
+                "SpcCoeff", "Little_Endian", "amsua_metop-c_v2.SpcCoeff.bin"
+            )
             # In 2.4.0_emc, the path is prefixed by 'fix/'
             if spec.version == Version("2.4.0_emc"):
                 amc_sc_path = join_path("fix", amc_sc_path)

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -59,7 +59,7 @@ class CrtmFix(Package):
         # Remove the incorrect file, and install it as noACC,, then install
         # correct file under new name.
         if "+big_endian" in spec and (
-            spec.version in [Version("2.4.0_emc"), Version("2.4.0.1_emc")]):
+          spec.version in [Version("2.4.0_emc"), Version("2.4.0.1_emc")]):
             amc_sc_path = join_path("SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin")
             amc_sc_v2_path = join_path(
                 "SpcCoeff", "Little_Endian", "amsua_metop-c_v2.SpcCoeff.bin"

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -59,7 +59,8 @@ class CrtmFix(Package):
         # Remove the incorrect file, and install it as noACC,, then install
         # correct file under new name.
         if "+big_endian" in spec and (
-          spec.version in [Version("2.4.0_emc"), Version("2.4.0.1_emc")]):
+            spec.version in [Version("2.4.0_emc"), Version("2.4.0.1_emc")]
+        ):
             amc_sc_path = join_path("SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin")
             amc_sc_v2_path = join_path(
                 "SpcCoeff", "Little_Endian", "amsua_metop-c_v2.SpcCoeff.bin"
@@ -74,16 +75,10 @@ class CrtmFix(Package):
             fix_files.remove(remove_path)
 
             # This file is incorrect, install it as a different name.
-            install(
-                amc_sc_path,
-                join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.noACC.bin"),
-            )
+            install(amc_sc_path, join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.noACC.bin"))
 
             # This "Little_Endian" file is actually the correct one.
-            install(
-                amc_sc_v2_path,
-                join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.bin"),
-            )
+            install(amc_sc_v2_path, join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.bin"))
 
         for f in fix_files:
             install(f, self.prefix.fix)


### PR DESCRIPTION
## Description

This causes spack to copy the erroneously-placed fix file `SpcCoeff/Little_Endian/amsua_metop-c_v2.SpcCoeff.bin` when copying big-endian fix files (i.e. `+big-endian`) to the final `fix` directory as `amsua_metop-c.SpcCoeff.bin`.

## Issue(s) addressed

Resolves [#963](https://github.com/JCSDA/spack-stack/issues/963)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
- [x] Tested by comparing installations to verify that only 