### PR TITLE
Introduce the bufr_query library from NOAA-EMC

### DIFF
--- a/var/spack/repos/builtin/packages/bufr-query/package.py
+++ b/var/spack/repos/builtin/packages/bufr-query/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
 from spack.package import *
 
 
@@ -19,18 +20,22 @@ class BufrQuery(CMakePackage):
 
     license("Apache-2.0", checked_by="srherbener")
 
+    version("0.0.2", sha256="b87a128246e79e3c76e3158d89823e2ae38e9ee1a5a81b6f7b423837bdb93a1f")
     version("0.0.1", sha256="001990d864533c101b93d1c351edf50cf8b5ccc575e442d174735f6c332d3d03")
 
     # Required dependencies
-    depends_on("llvm-openmp", type=("build", "run"))
+    depends_on("ecbuild", type=("build"))
+    depends_on("llvm-openmp", when="%apple-clang", type=("build", "run"))
     depends_on("mpi", type=("build", "run"))
     depends_on("eckit@1.24.4:", type=("build", "run"))
     depends_on("eigen@3:", type=("build", "run"))
     depends_on("gsl-lite", type=("build", "run"))
-    depends_on("netcdf-cxx", type=("build", "run"))
+    depends_on("netcdf-c", type=("build", "run"))
+    depends_on("netcdf-cxx4", type=("build", "run"))
+    depends_on("bufr", type=("build", "run"))
 
     # Optional dependencies
-    variant("python", default=False, description="Enable Python interface")
+    variant("python", default=True, description="Enable Python interface")
     depends_on("python@3:", type=("build", "run"), when="+python")
     depends_on("py-pybind11", type=("build"), when="+python")
 
@@ -39,4 +44,10 @@ class BufrQuery(CMakePackage):
         args = [
             self.define_from_variant("BUILD_PYTHON_BINDINGS", "python")
         ]
+
+        # provide path to netcdf-c include files
+        nc_include_dir = Executable("nc-config")("--includedir", output=str).strip()
+        args.append("-DCMAKE_C_FLAGS=-I" + nc_include_dir)
+        args.append("-DCMAKE_CXX_FLAGS=-I" + nc_include_dir)
+
         return args

--- a/var/spack/repos/builtin/packages/bufr-query/package.py
+++ b/var/spack/repos/builtin/packages/bufr-query/package.py
@@ -5,14 +5,15 @@
 
 import os
 import sys
+
 from spack.package import *
 
 
 class BufrQuery(CMakePackage):
     """The NOAA bufr-query Library can be used to read NCEP and WMO formated BUFR
-       files using a simple interface that does not require the user to know the
-       details of the BUFR format. Detailed documentation for the BUFR Library can
-       be found at https://bufr-query.readthedocs.io/en/latest/index.html"""
+    files using a simple interface that does not require the user to know the
+    details of the BUFR format. Detailed documentation for the BUFR Library can
+    be found at https://bufr-query.readthedocs.io/en/latest/index.html"""
 
     homepage = "https://github.com/NOAA-EMC/bufr-query"
     url = "https://github.com/NOAA-EMC/bufr-query/archive/refs/tags/v0.0.1.tar.gz"
@@ -41,9 +42,7 @@ class BufrQuery(CMakePackage):
 
     # CMake configuration
     def cmake_args(self):
-        args = [
-            self.define_from_variant("BUILD_PYTHON_BINDINGS", "python")
-        ]
+        args = [self.define_from_variant("BUILD_PYTHON_BINDINGS", "python")]
 
         # provide path to netcdf-c include files
         nc_include_dir = Executable("nc-config")("--includedir", output=str).strip()

--- a/var/spack/repos/builtin/packages/bufr-query/package.py
+++ b/var/spack/repos/builtin/packages/bufr-query/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+from spack.package import *
+
+
+class BufrQuery(CMakePackage):
+    """The NOAA bufr-query Library can be used to read NCEP and WMO formated BUFR
+       files using a simple interface that does not require the user to know the
+       details of the BUFR format.
+       
+       Detailed documentation for the BUFR Library can be found at
+       https://bufr-query.readthedocs.io/en/latest/index.html"""
+
+    homepage = "https://github.com/NOAA-EMC/bufr-query"
+    url = "https://github.com/NOAA-EMC/bufr-query/archive/refs/tags/v0.0.1.tar.gz"
+    maintainers("srherbener", "rmclaren")
+
+    license("Apache-2.0", checked_by="srherbener")
+
+    version("0.0.1", sha256="001990d864533c101b93d1c351edf50cf8b5ccc575e442d174735f6c332d3d03")
+
+    # Required dependencies
+    depends_on("llvm-openmp", type=("build", "run"))
+    depends_on("mpi", type=("build", "run"))
+    depends_on("eckit@1.24.4:", type=("build", "run"))
+    depends_on("eigen@3:", type=("build", "run"))
+    depends_on("gsl-lite", type=("build", "run"))
+    depends_on("netcdf-cxx", type=("build", "run"))
+
+    # Optional dependencies
+    variant("python", default=False, description="Enable Python interface")
+    depends_on("python@3:", type=("build", "run"), when="+python")
+    depends_on("py-pybind11", type=("build"), when="+python")
+
+    # CMake configuration
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_PYTHON_BINDINGS", "python")
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/bufr-query/package.py
+++ b/var/spack/repos/builtin/packages/bufr-query/package.py
@@ -39,6 +39,9 @@ class BufrQuery(CMakePackage, PythonExtension):
         extends("python")
         depends_on("py-pybind11")
 
+    # Patches
+    patch("site-packages.patch", when="+python @:0.0.2")
+
     # CMake configuration
     def cmake_args(self):
         args = [self.define_from_variant("BUILD_PYTHON_BINDINGS", "python")]

--- a/var/spack/repos/builtin/packages/bufr-query/package.py
+++ b/var/spack/repos/builtin/packages/bufr-query/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class BufrQuery(CMakePackage):
     """The NOAA bufr-query Library can be used to read NCEP and WMO formated BUFR
     files using a simple interface that does not require the user to know the

--- a/var/spack/repos/builtin/packages/bufr-query/package.py
+++ b/var/spack/repos/builtin/packages/bufr-query/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class BufrQuery(CMakePackage):
+class BufrQuery(CMakePackage, PythonExtension):
     """The NOAA bufr-query Library can be used to read NCEP and WMO formated BUFR
     files using a simple interface that does not require the user to know the
     details of the BUFR format. Detailed documentation for the BUFR Library can
@@ -34,8 +34,10 @@ class BufrQuery(CMakePackage):
 
     # Optional dependencies
     variant("python", default=True, description="Enable Python interface")
-    depends_on("python@3:", type=("build", "run"), when="+python")
-    depends_on("py-pybind11", type=("build"), when="+python")
+
+    with when("+python"):
+        extends("python")
+        depends_on("py-pybind11")
 
     # CMake configuration
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/bufr-query/package.py
+++ b/var/spack/repos/builtin/packages/bufr-query/package.py
@@ -3,11 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-import sys
-
 from spack.package import *
-
 
 class BufrQuery(CMakePackage):
     """The NOAA bufr-query Library can be used to read NCEP and WMO formated BUFR

--- a/var/spack/repos/builtin/packages/bufr-query/package.py
+++ b/var/spack/repos/builtin/packages/bufr-query/package.py
@@ -10,10 +10,8 @@ from spack.package import *
 class BufrQuery(CMakePackage):
     """The NOAA bufr-query Library can be used to read NCEP and WMO formated BUFR
        files using a simple interface that does not require the user to know the
-       details of the BUFR format.
-       
-       Detailed documentation for the BUFR Library can be found at
-       https://bufr-query.readthedocs.io/en/latest/index.html"""
+       details of the BUFR format. Detailed documentation for the BUFR Library can
+       be found at https://bufr-query.readthedocs.io/en/latest/index.html"""
 
     homepage = "https://github.com/NOAA-EMC/bufr-query"
     url = "https://github.com/NOAA-EMC/bufr-query/archive/refs/tags/v0.0.1.tar.gz"

--- a/var/spack/repos/builtin/packages/bufr-query/site-packages.patch
+++ b/var/spack/repos/builtin/packages/bufr-query/site-packages.patch
@@ -1,0 +1,93 @@
+diff --git a/cmake/Targets.cmake b/cmake/Targets.cmake
+index 42dc2bc..8a26827 100644
+--- a/cmake/Targets.cmake
++++ b/cmake/Targets.cmake
+@@ -104,17 +104,17 @@ macro(AddPyLib libname pyname pybasename)
+     ApplyBaseSettings(${libname})
+     set_target_properties( ${libname} PROPERTIES FOLDER "Libs/Python/${pybasename}")
+     set_target_properties( ${libname} PROPERTIES
+-        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${pybasename}/${pyname}"
+-        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${pybasename}/${pyname}"
+-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/${pybasename}/${pyname}"
++        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${pybasename}/site-packages/${pyname}"
++        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${pybasename}/site-packages/${pyname}"
++        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/${pybasename}/site-packages/${pyname}"
+         INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}"
+         )
+     export( TARGETS ${libname} APPEND FILE "${PROJECT_TARGETS_FILE}" )
+     install( TARGETS ${libname}
+         EXPORT ${PROJECT_NAME}-targets
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pybasename}/${pyname}
+-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pybasename}/${pyname}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pybasename}/site-packages/${pyname}
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pybasename}/site-packages/${pyname}
+         COMPONENT Python)
+ endmacro(AddPyLib)
+ 
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 1082d30..cf4fd54 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -5,28 +5,21 @@ include(Targets)
+ # Location of .pycodestyle for norm checking within IODA-converters
+ set( BUFR_PYLINT_CFG_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
+ 
+-set(pyver python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR})
+-set(PYDIR ${pyver}/bufr)
+-
+-# Location of installed python iodaconv libraries
+-set( PYIODACONV_BUILD_LIBDIR   ${CMAKE_BINARY_DIR}/lib/${PYDIR} )
+-set( PYIODACONV_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib/${PYDIR} )
+-
+-
+-list (APPEND PYTHON_SRCS DataObjectFunctions.h
+-												DataObjectFunctions.cpp
+-												py_bufr.cpp
+-												py_result_set.cpp
+-												py_data_container.cpp
+-												py_query_set.cpp
+-												py_file.cpp
+-												py_parser.cpp
+-												py_data_cache.cpp
+-											  py_encoder_description.cpp
+-												py_netcdf_encoder.cpp
+-												py_mpi.h
+-												py_mpi.cpp
+-												)
++list (APPEND PYTHON_SRCS
++  DataObjectFunctions.h
++  DataObjectFunctions.cpp
++  py_bufr.cpp
++  py_result_set.cpp
++  py_data_container.cpp
++  py_query_set.cpp
++  py_file.cpp
++  py_parser.cpp
++  py_data_cache.cpp
++  py_encoder_description.cpp
++  py_netcdf_encoder.cpp
++  py_mpi.h
++  py_mpi.cpp
++)
+ 
+ # We cannot call ecbuild_add_library here since it conflicts with pybind11_add_module.
+ pybind11_add_module(bufr_python ${PYTHON_SRCS})
+@@ -51,13 +44,7 @@ else()
+ 		)
+ endif()
+ 
+-add_custom_command(TARGET bufr_python
+-									 POST_BUILD
+-									 COMMAND ${CMAKE_COMMAND} -E copy_directory
+-	                 				 ${CMAKE_CURRENT_SOURCE_DIR}/bufr
+-													 $<TARGET_FILE_DIR:bufr_python>)
+-
+ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bufr
+-	      DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pyver}
+-			  COMPONENT Python
+-	      FILES_MATCHING PATTERN "*.py")
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pyver}/site-packages
++        COMPONENT Python
++        FILES_MATCHING PATTERN "*.py")
+


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR adds in a new package.py script for the new bufr_query library from NOAA-EMC. This is being used by JEDI and other applications.

This partially addresses jcsda/spack-stack/issues/1182