### PR TITLE
For gcc@13: Update GFE packages (yafyaml etc) from spack develop and add odc@1.5.2

### DIFF
--- a/var/spack/repos/builtin/packages/fargparse/package.py
+++ b/var/spack/repos/builtin/packages/fargparse/package.py
@@ -20,6 +20,7 @@ class Fargparse(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.8.0", sha256="37108bd3c65d892d8c24611ce4d8e5451767e4afe81445fde67eab652178dd01")
     version("1.7.0", sha256="9889e7eca9c020b742787fba2be0ba16edcc3fcf52929261ccb7d09996a35f89")
     version("1.6.0", sha256="055a0af44f50c302f8f20a8bcf3d26c5bbeacf5222cdbaa5b19da4cff56eb9c0")
     version("1.5.0", sha256="1c16ead5f1bacb9c2f33aab99a0889c68c1a1ece754ddc3fd340f10a0d5da2f7")

--- a/var/spack/repos/builtin/packages/gftl-shared/package.py
+++ b/var/spack/repos/builtin/packages/gftl-shared/package.py
@@ -25,6 +25,7 @@ class GftlShared(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.9.0", sha256="a3291ce61b512fe88628cc074b02363c2ba3081e7b453371089121988482dd6f")
     version("1.8.0", sha256="3450161508c573ea053b2a23cdbf2a1d6fd6fdb78c162d31fc0019da0f8dd03c")
     version("1.7.0", sha256="8ba567133fcee6b93bc71f61b3bb2053b4b07c6d78f6ad98a04dfc40aa478de7")
     version("1.6.1", sha256="0e3e1e0c7e0c3f1576e296b3b199dcae4bbaad055fc8fe929c34e52d4b07b02c")

--- a/var/spack/repos/builtin/packages/gftl/package.py
+++ b/var/spack/repos/builtin/packages/gftl/package.py
@@ -39,6 +39,7 @@ class Gftl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.14.0", sha256="bf8e3ba3f708ea327c7eb1a5bd1afdce41358c6df1a323aba0f73575c25d5fc8")
     version("1.13.0", sha256="d8ef4bca5fb67e63dcd69e5377a0cef8336b00178a97450e79010552000d0a52")
     version("1.12.0", sha256="b50e17cb2109372819b3ee676e6e61fd3a517dc4c1ea293937c8a83f03b0cbd6")
     version("1.11.0", sha256="b28935bc077749823b1505ad8c1208360a5ba7e961d7593c17a33b11455a32a4")

--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -34,4 +34,10 @@ class Odc(CMakePackage):
             # The tests download additional data (~650MB):
             self.define("ENABLE_TESTS", self.run_tests),
         ]
+        # https://github.com/JCSDA/spack-stack/issues/585
+        if self.spec.satisfies("%apple-clang@14.0.3"):
+            args.append(self.define("CMAKE_C_FLAGS_RELEASE", "-O1"))
+            args.append(self.define("CMAKE_CXX_FLAGS_RELEASE", "-O1"))
+            args.append(self.define("CMAKE_C_FLAGS_RELWITHDEBINFO", "-O1"))
+            args.append(self.define("CMAKE_CXX_FLAGS_RELWITHDEBINFO", "-O1"))
         return args

--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -16,6 +16,7 @@ class Odc(CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.5.2", sha256="49575c3ef9ae8825d588357022d0ff6caf3e557849888c9d2f0677e9efe95869")
     version("1.4.6", sha256="ff99d46175e6032ddd0bdaa3f6a5e2c4729d24b698ba0191a2a4aa418f48867c")
     version("1.4.5", sha256="8532d0453531d62e1f15791d1c5c96540b842913bd211a8ef090211eaf4cccae")
     version("1.4.4", sha256="65cb7b491566d3de14b66741544360f20eaaf1a6d5a24af7d8b939dd50e26431")

--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -19,9 +19,6 @@ class Odc(CMakePackage):
     version("1.5.2", sha256="49575c3ef9ae8825d588357022d0ff6caf3e557849888c9d2f0677e9efe95869")
     version("1.4.6", sha256="ff99d46175e6032ddd0bdaa3f6a5e2c4729d24b698ba0191a2a4aa418f48867c")
     version("1.4.5", sha256="8532d0453531d62e1f15791d1c5c96540b842913bd211a8ef090211eaf4cccae")
-    version("1.4.4", sha256="65cb7b491566d3de14b66741544360f20eaaf1a6d5a24af7d8b939dd50e26431")
-    version("1.4.2", sha256="19572e93238c1531bcf0f7966f0d2342a0400f5fe9deb934a384228f895909c9")
-    version("1.4.1", sha256="e79707c8cd951a3d79439013d43d6b2888956a34e9b76ce416bece5262b77d93")
     version("1.3.0", sha256="97a4f10765b341cc8ccbbf203f5559cb1b838cbd945f48d4cecb1bc4305e6cd6")
 
     variant("fortran", default=False, description="Enable the Fortran interface")
@@ -37,10 +34,4 @@ class Odc(CMakePackage):
             # The tests download additional data (~650MB):
             self.define("ENABLE_TESTS", self.run_tests),
         ]
-        # https://github.com/JCSDA/spack-stack/issues/585
-        if self.spec.satisfies("%apple-clang@14.0.3"):
-            args.append(self.define("CMAKE_C_FLAGS_RELEASE", "-O1"))
-            args.append(self.define("CMAKE_CXX_FLAGS_RELEASE", "-O1"))
-            args.append(self.define("CMAKE_C_FLAGS_RELWITHDEBINFO", "-O1"))
-            args.append(self.define("CMAKE_CXX_FLAGS_RELWITHDEBINFO", "-O1"))
         return args

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -19,6 +19,7 @@ class Pfunit(CMakePackage):
 
     maintainers("mathomp4", "tclune")
 
+    version("4.10.0", sha256="ee5e899dfb786bac46e3629b272d120920bafdb7f6a677980fc345f6acda0f99")
     version("4.9.0", sha256="caea019f623d4e02dd3e8442cee88e6087b4c431a2628e9ec2de55b527b51ab6")
     version("4.8.0", sha256="b5c66ab949fd23bee5c3b4d93069254f7ea40decb8d21f622fd6aa45ee68ef10")
     version("4.7.4", sha256="ac850e33ea99c283f503f75293bf238b4b601885d7adba333066e6185dad5c04")
@@ -113,6 +114,7 @@ class Pfunit(CMakePackage):
     depends_on("mpi", when="+mpi")
     depends_on("esmf", when="+esmf")
     depends_on("m4", when="@4.1.5:", type="build")
+    depends_on("fargparse@1.8.0:", when="@4.10.0:")
     depends_on("fargparse", when="@4:")
     depends_on("cmake@3.12:", type="build")
 

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 
 from spack.package import *
 
@@ -30,6 +31,7 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.4.0", sha256="2a415087eb26d291ff40da4430d668c702d22601ed52a72d001140d97372bc7d")
     version("1.3.0", sha256="a3882210b2620485471e3337d995edc1e653b49d9caaa902a43293826a61a635")
     version("1.2.0", sha256="912a4248bbf2e2e84cf3e36f2ae8483bee6b32d2eaa4406dd2100ad660c9bfc6")
     version("1.1.0", sha256="f0be81afe643adc2452055e5485f09cdb509a8fdd5a4ec5547b0c31dd22b4830")
@@ -59,6 +61,35 @@ class Yafyaml(CMakePackage):
         when="@:1.2.0",
         msg="yaFyaml only works with the Fujitsu compiler from 1.3.0 onwards",
     )
+
+    # GCC 13.3 and higher only work with yafyaml 1.4.0 onwards
+    # First we can check if the spec is gcc@13.3...
+    conflicts("%gcc@13.3:", when="@:1.3.0", msg="GCC 13.3+ only works with yafyaml 1.4.0 onwards")
+
+    # ...but if it is not (say apple-clang with gfortran as a fc), there is
+    # no easy way to check this. So we hijack flag_handler to raise an
+    # exception if we detect gfortran 13.3 or 14.
+    # NOTE: This will only error out at install time, so `spack spec` will
+    # not catch this.
+    def flag_handler(self, name, flags):
+        # We need to match any compiler that has a name of gfortran or gfortran-*
+        pattern = re.compile(r"gfortran(-\d+)?$")
+
+        if pattern.search(self.compiler.fc):
+            gfortran_version = spack.compiler.get_compiler_version_output(
+                self.compiler.fc, "-dumpfullversion"
+            ).strip()
+
+            # gfortran_version is now a string like "13.3.0". We now need to just capture
+            # the major and minor version numbers
+            gfortran_version = ".".join(gfortran_version.split(".")[:2])
+
+            if self.spec.satisfies("@:1.3.0") and (float(gfortran_version) >= 13.3):
+                raise InstallError(
+                    f"Your gfortran version {gfortran_version} is not compatible with "
+                    f"yafyaml 1.3.0 and below. Use yafyaml 1.4.0 or higher."
+                )
+        return None, None, None
 
     variant(
         "build_type",


### PR DESCRIPTION
## Description

These changes are required to build the unified environment with `gcc13`:
1. Cherry-pick a commit from @mathomp4 that went into spack/develop to update various GFE packages. In particular, we need `yafyaml@1.4.0` because 1.3.0 doesn't build with `gcc@13`.
2. Add `odc@1.5.2` (see https://github.com/spack/spack/pull/45622 for the corresponding PR to spack/develop)

## Testing

- [x] Built the entire unified environment with gcc@13 on my Oracle Linux 9.1 system

For CI testing, see (unrelated) PR https://github.com/JCSDA/spack-stack/pull/1226