### PR TITLE
Add py-dask versions 2021.2.0, 2021.3.0, 2021.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -20,6 +20,9 @@ class PyDask(PythonPackage):
     version("2022.10.2", sha256="42cb43f601709575fa46ce09e74bea83fdd464187024f56954e09d9b428ceaab")
     version("2021.6.2", sha256="8588fcd1a42224b7cfcd2ebc8ad616734abb6b1a4517efd52d89c7dd66eb91f8")
     version("2021.4.1", sha256="195e4eeb154222ea7a1c368119b5f321ee4ec9d78531471fe0145a527f744aa8")
+    version("2021.3.1", sha256="1fa7e1809e7c50c5505297b03e6ee161e0695df73b4c4051b5b1c8fd670bf5d7")
+    version("2021.3.0", sha256="566054b493d63c15732f2a640382b21e861571d61639f59341bc7695a9be138e")
+    version("2021.2.0", sha256="e7054b8d685205e95c789900ae87d6174550180cbe38a3cb1142e10c73004c22")
     version("2020.12.0", sha256="43e745afd4b464e6c0113131e430a16dce6ac42460b06e24d799093d098f7ab0")
 
     variant("array", default=True, description="Install requirements for dask.array")


### PR DESCRIPTION
## Description

Add more `py-dask` versions, especially 2021.3.0 which we need to fix https://github.com/JCSDA/spack-stack/issues/1216 . Note that all the variants and options for the different versions were already configured correctly in the package.

## Testing

See https://github.com/JCSDA/spack-stack/pull/1221