### PR TITLE
Add mapl/2.46.2 and esmf/8.6.1 recipes to release/1.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -29,9 +29,7 @@ class Esmf(MakefilePackage):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
-    version("8.7.0b04", commit="609c81179572747407779492c43776e34495d267")
     version("8.6.1", sha256="dc270dcba1c0b317f5c9c6a32ab334cb79468dda283d1e395d98ed2a22866364")
-    version("8.6.1b04", commit="64d3aacc36f2d4d39255eb521c34123903cc0551")
     version("8.6.0", sha256="ed057eaddb158a3cce2afc0712b49353b7038b45b29aee86180f381457c0ebe7")
     version("8.5.0", sha256="acd0b2641587007cc3ca318427f47b9cae5bfd2da8d2a16ea778f637107c29c4")
     version("8.4.2", sha256="969304efa518c7859567fa6e65efd960df2b4f6d72dbf2c3f29e39e4ab5ae594")

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -33,9 +33,33 @@ class Mapl(CMakePackage):
         "AlexanderRichert-NOAA",
     )
 
+    license("Apache-2.0")
+
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("2.47.0", sha256="66c862d2ab8bcd6969e9728091dbca54f1f420e97e41424c4ba93ef606088459")
+    version("2.46.2", sha256="6d397ad73042355967de8ef5b521d6135c004f96e93ae7b215f9ee325e75c6f0")
+    version("2.46.1", sha256="f3090281de6293b484259d58f852c45b98759de8291d36a4950e6d348ece6573")
+    version("2.46.0", sha256="726d9588b724bd43e5085d1a2f8d806d548f185ed6b22a1b13c0ed06212d7be2")
+    # NOTE: Due to issues with CMake and ESMF, versions 2.44 and 2.45 of MAPL were not
+    #       correctly installable with spack. The versions are still available in the
+    #       repository, but we are skipping them in spack. There are references to these
+    #       versions below in case a 2.44 or 2.45 spack-compatible version is needed
+    #       and changes backported.
+    version("2.43.2", sha256="966130931153a9a3974ad6ae011d1df194e057cb82301c8703ef69669b9f27ba")
+    version("2.43.1", sha256="62b7a8c438c960e47b83d9835cb37c7ce25f617d648f2affe9961b4a6e638abc")
+    version("2.43.0", sha256="1be99d64ca46001ac94f7db3607c345e144976dc34fe184e734e212bf3955d01")
+    version("2.42.4", sha256="f6b643cc45f2dc55df96a316c84d84ace341bb6e06f81f83b5de258d9978b3d4")
+    version("2.42.3", sha256="4ccac684dcbbca36cd7b30cb1515b52f05d7c06ca93399e60ccf42726d147018")
+    version("2.42.2", sha256="cc70be57942a3d7f7a53d4762cb972cebcb9ae1737be7e03f195e4d4eefbc68a")
+    version("2.42.1", sha256="78fdcc17f99f525feded05fc360f5b76e6f2c07057e0b16ce3177da2a534dc33")
+    version("2.42.0", sha256="9b6c3434919c14ef79004db5f76cb3dd8ef375584227101c230a372bb0470fdd")
+    version("2.41.2", sha256="73e1f0961f1b70e8159c0a2ce3499eb5158f3ca6d081f4c7826af7854ebfb44d")
+    version("2.41.1", sha256="2b384bd4fbaac1bff4ef009922c436c4ab54832172a5cd4d312ea44e32c1ae7c")
+    version("2.41.0", sha256="1142f9395e161174e3ec1654fba8bda1d0bd93edc7438b1927d8f5d7b42a0a86")
+    version("2.40.5", sha256="85b4a4ac0d843398452808b88d7a5c29435aa37b69b91a1f4bee664e9f367b7d")
+    version("2.40.4", sha256="fb843b118d6e56cd4fc4b114c4d6f91956d5c8b3d9389ada56da1dfdbc58904f")
     version("2.40.3", sha256="4b82a314c88a035fc2b91395750aa7950d6bee838786178ed16a3f39a1e45519")
     version("2.40.2", sha256="7327f6f5bce6e09e7f7b930013fba86ee7cbfe8ed4c7c087fc9ab5acbf6640fd")
     version("2.40.1", sha256="6f40f946fabea6ba73b0764092e495505d220455b191b4e454736a0a25ee058c")
@@ -119,8 +143,32 @@ class Mapl(CMakePackage):
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v3.46.0",
+        when="@2.47:",
+    )
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v3.45.2",
+        when="@2.45:2.46",
+    )
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v3.40.0",
+        when="@2.44",
+    )
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v3.36.0",
+        when="@2.42.0:2.43",
+    )
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.31.0",
-        when="@2.40.0:",
+        when="@2.40.0:2.41",
     )
     resource(
         name="esma_cmake",
@@ -159,13 +207,15 @@ class Mapl(CMakePackage):
     # Patch to add missing MPI Fortran target to top-level CMakeLists.txt
     patch("mapl-2.12.3-mpi-fortran.patch", when="@:2.12.3")
 
-    # Patch for mpich4 for selected older versions of mapl used by UFS
-    # https://github.com/GEOS-ESM/MAPL/pull/2381
-    patch("backport-b571b3f-from-develop-to-v2.40.3.patch", when="@2.40.3")
-    patch("backport-b571b3f-from-develop-to-v2.35.2.patch", when="@2.35.2")
-    conflicts("mpich@4", when="@2.40.4:")
-    conflicts("mpich@4", when="@2.35.3:2.40.2")
-    conflicts("mpich@4", when="@:2.35.1")
+    # MAPL only compiles with MPICH from version 2.42.0 and higher so we conflict
+    # with older versions. Also, it's only been tested with MPICH 4, so we don't
+    # allow older MPICH
+    conflicts("mpich@:3")
+    conflicts("mpich@4", when="@:2.41")
+
+    # MAPL only supports gcc 13 from MAPL 2.45 onwards, so we only allow
+    # builds with gcc 13 from that version onwards
+    conflicts("%gcc@13:", when="@:2.44")
 
     variant("flap", default=False, description="Build with FLAP support", when="@:2.39")
     variant("pflogger", default=True, description="Build with pFlogger support")
@@ -192,19 +242,25 @@ class Mapl(CMakePackage):
     depends_on("hdf5")
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")
-    depends_on("esmf@8.5:", when="@2.40:")
+    depends_on("esmf@8.6.1:", when="@2.45:")
+    depends_on("esmf@8.6.0", when="@2.44")
+    depends_on("esmf@8.5:", when="@2.40:2.43")
     depends_on("esmf@8.4", when="@2.34:2.39")
     depends_on("esmf@8.3", when="@2.22:2.33")
     depends_on("esmf", when="@:2.12.99")
     depends_on("esmf~debug", when="~debug")
     depends_on("esmf+debug", when="+debug")
 
-    depends_on("gftl@1.10.0:", when="@2.40:")
+    depends_on("gftl@1.13.0:", when="@2.45:")
+    depends_on("gftl@1.11.0:", when="@2.44")
+    depends_on("gftl@1.10.0:", when="@2.40:2.43")
     depends_on("gftl@1.5.5:1.9", when="@:2.39")
 
     # There was an interface change in gftl-shared, so we need to control versions
     # MAPL 2.39 and older can use up to 1.6.0 but MAPL 2.40+ needs 1.6.1 or higher
-    depends_on("gftl-shared@1.6.1:", when="@2.40:")
+    depends_on("gftl-shared@1.8.0:", when="@2.45:")
+    depends_on("gftl-shared@1.7.0:", when="@2.44")
+    depends_on("gftl-shared@1.6.1:", when="@2.40:2.43")
     depends_on("gftl-shared@1.3.1:1.6.0", when="@:2.39")
 
     # There was an interface change in yaFyaml, so we need to control versions
@@ -218,14 +274,23 @@ class Mapl(CMakePackage):
     # yaFyaml so we need to use old pFlogger, but MAPL 2.23+ uses new yaFyaml
     depends_on("pflogger@:1.6 +mpi", when="@:2.22+pflogger")
     depends_on("pflogger@1.9.1: +mpi", when="@2.23:2.39+pflogger")
-    depends_on("pflogger@1.9.5: +mpi", when="@2.40:+pflogger")
+    depends_on("pflogger@1.9.5: +mpi", when="@2.40:2.43+pflogger")
+    depends_on("pflogger@1.11.0: +mpi", when="@2.44+pflogger")
+    depends_on("pflogger@1.14.0: +mpi", when="@2.45:+pflogger")
 
     # fArgParse v1.4.1 is the first usable version with MAPL
     # we now require 1.5.0 with MAPL 2.40+
-    depends_on("fargparse@1.5.0:", when="@2.40:+fargparse")
+    depends_on("fargparse@1.7.0:", when="@2.45:+fargparse")
+    depends_on("fargparse@1.6.0:", when="@2.44+fargparse")
+    depends_on("fargparse@1.5.0:", when="@2.40:43+fargparse")
     depends_on("fargparse@1.4.1:1.4", when="@:2.39+fargparse")
 
-    depends_on("pfunit@4.2: +mpi +fhamcrest", when="+pfunit")
+    depends_on("pfunit@4.9: +mpi +fhamcrest", when="@2.45:+pfunit")
+    depends_on("pfunit@4.8: +mpi +fhamcrest", when="@2.44+pfunit")
+    depends_on("pfunit@4.7.3: +mpi +fhamcrest", when="@2.40:+pfunit")
+    depends_on("pfunit@4.6.1: +mpi +fhamcrest", when="@2.32:+pfunit")
+    depends_on("pfunit@4.4.1: +mpi +fhamcrest", when="@2.26:+pfunit")
+    depends_on("pfunit@4.2: +mpi +fhamcrest", when="@:2.25+pfunit")
     depends_on("flap", when="+flap")
 
     depends_on("ecbuild", type="build")
@@ -234,18 +299,22 @@ class Mapl(CMakePackage):
     depends_on("py-numpy", when="+f2py")
     depends_on("perl")
 
+    # when using apple-clang version 15.x or newer, need to use the llvm-openmp library
+    depends_on("llvm-openmp", when="%apple-clang@15:", type=("build", "run"))
+
     def cmake_args(self):
         args = [
-            self.define_from_variant("BUILD_WITH_FLAP", "flap"),
             self.define_from_variant("BUILD_WITH_PFLOGGER", "pflogger"),
             self.define_from_variant("BUILD_WITH_FARGPARSE", "fargparse"),
             self.define_from_variant("BUILD_SHARED_MAPL", "shared"),
             self.define_from_variant("USE_EXTDATA2G", "extdata2g"),
             self.define_from_variant("USE_F2PY", "f2py"),
-            "-DCMAKE_C_COMPILER=%s" % self.spec["mpi"].mpicc,
-            "-DCMAKE_CXX_COMPILER=%s" % self.spec["mpi"].mpicxx,
-            "-DCMAKE_Fortran_COMPILER=%s" % self.spec["mpi"].mpifc,
         ]
+
+        # We only want to add BUILD_WITH_FLAP if we are @:2.39 otherwise
+        # there is a weird empty string that gets added to the CMake command
+        if self.spec.satisfies("@:2.39"):
+            args.append(self.define("BUILD_WITH_FLAP", self.spec.satisfies("+flap")))
 
         if self.spec.satisfies("@2.22.0:"):
             args.append(self.define("CMAKE_MODULE_PATH", self.spec["esmf"].prefix.cmake))
@@ -264,6 +333,34 @@ class Mapl(CMakePackage):
                 fflags.append("-fallow-argument-mismatch")
         if fflags:
             args.append(self.define("CMAKE_Fortran_FLAGS", " ".join(fflags)))
+
+        # Scripts often need to know the MPI stack used to setup the environment.
+        # Normally, we can autodetect this, but building with Spack does not
+        # seem to work. We need to pass in the MPI stack used to CMake
+        # via -DMPI_STACK on the CMake command line. We use the following
+        # names for the MPI stacks:
+        #
+        # - MPICH --> mpich
+        # - Open MPI --> openmpi
+        # - Intel MPI --> intelmpi
+        # - MVAPICH --> mvapich
+        # - HPE MPT --> mpt
+        # - Cray MPICH --> mpich
+
+        if self.spec.satisfies("^mpich"):
+            args.append(self.define("MPI_STACK", "mpich"))
+        elif self.spec.satisfies("^openmpi"):
+            args.append(self.define("MPI_STACK", "openmpi"))
+        elif self.spec.satisfies("^intel-oneapi-mpi"):
+            args.append(self.define("MPI_STACK", "intelmpi"))
+        elif self.spec.satisfies("^mvapich"):
+            args.append(self.define("MPI_STACK", "mvapich"))
+        elif self.spec.satisfies("^mpt"):
+            args.append(self.define("MPI_STACK", "mpt"))
+        elif self.spec.satisfies("^cray-mpich"):
+            args.append(self.define("MPI_STACK", "mpich"))
+        else:
+            raise InstallError("Unsupported MPI stack")
 
         return args
 


### PR DESCRIPTION
Pull in the dev. versions of mapl and esmf package.py to accommodate installation of mapl/2.46.2 and esmf/8.6.1 in spack-stack release/1.6.0 https://github.com/JCSDA/spack-stack/issues/1117 and https://github.com/ufs-community/ufs-weather-model/issues/2346.
