### PR TITLE
zlib-ng: New variants: +shared and +pic (#42796)

### DIFF
--- a/var/spack/repos/builtin/packages/zlib-ng/package.py
+++ b/var/spack/repos/builtin/packages/zlib-ng/package.py
@@ -35,6 +35,12 @@ class ZlibNg(AutotoolsPackage, CMakePackage):
 
     variant("compat", default=True, description="Enable compatibility API")
     variant("opt", default=True, description="Enable optimizations")
+    variant("shared", default=True, description="Build shared library")
+    variant("pic", default=True, description="Enable position-independent code (PIC)")
+
+    conflicts("+shared~pic")
+
+    variant("new_strategies", default=True, description="Enable new deflate strategies")
 
     provides("zlib-api", when="+compat")
 
@@ -56,7 +62,14 @@ class ZlibNg(AutotoolsPackage, CMakePackage):
     @property
     def libs(self):
         name = "libz" if self.spec.satisfies("+compat") else "libz-ng"
-        return find_libraries(name, root=self.prefix, recursive=True, shared=True)
+        return find_libraries(
+            name, root=self.prefix, recursive=True, shared=self.spec.satisfies("+shared")
+        )
+
+    def flag_handler(self, name, flags):
+        if name == "cflags" and self.spec.satisfies("+pic build_system=autotools"):
+            flags.append(self.compiler.cc_pic_flag)
+        return (flags, None, None)
 
 
 class AutotoolsBuilder(autotools.AutotoolsBuilder):
@@ -66,6 +79,10 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
             args.append("--zlib-compat")
         if self.spec.satisfies("~opt"):
             args.append("--without-optimizations")
+        if self.spec.satisfies("~shared"):
+            args.append("--static")
+        if self.spec.satisfies("~new_strategies"):
+            args.append("--without-new-strategies")
         return args
 
 
@@ -74,4 +91,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
         return [
             self.define_from_variant("ZLIB_COMPAT", "compat"),
             self.define_from_variant("WITH_OPTIM", "opt"),
+            self.define("BUILD_SHARED_LIBS", self.spec.satisfies("+shared")),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+            self.define_from_variant("WITH_NEW_STRATEGIES", "new_strategies"),
         ]


### PR DESCRIPTION
## Description

Unfortunately zlib-ng is having the same issues as regular zlib on Hera as far as the shared library, segfault, libm, etc. etc., so we'll need to build with the static version.

## Issue(s) addressed

Needed for https://github.com/JCSDA/spack-stack/issues/1042

## Dependencies
none

## Impact
We'll only build static-only on Hera with Intel.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
