### PR TITLE
Remove use of MPI wrappers for fms and mapl package.py scripts

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -134,10 +134,6 @@ class Fms(CMakePackage):
             self.define_from_variant("USE_DEPRECATED_IO", "deprecated_io"),
         ]
 
-        args.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))
-        args.append(self.define("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx))
-        args.append(self.define("CMAKE_Fortran_COMPILER", self.spec["mpi"].mpifc))
-
         fflags = []
 
         if self.compiler.name in ["gcc", "clang", "apple-clang"]:

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -250,6 +250,9 @@ class Mapl(CMakePackage):
     depends_on("py-numpy", when="+f2py")
     depends_on("perl")
 
+    # when using apple-clang version 15.x or newer, need to use the llvm-openmp library
+    depends_on("llvm-openmp", when="%apple-clang@15:", type=("build", "run"))
+
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_WITH_FLAP", "flap"),
@@ -258,9 +261,6 @@ class Mapl(CMakePackage):
             self.define_from_variant("BUILD_SHARED_MAPL", "shared"),
             self.define_from_variant("USE_EXTDATA2G", "extdata2g"),
             self.define_from_variant("USE_F2PY", "f2py"),
-            "-DCMAKE_C_COMPILER=%s" % self.spec["mpi"].mpicc,
-            "-DCMAKE_CXX_COMPILER=%s" % self.spec["mpi"].mpicxx,
-            "-DCMAKE_Fortran_COMPILER=%s" % self.spec["mpi"].mpifc,
         ]
 
         if self.spec.satisfies("@2.22.0:"):


### PR DESCRIPTION
## Description

This PR removes the use of the MPI wrappers on the FMS and MAPL package.py scripts. This was done to enable spack-stack builds on the Mac using apple-clang%15.x compilers.

I cherry picked the commit used in the PR into the authoritative spack repo https://github.com/spack/spack/pull/43726 to create this PR.

## Issue(s) addressed

Partially addresses JCSDA/spack-stack/issues/1083

## Dependencies

List the other PRs that this PR is dependent on:
None

## Impact

Expected impact on downstream repositories:
None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (N/A)
- [ ] I have run the unit tests before creating the PR
