### PR TITLE
awscli-v2: remove examples dir

### DIFF
--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -29,3 +29,11 @@ class AwscliV2(PythonPackage):
     depends_on("py-python-dateutil@2.1:2", type=("build", "run"))
     depends_on("py-jmespath@0.7.1:1.0", type=("build", "run"))
     depends_on("py-urllib3@1.25.4:1.26", type=("build", "run"))
+
+    variant("examples", default=True, description="Install code examples")
+
+    @run_after("install")
+    @when("~examples")
+    def post_install(self):
+        examples_dir = join_path(python_purelib, "awscli", "examples")
+        remove_directory_contents(examples_dir)


### PR DESCRIPTION
## Description

This PR pulls in the change from main spack that allows us to reduce the instlalation footprint of awscli-v2.

## Issue(s) addressed

Addresses https://github.com/JCSDA/spack-stack/issues/1003

## Dependencies

none

## Impact

none

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
