### PR TITLE
Fix for dependent specs in view

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -792,7 +792,13 @@ class ViewDescriptor:
         # Create a new view
         try:
             fs.mkdirp(new_root)
-            view.add_specs(*specs)
+
+            if self.link == "all" or self.link == "run":
+                withdeps = True
+            else:
+                withdeps = False
+
+            view.add_specs(*specs, with_dependencies=withdeps)
 
             # create symlink from tmp_symlink_name to new_root
             if os.path.exists(tmp_symlink_name):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -798,7 +798,7 @@ class ViewDescriptor:
             else:
                 withdeps = False
 
-            view.add_specs(*specs, with_dependencies=withdeps)
+            view.add_specs(*specs, with_dependencies=withdeps, exclude=self.exclude)
 
             # create symlink from tmp_symlink_name to new_root
             if os.path.exists(tmp_symlink_name):

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -655,11 +655,16 @@ class SimpleFilesystemView(FilesystemView):
                 raise ConflictingSpecsError(current_spec, conflicting_spec)
             seen[metadata_dir] = current_spec
 
-    def add_specs(self, *specs: spack.spec.Spec) -> None:
+    def add_specs(self, *specs: spack.spec.Spec, **kwargs) -> None:
         """Link a root-to-leaf topologically ordered list of specs into the view."""
         assert all((s.concrete for s in specs))
         if len(specs) == 0:
             return
+
+        specs = set(specs)
+
+        if kwargs.get("with_dependencies", True):
+            specs.update(get_dependencies(specs))
 
         # Drop externals
         specs = [s for s in specs if not s.external]

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -666,6 +666,9 @@ class SimpleFilesystemView(FilesystemView):
         if kwargs.get("with_dependencies", True):
             specs.update(get_dependencies(specs))
 
+        if kwargs.get("exclude", None):
+            specs = set(filter_exclude(specs, kwargs["exclude"]))
+
         # Drop externals
         specs = [s for s in specs if not s.external]
 


### PR DESCRIPTION
This PR fixes an issue with spack environment views.

Let's say that you have this in a `spack.yaml` file:
```yaml
spack:
  # ...
  view:
    jedi-skylab-env:
      root: /path/to/view
      select: [ jedi-skylab-env ]
      link: all
```
As it stands right now, if you try to generate this view (e.g. with `spack env view regenerate`), you get nothing even though `link: all` is set, which should pull in the dependencies of `jedi-skylab-env`. That's the bug.

The main issue is that Spack's [`SimpleFilesystemView`](https://github.com/rhoneyager-tomorrow/spack-1/blob/4c762fc5cbc1a12aa90e1b098a38e646b5ff9ec0/lib/spack/spack/filesystem_view.py#L637) is missing the logic to fill in these dependencies. It should have this logic according to the [base class' comments](https://github.com/rhoneyager-tomorrow/spack-1/blob/4c762fc5cbc1a12aa90e1b098a38e646b5ff9ec0/lib/spack/spack/filesystem_view.py#L162-L168). To fix, I've copied the correct logic over from [`YamlFileSystemView`](https://github.com/rhoneyager-tomorrow/spack-1/blob/4c762fc5cbc1a12aa90e1b098a38e646b5ff9ec0/lib/spack/spack/filesystem_view.py#L300).

Then, I'm also ensuring that the `with_dependencies` option needs to be passed to when calling `view.add_specs` in `lib/spack/spack/environment/environment.py`.

I'm going to also open this upstream, but figured it's good to get this in before spack-stack 1.8.0.


**Note:** this now causes the `exclude` tests to fail, so it's not a complete fix. Work in progress for today.