### PR TITLE
Update CRTM - add 2.4-jedi.2 back in (used by NASA's swell env)

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -70,6 +70,7 @@ class Crtm(CMakePackage):
     version(
         "v2.4.1-jedi", sha256="fd8bf4db4f2a3b420b4186de84483ba2a36660519dffcb1e0ff14bfe8c6f6a14"
     )
+    version("v2.4-jedi.2", commit="62831cbb6c1ffcbb219eeec60e1b1c422526f597")
     version("2.4.0.1", tag="v2.4.0_emc.3", commit="7ecad4866c400d7d0db1413348ee225cfa99ff36")
     # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
     version("2.4.0", commit="5ddd0d6b0138284764065feda73b5adf599082a2")


### PR DESCRIPTION
## Description

In PR #425 I accidentally removed a version that is still being used by NASA's SWELL env. This PR adds it back in.

I am wondering if any other version that got removed in #425 is still needed. @sking112 @Dooruk @BenjaminTJohnson do you know?

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
