### PR TITLE
release/1.60: bug fix for mapl with mvapich2

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -349,6 +349,8 @@ class Mapl(CMakePackage):
 
         if self.spec.satisfies("^mpich"):
             args.append(self.define("MPI_STACK", "mpich"))
+        elif self.spec.satisfies("^mvapich2"):
+            args.append(self.define("MPI_STACK", "mpich"))
         elif self.spec.satisfies("^openmpi"):
             args.append(self.define("MPI_STACK", "openmpi"))
         elif self.spec.satisfies("^intel-oneapi-mpi"):

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -350,7 +350,7 @@ class Mapl(CMakePackage):
         if self.spec.satisfies("^mpich"):
             args.append(self.define("MPI_STACK", "mpich"))
         elif self.spec.satisfies("^mvapich2"):
-            args.append(self.define("MPI_STACK", "mpich"))
+            args.append(self.define("MPI_STACK", "mvapich"))
         elif self.spec.satisfies("^openmpi"):
             args.append(self.define("MPI_STACK", "openmpi"))
         elif self.spec.satisfies("^intel-oneapi-mpi"):


### PR DESCRIPTION
## Description

Yet another bug fix for `mapl` for `release/1.6.0` because it wants to configure MPI providers itself. Need to add `mvapich2`, because Hercules uses `mvapich2` for spack-stack-1.6.0 with `gcc`. I will also cherry-pick this and send it to spack develop.

**Ignore** the failing style tests!

## Testing

Corresponding spack-stack PR: https://github.com/JCSDA/spack-stack/pull/1190