### PR TITLE
Revert "Add conflict with Intel-19 to var/spack/repos/builtin/package…

### DIFF
--- a/var/spack/repos/builtin/packages/py-contourpy/package.py
+++ b/var/spack/repos/builtin/packages/py-contourpy/package.py
@@ -22,12 +22,5 @@ class PyContourpy(PythonPackage):
     depends_on("py-pybind11@2.6:", type=("build", "link"))
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-numpy@1.16:", type=("build", "run"))
-    depends_on("py-build", when="@:1.0.5", type="build")
 
-    # py-contourpy uses c++-17 flags that cause a problem
-    # with older Intel compilers (@19) in combination with
-    # C++-17 capable backends (gnu@9:). Instead of trying
-    # to figure out what gnu version the Intel compiler
-    # uses as backend, simply refuse to build. See also:
-    # https://bitbucket.org/berkeleylab/upcxx/issues/302/build-failure-for-intel-c-with-std-c-17
-    conflicts("%intel@:19")
+    depends_on("py-build", when="@:1.0.5", type="build")


### PR DESCRIPTION
…s/py-contourpy/package.py"

This reverts commit 425b5565d5da73935dfbb2eb870506d64bcb638b.

## Description

This PR removes the intel@19 conflict from py-contourpy

## Issue(s) addressed

Fixes https://github.com/JCSDA/spack-stack/issues/959

## Dependencies

none

## Impact

none (no systems other than Acorn use intel@19, and py-contourpy%intel@19.1.3.304 builds on Acorn)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
