### PR TITLE
Update CRTM from spack develop, add versions v3.1.0-skylabv{5,6,7,8}

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -34,8 +34,8 @@ class CrtmFix(Package):
         if version == Version("2.4.0.1_emc"):
             url = "ftp://ftp.ssec.wisc.edu/pub/s4/CRTM/fix_REL-2.4.0_emc_07112023.tgz"
         else:
-            url = "ftp://ftp.ssec.wisc.edu/pub/s4/CRTM/fix_REL-{}.tgz"
-        return url.format(version)
+            url = f"ftp://ftp.ssec.wisc.edu/pub/s4/CRTM/fix_REL-{version}.tgz"
+        return url
 
     def install(self, spec, prefix):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -24,9 +24,11 @@ class Crtm(CMakePackage):
         "Hang-Lei-NOAA",
         "climbfuji",
     )
+
     variant(
         "fix", default=False, description='Download CRTM coeffecient or "fix" files (several GBs).'
     )
+
     depends_on("cmake@3.15:", type="build")
     depends_on("git-lfs")
     depends_on("netcdf-fortran", when="@2.4.0:")
@@ -34,7 +36,7 @@ class Crtm(CMakePackage):
     depends_on("netcdf-fortran", when="@v2.4-jedi.1")
     depends_on("netcdf-fortran", when="@v2.4-jedi.2")
     depends_on("netcdf-fortran", when="@v2.4.1-jedi")
-    depends_on("netcdf-fortran", when="@v3.0.0-rc.1")
+    depends_on("netcdf-fortran", when="@v3")
 
     depends_on("crtm-fix@2.3.0_emc", when="@2.3.0 +fix")
     depends_on("crtm-fix@2.4.0_emc", when="@=2.4.0 +fix")
@@ -44,10 +46,23 @@ class Crtm(CMakePackage):
     depends_on("ecbuild", type=("build"), when="@v2.4-jedi.1")
     depends_on("ecbuild", type=("build"), when="@v2.4-jedi.2")
     depends_on("ecbuild", type=("build"), when="@v2.4.1-jedi")
-    depends_on("ecbuild", type=("build"), when="@v3.0.0-rc.1")
+    depends_on("ecbuild", type=("build"), when="@v3.0")
+    depends_on("ecbuild", type=("build"), when="@v3.1.0-skylabv7")
 
     license("CC0-1.0")
 
+    version(
+        "v3.1.0-skylabv8", sha256="a475c8a444072aef1e8c2babba3d12f13ab0fb6c7ecab88edad57130839e29ff"
+    )
+    version(
+        "v3.1.0-skylabv7", sha256="3ac45c49562ab41c3baf443ce382e3a6bcb7226831b54146d9f73995be165ec7"
+    )
+    version(
+        "v3.0.0-skylabv6", sha256="780fbc4e0f3b0414fbade4b595832bb35d9c5d3e7c3b25ad128ca94f71bea2b8"
+    )
+    version(
+        "v3.0.0-skylabv5", sha256="4fa5dd2d65b4d4ff77d50992e8e0c02a59584b35599f424085fccdc2174d7bd2"
+    )
     version(
         "v2.4.1-jedi", sha256="fd8bf4db4f2a3b420b4186de84483ba2a36660519dffcb1e0ff14bfe8c6f6a14"
     )
@@ -56,18 +71,15 @@ class Crtm(CMakePackage):
     version("2.4.0", commit="5ddd0d6b0138284764065feda73b5adf599082a2")
     # Uses the tip of REL-2.3.0_emc branch
     version("2.3.0", commit="99760e693ce3b90a3b3b0e97d80972b4dfb61196")
-    # JEDI applications so far use these versions
-    # Branch release/crtm_jedi
-    version("v2.3-jedi.4", commit="bfede42adc6149213f28f58bf4e02fa8f7cb0198")
-    # Branch release/crtm_jedi_v2.4.0
-    version("v2.4-jedi.1", commit="82223419fdb479d76c2f2109c2b704e1d9618f22")
-    version("v2.4-jedi.2", commit="62831cbb6c1ffcbb219eeec60e1b1c422526f597")
 
     def url_for_version(self, version):
         if self.spec.satisfies("@v3") or version >= Version("3.0.0"):
-            return "https://github.com/JCSDA/crtmv3/archive/refs/tags/{}.tar.gz".format(version)
+            return f"https://github.com/JCSDA/crtmv3/archive/refs/tags/{version}.tar.gz"
         else:
-            return "https://github.com/JCSDA/crtm/archive/refs/tags/{}.tar.gz".format(version)
+            return f"https://github.com/JCSDA/crtm/archive/refs/tags/{version}.tar.gz"
+
+    # https://github.com/JCSDA/spack-stack/issues/1088
+    patch("v3.1.0-skylabv8.installprefix.patch", when="@v3.1.0-skylabv8")
 
     @when("@2.4.0.1")
     def patch(self):

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -52,16 +52,20 @@ class Crtm(CMakePackage):
     license("CC0-1.0")
 
     version(
-        "v3.1.0-skylabv8", sha256="a475c8a444072aef1e8c2babba3d12f13ab0fb6c7ecab88edad57130839e29ff"
+        "v3.1.0-skylabv8",
+        sha256="a475c8a444072aef1e8c2babba3d12f13ab0fb6c7ecab88edad57130839e29ff",
     )
     version(
-        "v3.1.0-skylabv7", sha256="3ac45c49562ab41c3baf443ce382e3a6bcb7226831b54146d9f73995be165ec7"
+        "v3.1.0-skylabv7",
+        sha256="3ac45c49562ab41c3baf443ce382e3a6bcb7226831b54146d9f73995be165ec7",
     )
     version(
-        "v3.0.0-skylabv6", sha256="780fbc4e0f3b0414fbade4b595832bb35d9c5d3e7c3b25ad128ca94f71bea2b8"
+        "v3.0.0-skylabv6",
+        sha256="780fbc4e0f3b0414fbade4b595832bb35d9c5d3e7c3b25ad128ca94f71bea2b8",
     )
     version(
-        "v3.0.0-skylabv5", sha256="4fa5dd2d65b4d4ff77d50992e8e0c02a59584b35599f424085fccdc2174d7bd2"
+        "v3.0.0-skylabv5",
+        sha256="4fa5dd2d65b4d4ff77d50992e8e0c02a59584b35599f424085fccdc2174d7bd2",
     )
     version(
         "v2.4.1-jedi", sha256="fd8bf4db4f2a3b420b4186de84483ba2a36660519dffcb1e0ff14bfe8c6f6a14"

--- a/var/spack/repos/builtin/packages/crtm/v3.1.0-skylabv8.installprefix.patch
+++ b/var/spack/repos/builtin/packages/crtm/v3.1.0-skylabv8.installprefix.patch
@@ -1,0 +1,14 @@
+--- a/CMakeLists.txt	2024-04-22 08:25:42.000000000 -0600
++++ b/CMakeLists.txt	2024-04-22 08:25:54.000000000 -0600
+@@ -6,8 +6,9 @@
+ 
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ set(CMAKE_DIRECTORY_LABELS ${PROJECT_NAME})
+-set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "default install path" FORCE)
+-message("CMAKE_INSTALL_PREFIX set to ${CMAKE_INSTALL_PREFIX}")
++# https://github.com/JCSDA/spack-stack/issues/1088
++#set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "default install path" FORCE)
++#message("CMAKE_INSTALL_PREFIX set to ${CMAKE_INSTALL_PREFIX}")
+ 
+ ## Configuration options
+ include(${PROJECT_NAME}_compiler_flags)


### PR DESCRIPTION
## Description

See title. This fixes a problem identified with `crtm@v3.1.0-skylabv8` during the final install step as described in https://github.com/JCSDA/spack-stack/issues/1088.

We need those updates so that we can finish @rhoneyager-tomorrow 's PR (install JEDI via spack - but updated for Skylab v8). Once this PR is merged, I will update the `crtm-fix` and `crtm` packages in spack develop to match what we have.

PR for crtmv3 develop: https://github.com/JCSDA/CRTMv3/pull/131

## Issue(s) addressed

Resolves https://github.com/JCSDA/spack-stack/issues/1088

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run ~~the unit~~ tests before creating the PR: I installed all versions of `crtm` (with all fixed packages as needed) on my macOS.
