### PR TITLE
Add nvhpc option in var/spack/repos/builtin/packages/fckit/package.py

### DIFF
--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -74,7 +74,7 @@ class Fckit(CMakePackage):
             # See comment above (conflicts for finalize_ddts)
             args.append("-DENABLE_FINAL=OFF")
 
-        if self.spec.satisfies("%intel") or self.spec.satisfies("%gcc"):
+        if self.spec.satisfies("%intel") or self.spec.satisfies("%gcc") or self.spec.satisfies('%nvhpc'):
             cxxlib = "stdc++"
         elif self.spec.satisfies("%clang") or self.spec.satisfies("%apple-clang"):
             cxxlib = "c++"

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -74,7 +74,11 @@ class Fckit(CMakePackage):
             # See comment above (conflicts for finalize_ddts)
             args.append("-DENABLE_FINAL=OFF")
 
-        if self.spec.satisfies("%intel") or self.spec.satisfies("%gcc") or self.spec.satisfies('%nvhpc'):
+        if (
+            self.spec.satisfies("%intel")
+            or self.spec.satisfies("%gcc")
+            or self.spec.satisfies("%nvhpc")
+        ):
             cxxlib = "stdc++"
         elif self.spec.satisfies("%clang") or self.spec.satisfies("%apple-clang"):
             cxxlib = "c++"


### PR DESCRIPTION
## Description

See title. Needed to build with `nvhpc` compilers. Tested on AWS EC2 instance (see https://github.com/JCSDA/spack-stack/pull/1084 for the template and site config/instructions).

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/1080

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
