### PR TITLE
For ecflow@5.11.4, apply ctsapi_cassert.path for all compilers, not just Intel Classic

### DIFF
--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -69,7 +69,8 @@ class Ecflow(CMakePackage):
     depends_on("cmake@3.16:", type="build")
 
     # https://github.com/JCSDA/spack-stack/issues/1001
-    patch("ctsapi_cassert.patch", when="@5.11.4 %intel@2021")
+    # https://github.com/JCSDA/spack-stack/issues/1009
+    patch("ctsapi_cassert.patch", when="@5.11.4")
 
     @when("@:4.13.0")
     def patch(self):


### PR DESCRIPTION
## Description

All in the title.

Corresponding spack develop PR is: https://github.com/spack/spack/pull/42793

## Issue(s) addressed

Fixes https://github.com/JCSDA/spack-stack/issues/1009

## Dependencies

n/a

## Testing

See https://github.com/JCSDA/spack-stack/pull/993 (testing for commit https://github.com/JCSDA/spack-stack/pull/993/commits/1bfb8cc77ee203a64ab2f99eb63eb1c1210bfa2f):
    - CI tests pass on macOS (Intel, Arm) and Ubuntu
    - Manual container test on @climbfuji's macOS for the `ubuntu-gcc-openmpi` container with `jedi-ci` (reported as failing in issue https://github.com/JCSDA/spack-stack/issues/1009)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
