### PR TITLE
mepo: add v1.52.0

### DIFF
--- a/var/spack/repos/builtin/packages/mepo/package.py
+++ b/var/spack/repos/builtin/packages/mepo/package.py
@@ -12,8 +12,9 @@ class Mepo(Package):
     homepage = "https://github.com/GEOS-ESM/mepo"
     url = "https://github.com/GEOS-ESM/mepo/archive/refs/tags/v1.51.1.tar.gz"
 
-    maintainers("mathomp4", "climbfuji")
+    maintainers("mathomp4", "pchakraborty", "climbfuji")
 
+    version("1.52.0", sha256="553876e9ce13484e25abb2e93b261e9f69b529cd4a62070b23dcbd0115b89ad9")
     version("1.51.1", sha256="543c1e7487afb2d62e5e8c8a2f69a85af1b1951f588f3dfc7471763e90847360")
 
     depends_on("python", type="run")


### PR DESCRIPTION
Update mepo package to have v1.52.0. I'm working on a geosgcm package and the blobless clone ability of mepo 1.52 is nice to have.

Also, I'm adding @pchakraborty as a maintainer as, well, he is pretty much the mepo maintainer now. Indeed, soon we hope to have mepo 2.0 out thanks to hard work from @pchakraborty.

mepo 2.0 will be a proper pip package which means this package will be changed a lot based on https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
