### PR TITLE
Updates towards compiling full unified environment with Intel oneAPI compilers (icx, icpx, ifort)

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -243,7 +243,7 @@ case "$command" in
         # Edge case for Intel's oneAPI compilers when using the legacy classic compilers:
         # Pass flags to disable deprecation warnings to vcheck mode, since the warnings
         # to stderr confuse tools that parse the output of compiler version checks.
-        case ${SPACK_CXXFLAGS} in
+        case ${SPACK_CFLAGS} in
             *"-diag-disable=10441"* )
                  vcheck_flags="-diag-disable=10441"
                  ;;
@@ -273,9 +273,9 @@ case "$command" in
         # Edge case for Intel's oneAPI compilers when using the legacy classic compilers:
         # Pass flags to disable deprecation warnings to vcheck mode, since the warnings
         # to stderr confuse tools that parse the output of compiler version checks.
-        case ${SPACK_CXXFLAGS} in
-            *"-diag-disable=10441"* )
-                 vcheck_flags="-diag-disable=10441"
+        case ${SPACK_FFLAGS} in
+            *"-diag-disable=10448"* )
+                 vcheck_flags="-diag-disable=10448"
                  ;;
         esac
         command="$SPACK_FC"

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -76,6 +76,7 @@ class Fckit(CMakePackage):
 
         if (
             self.spec.satisfies("%intel")
+            or self.spec.satisfies("%oneapi")
             or self.spec.satisfies("%gcc")
             or self.spec.satisfies("%nvhpc")
         ):

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -33,6 +33,7 @@ class Qt(Package):
 
     license("LGPL-3.0-only")
 
+    version("5.15.13", sha256="9550ec8fc758d3d8d9090e261329700ddcd712e2dda97e5fcfeabfac22bea2ca")
     version("5.15.12", sha256="93f2c0889ee2e9cdf30c170d353c3f829de5f29ba21c119167dee5995e48ccce")
     version("5.15.11", sha256="7426b1eaab52ed169ce53804bdd05dfe364f761468f888a0f15a308dc1dc2951")
     version("5.15.10", sha256="b545cb83c60934adc9a6bbd27e2af79e5013de77d46f5b9f5bb2a3c762bf55ca")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -33,6 +33,7 @@ class Qt(Package):
 
     license("LGPL-3.0-only")
 
+    version("5.15.14", sha256="fdd3a4f197d2c800ee0085c721f4bef60951cbda9e9c46e525d1412f74264ed7")
     version("5.15.13", sha256="9550ec8fc758d3d8d9090e261329700ddcd712e2dda97e5fcfeabfac22bea2ca")
     version("5.15.12", sha256="93f2c0889ee2e9cdf30c170d353c3f829de5f29ba21c119167dee5995e48ccce")
     version("5.15.11", sha256="7426b1eaab52ed169ce53804bdd05dfe364f761468f888a0f15a308dc1dc2951")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -259,6 +259,11 @@ class Qt(Package):
     # https://doc.qt.io/qt-5.14/supported-platforms.html
     conflicts("%gcc@:4", when="@5.14:")
 
+    # Compiling with oneAPI compilers icx, icpx requires patching
+    # This has only been tested for 5.15.14 so far
+    conflicts("%oneapi", when="@:5.15.13")
+    patch("qt51514-oneapi.patch", when="@5.15.14: %oneapi")
+
     # Non-macOS dependencies and special macOS constraints
     if MACOS_VERSION is None:
         with when("+gui"):
@@ -288,6 +293,10 @@ class Qt(Package):
     # Mapping for compilers/systems in the QT 'mkspecs'
     compiler_mapping = {
         "intel": ("icc",),
+        # This only works because we apply patch "qt51514-oneapi.patch"
+        # above that replaces calls to "icc" with calls to "icx" in
+        # qtbase/mkspecs/*
+        "oneapi": ("icc",),
         "apple-clang": ("clang-libc++", "clang"),
         "clang": ("clang-libc++", "clang"),
         "aocc": ("clang-libc++", "clang"),

--- a/var/spack/repos/builtin/packages/qt/qt51514-oneapi.patch
+++ b/var/spack/repos/builtin/packages/qt/qt51514-oneapi.patch
@@ -1,0 +1,31 @@
+--- a/qtbase/mkspecs/common/icc-base-unix.conf	2024-05-07 23:17:16.000000000 -0600
++++ b/qtbase/mkspecs/common/icc-base-unix.conf	2024-07-10 21:32:47.808327220 -0600
+@@ -16,7 +16,7 @@
+ QMAKE_CFLAGS_OPTIMIZE      = -O2
+ QMAKE_CFLAGS_OPTIMIZE_SIZE = -Os
+ 
+-QMAKE_CC                = icc
++QMAKE_CC                = icx
+ QMAKE_LEX               = flex
+ QMAKE_LEXFLAGS          =
+ QMAKE_YACC              = yacc
+@@ -61,7 +61,7 @@
+ QMAKE_CFLAGS_SHANI     += -msha
+ QMAKE_CFLAGS_VAES      += -mvaes
+ 
+-QMAKE_CXX               = icpc
++QMAKE_CXX               = icpx
+ QMAKE_CXXFLAGS          = $$QMAKE_CFLAGS
+ QMAKE_CXXFLAGS_APP      = $$QMAKE_CFLAGS_APP
+ QMAKE_CXXFLAGS_DEPS     = $$QMAKE_CFLAGS_DEPS
+@@ -92,8 +92,8 @@
+ QMAKE_CFLAGS_HIDESYMS   += -fvisibility=hidden
+ QMAKE_CXXFLAGS_HIDESYMS += $$QMAKE_CFLAGS_HIDESYMS -fvisibility-inlines-hidden
+ 
+-QMAKE_LINK              = icpc
+-QMAKE_LINK_SHLIB        = icpc
++QMAKE_LINK              = icpx
++QMAKE_LINK_SHLIB        = icpx
+ QMAKE_LFLAGS            =
+ QMAKE_LFLAGS_RELEASE    =
+ QMAKE_LFLAGS_DEBUG      =


### PR DESCRIPTION
## Description

Several unrelated updates and a rather important bug fix that bring us one step closer to compiling the entire unified environment with the mixed Intel oneAPI compilers (icx, icpx, ifort):
- `fckit`: Straightforward, Upstream PR for spack develop: https://github.com/spack/spack/pull/45196 (includes an earlier update we made in spack-stack-dev for compiling with `nvhpc`).
- `qt`: First, pulled in updates (two mostrecent commits) for the package from spack develop, then added the workaround for oneAPI. Tested successfully on Blackpearl (compiled `qt` and `ecflow` with oneAPI, then start ecflow server and ecflow GUI). Upstream PR for spack develop: https://github.com/spack/spack/pull/45195
- **Bug fix** in `lib/spack/env/cc`: I mistakenly copied the C++logic into the Fortran block and nobody noticed it. This fixes it. Note that the entire `vcheck_flags` logic in `lib/spack/env/cc` will eventually be replaced by a better solution. But since I am currently iterating with the spack developers on how that solution should look like (see https://github.com/spack/spack/pull/44588), let's merge this important bug fix now.

Corresponding spack-stack PR: https://github.com/JCSDA/spack-stack/pull/1195