### PR TITLE
Updates to hdf-eos2 from spack develop PR

### DIFF
--- a/var/spack/repos/builtin/packages/hdf-eos2/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos2/package.py
@@ -116,8 +116,8 @@ class HdfEos2(AutotoolsPackage):
         # https://forum.hdfgroup.org/t/help-building-hdf4-with-clang-error-implicit-declaration-of-function-test-mgr-szip-is-invalid-in-c99/7680
         # -fPIC: https://github.com/spack/spack/issues/43792
         if self.spec.satisfies("%apple-clang"):
-            extra_args.append("CFLAGS=-Wno-error=implicit-function-declaration -fPIC")
+            extra_args.append("CFLAGS=-Wno-error=implicit-function-declaration {0}".format(self.compiler.cc_pic_flag))
         else:
-            extra_args.append("CFLAGS=-fPIC")
+            extra_args.append("CFLAGS={0}".format(self.compiler.cc_pic_flag))
 
         return extra_args

--- a/var/spack/repos/builtin/packages/hdf-eos2/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos2/package.py
@@ -116,7 +116,11 @@ class HdfEos2(AutotoolsPackage):
         # https://forum.hdfgroup.org/t/help-building-hdf4-with-clang-error-implicit-declaration-of-function-test-mgr-szip-is-invalid-in-c99/7680
         # -fPIC: https://github.com/spack/spack/issues/43792
         if self.spec.satisfies("%apple-clang"):
-            extra_args.append("CFLAGS=-Wno-error=implicit-function-declaration {0}".format(self.compiler.cc_pic_flag))
+            extra_args.append(
+                "CFLAGS=-Wno-error=implicit-function-declaration {0}".format(
+                    self.compiler.cc_pic_flag
+                )
+            )
         else:
             extra_args.append("CFLAGS={0}".format(self.compiler.cc_pic_flag))
 


### PR DESCRIPTION
## Description

This PR adds changes requested during the code review of https://github.com/spack/spack/pull/43794 to the spack-stack-dev branch.

Note that the failing macOS unit tests are known and unrelated to this PR: https://github.com/JCSDA/spack/issues/429

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have run the unit tests before creating the PR
