### PR TITLE
Backporting to release/1.7.0: add esmf tags 8.6.1b04, 8.6.1, 8.7.0b04

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -30,6 +30,7 @@ class Esmf(MakefilePackage):
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
     version("8.7.0b04", commit="609c81179572747407779492c43776e34495d267")
+    version("8.6.1", sha256="dc270dcba1c0b317f5c9c6a32ab334cb79468dda283d1e395d98ed2a22866364")
     version("8.6.1b04", commit="64d3aacc36f2d4d39255eb521c34123903cc0551")
     version("8.6.0", sha256="ed057eaddb158a3cce2afc0712b49353b7038b45b29aee86180f381457c0ebe7")
     version("8.5.0", sha256="acd0b2641587007cc3ca318427f47b9cae5bfd2da8d2a16ea778f637107c29c4")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -29,6 +29,8 @@ class Esmf(MakefilePackage):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
+    version("8.7.0b04", commit="609c81179572747407779492c43776e34495d267")
+    version("8.6.1b04", commit="64d3aacc36f2d4d39255eb521c34123903cc0551")
     version("8.6.0", sha256="ed057eaddb158a3cce2afc0712b49353b7038b45b29aee86180f381457c0ebe7")
     version("8.5.0", sha256="acd0b2641587007cc3ca318427f47b9cae5bfd2da8d2a16ea778f637107c29c4")
     version("8.4.2", sha256="969304efa518c7859567fa6e65efd960df2b4f6d72dbf2c3f29e39e4ab5ae594")


### PR DESCRIPTION
## Description

This PR adds esmf tags 8.6.1b04, 8.6.1, 8.7.0b04 to the release/1.7.0 branch.

Should we merge the PR without retagging the release?

We don't necessarily need to merge the PR, but at least we can use the branch or cherry-pick the commits to add one or more of these versions to the existing 1.7.0 installs.

## Issue(s) addressed

Working towards https://github.com/JCSDA/spack-stack/issues/1117.

(in order to close the issue, we need to also add those commits to spack-stack develop)

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
    -  also installed on @climbfuji's macOS and/or Nautilus and/or Narwhal
    - note: unit tests / macos (3.11) (pull_request) on the release branch is expected
