### PR TITLE
Correct dependencies in py-poetry, py-numexpr, and py-metpy packages

### DIFF
--- a/var/spack/repos/builtin/packages/py-metpy/package.py
+++ b/var/spack/repos/builtin/packages/py-metpy/package.py
@@ -30,7 +30,8 @@ class PyMetpy(PythonPackage):
     depends_on("py-matplotlib@2.1.0:", type=("build", "run"))
     depends_on("py-numpy@1.16.0:", type=("build", "run"))
     depends_on("py-pandas@0.24.0:", type=("build", "run"))
-    depends_on("py-pint@0.10.1:", type=("build", "run"))
+    # Unable to Find "pint.unit" -- Module Not Found Error with py-pint@0.20:
+    depends_on("py-pint@0.10.1:0.19", type=("build", "run"))
     depends_on("py-pooch@0.1:", type=("build", "run"))
     depends_on("py-pyproj@2.3.0:", type=("build", "run"))
     depends_on("py-scipy@1.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-numexpr/package.py
+++ b/var/spack/repos/builtin/packages/py-numexpr/package.py
@@ -28,7 +28,7 @@ class PyNumexpr(PythonPackage):
     depends_on("python@3.7:", when="@2.8.3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
-    depends_on("py-numpy@1.13.3:", type=("build", "run"), when="@2.8.3:")
+    depends_on("py-numpy@1.13.3:1.25", type=("build", "run"), when="@2.8.3:")
     # https://github.com/pydata/numexpr/issues/397
     depends_on("py-numpy@1.7:1.22", type=("build", "run"), when="@:2.7")
 

--- a/var/spack/repos/builtin/packages/py-pint/package.py
+++ b/var/spack/repos/builtin/packages/py-pint/package.py
@@ -21,6 +21,7 @@ class PyPint(PythonPackage):
     version("0.22", sha256="2d139f6abbcf3016cad7d3cec05707fe908ac4f99cf59aedfd6ee667b7a64433")
     version("0.21.1", sha256="5d5b6b518d0c5a7ab03a776175db500f1ed1523ee75fb7fafe38af8149431c8d")
     version("0.20.1", sha256="387cf04078dc7dfe4a708033baad54ab61d82ab06c4ee3d4922b1e45d5626067")
+    version("0.19.2", sha256="e1d4989ff510b378dad64f91711e7bdabe5ca78d75b06a18569ac454678c4baf")
     version("0.18", sha256="8c4bce884c269051feb7abc69dbfd18403c0c764abc83da132e8a7222f8ba801")
     version("0.17", sha256="f4d0caa713239e6847a7c6eefe2427358566451fe56497d533f21fb590a3f313")
     version("0.11", sha256="308f1070500e102f83b6adfca6db53debfce2ffc5d3cbe3f6c367da359b5cf4d")

--- a/var/spack/repos/builtin/packages/py-poetry/package.py
+++ b/var/spack/repos/builtin/packages/py-poetry/package.py
@@ -71,7 +71,7 @@ class PyPoetry(PythonPackage):
     depends_on("py-virtualenv@20.4.3:20.4.4,20.4.7:", when="@1.2", type=("build", "run"))
     depends_on("py-virtualenv@20.0.26:20", when="@:1.1", type=("build", "run"))
     depends_on("py-xattr@0.10", when="platform=darwin @1.6.1", type=("build", "run"))
-    depends_on("py-xattr@0.9.7:0.9", when="platform=darwin @1.2:")
+    depends_on("py-xattr@0.9.7:0.9", when="platform=darwin @1.2")
     depends_on("py-urllib3@1.26.0:1", when="@1.2")
     depends_on("py-dulwich@0.21.2:0.21", when="@1.6.1", type=("build", "run"))
     depends_on("py-dulwich@0.20.46:0.20", when="@1.2.1")


### PR DESCRIPTION
## Description

- Bug fix in `var/spack/repos/builtin/packages/py-poetry/package.py`: specify ranges of py-xattr dependency on Darwin correctly to avoid concretization errors
- Bug fix in `var/spack/repos/builtin/packages/py-numexpr/package.py`: 2.8.4 doesn't build with `py-numpy@1.26`
- Add `py-pint@0.19.2` and correct version dependency on `py-pint` in `py-metpy`

Upstream PR for spack develop for all of the above changes: https://github.com/spack/spack/pull/44651

## Issue

Working towards https://github.com/JCSDA/spack-stack/issues/1122

## Dependencies

None

## Testing

See https://github.com/JCSDA/spack-stack/pull/1124