### PR TITLE
Use case-preserving packageName_ROOT env variables in auto-generated modules

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -758,9 +758,11 @@ class BaseContext(tengine.Context):
         # Prepare a suitable transformation dictionary for the names
         # of the environment variables. This means turn the valid
         # tokens uppercase.
+        # DH 20240410 - reverting this to case-preserving, see
+        # https://github.com/spack/spack/issues/43569
         transform = {}
         for token in _valid_tokens:
-            transform[token] = lambda s, string: str.upper(string)
+            transform[token] = lambda s, string: string
 
         for x in env:
             # Ensure all the tokens are valid in this context

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -119,7 +119,7 @@ class TestTcl:
         assert len([x for x in content if "setenv OMPI_MCA_mpi_leave_pinned {1}" in x]) == 1
         assert len([x for x in content if "setenv OMPI_MCA_MPI_LEAVE_PINNED {1}" in x]) == 0
         assert len([x for x in content if "unsetenv BAR" in x]) == 1
-        assert len([x for x in content if "setenv MPILEAKS_ROOT" in x]) == 1
+        assert len([x for x in content if "setenv mpileaks_ROOT" in x]) == 1
 
         content = modulefile_content("libdwarf platform=test target=core2")
 
@@ -128,7 +128,7 @@ class TestTcl:
         assert len([x for x in content if "unsetenv BAR" in x]) == 0
         assert len([x for x in content if "depends-on foo/bar" in x]) == 1
         assert len([x for x in content if "module load foo/bar" in x]) == 1
-        assert len([x for x in content if "setenv LIBDWARF_ROOT" in x]) == 1
+        assert len([x for x in content if "setenv libdwarf_ROOT" in x]) == 1
 
     def test_prepend_path_separator(self, modulefile_content, module_configuration):
         """Tests that we can use custom delimiters to manipulate path lists."""


### PR DESCRIPTION
## Description

Use case-preserving packageName_ROOT env variables in auto-generated modules instead of all uppercase PACKAGENAME_ROOT.

See https://github.com/JCSDA/spack-stack/pull/1068 for a list of systems that need to get updated for spack-stack-1.7.0.

## Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1066

Related spack develop issue: https://github.com/spack/spack/issues/43569

## Dependencies

n/a

## Impact

Fixes cmake warnings and build errors.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
