### PR TITLE
For jcsda_emc_spack_stack: bug fix in gsibec package: sp is a runtime dependency

### DIFF
--- a/var/spack/repos/builtin/packages/gsibec/package.py
+++ b/var/spack/repos/builtin/packages/gsibec/package.py
@@ -40,7 +40,12 @@ class Gsibec(CMakePackage):
 
     depends_on("ecbuild", type=("build"))
     depends_on("jedi-cmake", type=("build"))
-    depends_on("sp", type=("build"))
+    # Replace the following line with the two commented lines
+    # below once we know the tag that has the ip changes from
+    # https://github.com/GEOS-ESM/GSIbec/pull/66
+    depends_on("sp", type=("build", "run"))
+    # depends_on("sp", when="@:1.2.1", type=("build", "run"))
+    # depends_on("ip@5:", when="@1.2.2:", type=("build", "run"))
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
## Description

I am fixing this on develop instead of release/1.7.0, we'll simply work around this by instructing people to load the `sp` module manually when using `gsibec`.

Make `sp` a runtime dependency, and also put comments in place for future transition to `ip` (see https://github.com/GEOS-ESM/GSIbec/issues/65 and https://github.com/GEOS-ESM/GSIbec/pull/66).

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
