### PR TITLE
Fix cc wrapper

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -243,9 +243,11 @@ case "$command" in
         # Edge case for Intel's oneAPI compilers when using the legacy classic compilers:
         # Pass flags to disable deprecation warnings to vcheck mode, since the warnings
         # to stderr confuse tools that parse the output of compiler version checks.
-        if [[ ${SPACK_CFLAGS} == *"-diag-disable=10441"* ]]; then
-            vcheck_flags="-diag-disable=10441"
-        fi
+        case ${SPACK_CXXFLAGS} in
+            *"-diag-disable=10441"* )
+                 vcheck_flags="-diag-disable=10441"
+                 ;;
+        esac
         command="$SPACK_CC"
         language="C"
         comp="CC"
@@ -256,9 +258,11 @@ case "$command" in
         # Edge case for Intel's oneAPI compilers when using the legacy classic compilers:
         # Pass flags to disable deprecation warnings to vcheck mode, since the warnings
         # to stderr confuse tools that parse the output of compiler version checks.
-        if [[ ${SPACK_CXXFLAGS} == *"-diag-disable=10441"* ]]; then
-            vcheck_flags="-diag-disable=10441"
-        fi
+        case ${SPACK_CXXFLAGS} in
+            *"-diag-disable=10441"* )
+                 vcheck_flags="-diag-disable=10441"
+                 ;;
+        esac
         command="$SPACK_CXX"
         language="C++"
         comp="CXX"
@@ -269,9 +273,11 @@ case "$command" in
         # Edge case for Intel's oneAPI compilers when using the legacy classic compilers:
         # Pass flags to disable deprecation warnings to vcheck mode, since the warnings
         # to stderr confuse tools that parse the output of compiler version checks.
-        if [[ ${SPACK_FFLAGS} == *"-diag-disable=10448"* ]]; then
-            vcheck_flags="-diag-disable=10448"
-        fi
+        case ${SPACK_CXXFLAGS} in
+            *"-diag-disable=10441"* )
+                 vcheck_flags="-diag-disable=10441"
+                 ;;
+        esac
         command="$SPACK_FC"
         language="Fortran 90"
         comp="FC"


### PR DESCRIPTION
This PR fixes lib/spack/env/cc by making the Intel warning-related clauses added in commit d465fa0d08d25e1a75ed90a61f5184063e96e675 POSIX compliant. Otherwise this script will fail on many OSes. See https://github.com/NOAA-EMC/UPP/pull/974#issuecomment-2163661393 and https://github.com/NOAA-EMC/UPP/actions/runs/9506866281/job/26205047049?pr=974 (and for that matter, https://stackoverflow.com/questions/229551/how-to-check-if-a-string-contains-a-substring-in-bash)