### PR TITLE
Add patch vfile_cassert.patch for ecflow@5.11.4

### DIFF
--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -72,6 +72,7 @@ class Ecflow(CMakePackage):
     # https://github.com/JCSDA/spack-stack/issues/1001
     # https://github.com/JCSDA/spack-stack/issues/1009
     patch("ctsapi_cassert.patch", when="@5.11.4")
+    patch("vfile_cassert.patch", when="@5.11.4")
 
     @when("@:4.13.0")
     def patch(self):

--- a/var/spack/repos/builtin/packages/ecflow/vfile_cassert.patch
+++ b/var/spack/repos/builtin/packages/ecflow/vfile_cassert.patch
@@ -1,0 +1,10 @@
+--- a/Viewer/ecflowUI/src/VFile.cpp	2024-08-28 12:20:27.000000000 +0000
++++ b/Viewer/ecflowUI/src/VFile.cpp	2024-08-28 12:20:51.000000000 +0000
+@@ -9,6 +9,7 @@
+ 
+ #include "VFile.hpp"
+ 
++#include <cassert>
+ #include <cstdio>
+ #include <cstdlib>
+ #include <cstring>


### PR DESCRIPTION
All in the title. Discovered and tested when building `ecflow+ui` on S4. There is already a `ctsapi_cassert.patch` for 5.11.4 that fixes a similar bug in the `Base` directory.

This needs to go into spack-stack-1.8.0.