### PR TITLE
Add esmf@8.6.1b04 and esmf@8.7.0b04

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -5,13 +5,13 @@ on:
     branches:
       - develop
       - releases/**
-      - jcsda_emc_spack_stack
+      - spack-stack-dev
       - release/**
   pull_request:
     branches:
       - develop
       - releases/**
-      - jcsda_emc_spack_stack
+      - spack-stack-dev
       - release/**
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -5,13 +5,13 @@ on:
     branches:
       - develop
       - releases/**
-      - jcsda_emc_spack_stack
+      - spack-stack-dev
       - release/**
   pull_request:
     branches:
       - develop
       - releases/**
-      - jcsda_emc_spack_stack
+      - spack-stack-dev
       - release/**
   workflow_dispatch:
   workflow_call:

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -29,6 +29,8 @@ class Esmf(MakefilePackage):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
+    version("8.7.0b04", commit="609c81179572747407779492c43776e34495d267")
+    version("8.6.1b04", commit="64d3aacc36f2d4d39255eb521c34123903cc0551")
     version("8.6.0", sha256="ed057eaddb158a3cce2afc0712b49353b7038b45b29aee86180f381457c0ebe7")
     version("8.5.0", sha256="acd0b2641587007cc3ca318427f47b9cae5bfd2da8d2a16ea778f637107c29c4")
     version("8.4.2", sha256="969304efa518c7859567fa6e65efd960df2b4f6d72dbf2c3f29e39e4ab5ae594")


### PR DESCRIPTION
## Description

Add esmf@8.6.1b04 and esmf@8.7.0b04. This will not be sent back to spack develop - we'll replace them when we get the official release tags.

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/1079 and https://github.com/JCSDA/spack-stack/issues/1062

## Dependencies

n/a

## Impact

none

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
- [x] I installed both versions on my macOS, alongside with `esmf@8.6.0`, using spack-stack PR https://github.com/JCSDA/spack-stack/pull/1081
