### PR TITLE
Bug fix for py-jupyter-server and hidden npm/node dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupyter-server/no_npm_node.patch
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/no_npm_node.patch
@@ -1,0 +1,14 @@
+--- a/pyproject.toml	2024-03-19 15:58:20.000000000 -0600
++++ b/pyproject.toml	2024-03-19 15:59:15.000000000 -0600
+@@ -5,6 +5,11 @@
+ [tool.jupyter-packaging.builder]
+ factory = "jupyter_packaging.npm_builder"
+ 
++# Injected by spack to solve problems with hidden npm/node dependencies
++# https://github.com/spack/spack/issues/41899
++[tool.jupyter-packaging.build-args]
++npm = "/dev/null"
++
+ [tool.check-manifest]
+ ignore = ["tbump.toml", ".*", "*.yml", "package-lock.json", "bootstrap*", "conftest.py"]
+ 

--- a/var/spack/repos/builtin/packages/py-jupyter-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/package.py
@@ -28,6 +28,16 @@ class PyJupyterServer(PythonPackage):
     version("1.9.0", sha256="7d19006380f6217458a9db309b54e3dab87ced6c06329c61823907bef2a6f51b")
     version("1.6.1", sha256="242ddd0b644f10e030f917019b47c381e0f2d2b950164af45cbd791d572198ac")
 
+    variant(
+        "typescript",
+        default=False,
+        description="Build the typescript code",
+        when="@:1",
+    )
+
+    # https://github.com/spack/spack/issues/41899
+    patch("no_npm_node.patch", when="@:1 ~typescript")
+
     depends_on("python@3.8:", when="@2:", type=("build", "run"))
     depends_on("py-hatchling@1.11:", when="@2:", type="build")
     # under [tool.hatch.build.hooks.jupyter-builder] in pyproject.toml
@@ -37,6 +47,7 @@ class PyJupyterServer(PythonPackage):
         depends_on("py-jupyter-packaging@0.9:0", when="@1.6.2:", type="build")
         depends_on("py-pre-commit", when="@1.16:", type="build")
         depends_on("py-setuptools", type="build")
+        depends_on("npm", type="build", when="+typescript")
 
     depends_on("py-anyio@3.1.0:", when="@2.2.1:", type=("build", "run"))
     depends_on("py-anyio@3.1.0:3", when="@:2.2.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyter-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/package.py
@@ -43,9 +43,7 @@ class PyJupyterServer(PythonPackage):
         depends_on("py-pre-commit", when="@1.16:", type="build")
         depends_on("py-setuptools", type="build")
 
-    with when("@1.10.2:1"):
-        depends_on("npm", type="build", when="+typescript")
-
+    depends_on("npm", type="build", when="+typescript")
     depends_on("py-anyio@3.1.0:", when="@2.2.1:", type=("build", "run"))
     depends_on("py-anyio@3.1.0:3", when="@:2.2.0", type=("build", "run"))
     depends_on("py-argon2-cffi", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyter-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/package.py
@@ -28,12 +28,7 @@ class PyJupyterServer(PythonPackage):
     version("1.9.0", sha256="7d19006380f6217458a9db309b54e3dab87ced6c06329c61823907bef2a6f51b")
     version("1.6.1", sha256="242ddd0b644f10e030f917019b47c381e0f2d2b950164af45cbd791d572198ac")
 
-    variant(
-        "typescript",
-        default=False,
-        description="Build the typescript code",
-        when="@:1",
-    )
+    variant("typescript", default=False, description="Build the typescript code", when="@:1")
 
     # https://github.com/spack/spack/issues/41899
     patch("no_npm_node.patch", when="@:1 ~typescript")

--- a/var/spack/repos/builtin/packages/py-jupyter-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/package.py
@@ -28,10 +28,10 @@ class PyJupyterServer(PythonPackage):
     version("1.9.0", sha256="7d19006380f6217458a9db309b54e3dab87ced6c06329c61823907bef2a6f51b")
     version("1.6.1", sha256="242ddd0b644f10e030f917019b47c381e0f2d2b950164af45cbd791d572198ac")
 
-    variant("typescript", default=False, description="Build the typescript code", when="@:1")
+    variant("typescript", default=False, description="Build the typescript code", when="@1.10.2:1")
 
     # https://github.com/spack/spack/issues/41899
-    patch("no_npm_node.patch", when="@:1 ~typescript")
+    patch("no_npm_node.patch", when="@1.10.2:1 ~typescript")
 
     depends_on("python@3.8:", when="@2:", type=("build", "run"))
     depends_on("py-hatchling@1.11:", when="@2:", type="build")
@@ -42,6 +42,8 @@ class PyJupyterServer(PythonPackage):
         depends_on("py-jupyter-packaging@0.9:0", when="@1.6.2:", type="build")
         depends_on("py-pre-commit", when="@1.16:", type="build")
         depends_on("py-setuptools", type="build")
+
+    with when("@1.10.2:1"):
         depends_on("npm", type="build", when="+typescript")
 
     depends_on("py-anyio@3.1.0:", when="@2.2.1:", type=("build", "run"))


### PR DESCRIPTION
## Description

Add variant typescript for `py-jupyter-server@:1`, which then requires `npm`/`node`. Patch the build system for `~typescript` so that it doesn't autodetect any system `npm`/`node` installations. That is because if it does find `npm` somewhere in the path, it attempts to build the typescript extension even though it shouldn't, and this can cause problems as described in https://github.com/JCSDA/spack-stack/issues/995, https://github.com/JCSDA/spack-stack/issues/928, and https://github.com/spack/spack/issues/41899.

Note that the build backend has changed from `py-packaging` to `py-hatch` between `py-jupyter-server` versions 1 and 2, therefore this bug fix is restricted to version 1.

Corresponding spack develop PR: https://github.com/spack/spack/pull/43279 (merged 2024/03/20)

## Testing

I tested installing `py-jupyter-server@1.21.1` on my macOS with a broken local `npm`/`node` installation (to mimick the problem described in https://github.com/JCSDA/spack-stack/issues/995. I was able to install it successfully with the default variant `~typescript`, and also with `+typescript` (which added `npm` and `node` as dependencies).

It also fixed the problem on Narwhal with the existing but broken `npm`/`node` installation.

Also testing default `~typescript` in https://github.com/JCSDA/spack-stack/pull/1033

## Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/995
Resolves https://github.com/JCSDA/spack-stack/issues/928

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
