### PR TITLE
Remove docs from rust-bootstrap

### DIFF
--- a/var/spack/repos/builtin/packages/rust-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/rust-bootstrap/package.py
@@ -126,4 +126,5 @@ class RustBootstrap(Package):
 
     def install(self, spec, prefix):
         install_script = Executable("./install.sh")
-        install_script(f"--prefix={prefix}")
+        install_args = [f"--prefix={prefix}", "--without=rust-docs"]
+        install_script(" ".join(install_args))


### PR DESCRIPTION
## Description

This PR pulls in the change from main Spack that disable doc installation for rust-bootstrap because it pointlessly takes up space/inodes.

## Issue(s) addressed

Addresses https://github.com/JCSDA/spack-stack/issues/1003

## Dependencies
none

## Impact
Smaller installation footprint :sunglasses: 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
