### PR TITLE
Update bufr recipe (now matches upstream Spack)

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -17,12 +17,13 @@ class Bufr(CMakePackage):
     """
 
     homepage = "https://noaa-emc.github.io/NCEPLIBS-bufr"
-    url = "https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags/v12.0.1.tar.gz"
+    url = "https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags/v12.1.0.tar.gz"
     git = "https://github.com/NOAA-EMC/NCEPLIBS-bufr"
 
     maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA", "jbathegit")
 
     version("develop", branch="develop")
+    version("12.1.0", sha256="b5eae61b50d4132b2933b6e6dfc607e5392727cdc4f46ec7a94a19109d91dcf3")
     version("12.0.1", sha256="525f26238dba6511a453fc71cecc05f59e4800a603de2abbbbfb8cbb5adf5708")
     version("12.0.0", sha256="d01c02ea8e100e51fd150ff1c4a1192ca54538474acb1b7f7a36e8aeab76ee75")
     version("11.7.1", sha256="6533ce6eaa6b02c0cb5424cfbc086ab120ccebac3894980a4daafd4dfadd71f8")
@@ -30,6 +31,9 @@ class Bufr(CMakePackage):
     version("11.6.0", sha256="af4c04e0b394aa9b5f411ec5c8055888619c724768b3094727e8bb7d3ea34a54")
     version("11.5.0", sha256="d154839e29ef1fe82e58cf20232e9f8a4f0610f0e8b6a394b7ca052e58f97f43")
     version("11.4.0", sha256="946482405e675b99e8e0c221d137768f246076f5e9ba92eed6cae47fb68b7a26")
+
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     # Patch to not add "-c" to ranlib flags when using llvm-ranlib on Apple systems
     patch("cmakelists-apple-llvm-ranlib.patch", when="@11.5.0:11.6.0")
@@ -40,6 +44,8 @@ class Bufr(CMakePackage):
 
     variant("python", default=False, description="Enable Python interface")
     variant("shared", default=True, description="Build shared libraries", when="@11.5:")
+    variant("test_files", default="none", description="Path to test files")
+    variant("utils", default=True, description="Build utilities", when="@12.1:")
 
     extends("python", when="+python")
 
@@ -48,6 +54,8 @@ class Bufr(CMakePackage):
     depends_on("py-numpy", type=("build", "run"), when="+python")
     depends_on("py-pip", type="build", when="+python")
     depends_on("py-wheel", type="build", when="+python")
+
+    conflicts("%oneapi@:2024.1", msg="Requires oneapi 2024.2 or later")
 
     def url_for_version(self, version):
         pre = "bufr_" if version < Version("12.0.1") else ""
@@ -65,7 +73,12 @@ class Bufr(CMakePackage):
             self.define_from_variant("ENABLE_PYTHON", "python"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("BUILD_TESTS", self.run_tests),
+            self.define("BUILD_TESTING", self.run_tests),
+            self.define_from_variant("BUILD_UTILS", "utils"),
         ]
+
+        if not self.spec.satisfies("test_files=none"):
+            args.append(self.define_from_variant("TEST_FILE_DIR", "test_files"))
 
         return args
 
@@ -116,6 +129,5 @@ class Bufr(CMakePackage):
             self._setup_bufr_environment(env, suffix)
 
     def check(self):
-        if self.spec.satisfies("~python"):
-            with working_dir(self.builder.build_directory):
-                make("test")
+        with working_dir(self.builder.build_directory):
+            make("test")

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -32,9 +32,6 @@ class Bufr(CMakePackage):
     version("11.5.0", sha256="d154839e29ef1fe82e58cf20232e9f8a4f0610f0e8b6a394b7ca052e58f97f43")
     version("11.4.0", sha256="946482405e675b99e8e0c221d137768f246076f5e9ba92eed6cae47fb68b7a26")
 
-    depends_on("c", type="build")
-    depends_on("fortran", type="build")
-
     # Patch to not add "-c" to ranlib flags when using llvm-ranlib on Apple systems
     patch("cmakelists-apple-llvm-ranlib.patch", when="@11.5.0:11.6.0")
     # C test does not explicity link to -lm causing DSO error when building shared libs


### PR DESCRIPTION
This PR updates the bufr recipe to match upstream Spack, most notably adding 12.1.0.

Addresses https://github.com/JCSDA/spack-stack/issues/1060