### PR TITLE
Update ESMF from spack develop: add python dependency and extension (not for release/1.8.0)

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -117,11 +117,13 @@ class Esmf(MakefilePackage, PythonExtension):
     depends_on("cmake@3.5.2:", type="build", when="~external-parallelio")
 
     # python library
-    extends("python", when="+python")
-    depends_on("py-setuptools", type="build", when="+python")
-    depends_on("py-mpi4py", when="+python +mpi")
-    depends_on("py-pip", when="+python")
-    depends_on("py-wheel", when="+python")
+    with when("+python"):
+        extends("python")
+        depends_on("py-setuptools", type="build")
+        depends_on("py-wheel", type="build")
+        depends_on("py-mpi4py", when="+mpi")
+        depends_on("py-pip")
+
 
     # Testing dependencies
     depends_on("perl", type="test")
@@ -157,7 +159,7 @@ class Esmf(MakefilePackage, PythonExtension):
     @when("+python")
     def patch(self):
         # The pyproject.toml file uses a dynamically generated version from git
-        # Howeer, this results in a version of 0.0.0 and a mismatch with the loaded version
+        # However, this results in a version of 0.0.0 and a mismatch with the loaded version
         # so this hardcodes it to match the library's version
         filter_file(
             """dynamic = \\[ "version" \\]""",

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -125,6 +125,11 @@ class Esmf(MakefilePackage, PythonExtension):
         depends_on("py-mpi4py", when="+mpi")
         depends_on("py-numpy")
 
+    # In esmf@8.4.0, esmx was introduced which depends on py-pyyaml
+    with when("@8.4.0:"):
+        depends_on("python", type="run")
+        depends_on("py-pyyaml", type="run")
+
     # Testing dependencies
     depends_on("perl", type="test")
 

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -116,6 +116,7 @@ class Esmf(MakefilePackage, PythonExtension):
     depends_on("parallelio@2.5.10: ~mpi", when="@8.5:+external-parallelio~mpi")
     depends_on("cmake@3.5.2:", type="build", when="~external-parallelio")
     
+    # python library
     extends("python", when="+python")
     depends_on("py-setuptools", type="build", when="+python")
     depends_on("py-mpi4py", when="+python +mpi")
@@ -153,6 +154,7 @@ class Esmf(MakefilePackage, PythonExtension):
     # https://github.com/spack/spack/issues/35957
     patch("esmf_cpp_info.patch")
 
+    @when("+python")
     def patch(self):
         # The pyproject.toml file uses a dynamically generated version from git
         # Howeer, this results in a version of 0.0.0 and a mismatch with the loaded version
@@ -477,8 +479,9 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
     def install(self, pkg, spec, prefix):
         make("install")
 
-        # build the python library
-        python_builder = PythonPipBuilder(pkg)
-        python_builder.install(pkg, spec, prefix)
+        if "+python" in spec:
+            # build the python library
+            python_builder = PythonPipBuilder(pkg)
+            python_builder.install(pkg, spec, prefix)
 
 

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -167,7 +167,7 @@ class Esmf(MakefilePackage, PythonExtension):
         # However, this results in a version of 0.0.0 and a mismatch with the loaded version
         # so this hardcodes it to match the library's version
         filter_file(
-            """dynamic = \\[ "version" \\]""",
+            """dynamic = \\[\\s+"version"\\s+\\]""",
             f"""version = "{self.version}" """,
             os.path.join("src/addon/esmpy/pyproject.toml"),
         )

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -124,7 +124,6 @@ class Esmf(MakefilePackage, PythonExtension):
         depends_on("py-mpi4py", when="+mpi")
         depends_on("py-pip")
 
-
     # Testing dependencies
     depends_on("perl", type="test")
 

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -68,10 +68,6 @@ class Esmf(MakefilePackage, PythonExtension):
         deprecated=True,
     )
 
-    # In esmf@8.4.0, esmx was introduced which depends on py-pyyaml
-    depends_on("python", when="@8.4.0:", type="run")
-    depends_on("py-pyyaml", when="@8.4.0:", type="run")
-
     variant("mpi", default=True, description="Build with MPI support")
     variant("external-lapack", default=False, description="Build with external LAPACK library")
     variant("netcdf", default=True, description="Build with NetCDF support")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -8,7 +8,7 @@ import sys
 
 from spack.build_environment import dso_suffix, stat_suffix
 from spack.package import *
-import spack as spack
+
 
 class Esmf(MakefilePackage, PythonExtension):
     """The Earth System Modeling Framework (ESMF) is high-performance, flexible
@@ -115,7 +115,7 @@ class Esmf(MakefilePackage, PythonExtension):
     depends_on("parallelio@2.5.10: +mpi", when="@8.5:+external-parallelio+mpi")
     depends_on("parallelio@2.5.10: ~mpi", when="@8.5:+external-parallelio~mpi")
     depends_on("cmake@3.5.2:", type="build", when="~external-parallelio")
-    
+
     # python library
     extends("python", when="+python")
     depends_on("py-setuptools", type="build", when="+python")
@@ -159,12 +159,12 @@ class Esmf(MakefilePackage, PythonExtension):
         # The pyproject.toml file uses a dynamically generated version from git
         # Howeer, this results in a version of 0.0.0 and a mismatch with the loaded version
         # so this hardcodes it to match the library's version
-        filter_file("""dynamic = \[ "version" \]""",
-                f"""version = "{self.version}" """,
-                os.path.join("src/addon/esmpy/pyproject.toml")
-                )
+        filter_file(
+            """dynamic = \\[ "version" \\]""",
+            f"""version = "{self.version}" """,
+            os.path.join("src/addon/esmpy/pyproject.toml"),
+        )
 
-    
     def setup_dependent_run_environment(self, env, dependent_spec):
         env.set("ESMFMKFILE", os.path.join(self.prefix.lib, "esmf.mk"))
 
@@ -173,13 +173,13 @@ class Esmf(MakefilePackage, PythonExtension):
 
 
 class PythonPipBuilder(spack.build_systems.python.PythonPipBuilder):
-    
+
     def setup_build_environment(self, env):
         env.set("ESMFMKFILE", os.path.join(self.prefix.lib, "esmf.mk"))
 
     @property
     def build_directory(self):
-        return os.path.join(self.stage.source_path, 'src/addon/esmpy')
+        return os.path.join(self.stage.source_path, "src/addon/esmpy")
 
 
 class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
@@ -197,7 +197,6 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
     def chmod_scripts(self):
         chmod = which("chmod")
         chmod("+x", "scripts/libs.mvapich2f90")
-
 
     def url_for_version(self, version):
         if version < Version("8.0.0"):
@@ -483,5 +482,3 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             # build the python library
             python_builder = PythonPipBuilder(pkg)
             python_builder.install(pkg, spec, prefix)
-
-

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -95,7 +95,10 @@ class Esmf(MakefilePackage, PythonExtension):
         default="none",
         description="Named variant for snapshots versions (e.g., 'b09')",
     )
-    variant("python", default=False, description="Build python bindings")
+
+    # The way python is handled here is only avialable >=8.4.0
+    # https://github.com/esmf-org/esmf/releases/tag/v8.4.0
+    variant("python", default=False, description="Build python bindings", when="@8.4.0:")
 
     # Optional dependencies
     depends_on("mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -119,10 +119,11 @@ class Esmf(MakefilePackage, PythonExtension):
     # python library
     with when("+python"):
         extends("python")
+        depends_on("py-pip")
         depends_on("py-setuptools", type="build")
         depends_on("py-wheel", type="build")
         depends_on("py-mpi4py", when="+mpi")
-        depends_on("py-pip")
+        depends_on("py-numpy")
 
     # Testing dependencies
     depends_on("perl", type="test")
@@ -166,17 +167,11 @@ class Esmf(MakefilePackage, PythonExtension):
             os.path.join("src/addon/esmpy/pyproject.toml"),
         )
 
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        env.set("ESMFMKFILE", os.path.join(self.prefix.lib, "esmf.mk"))
-
     def setup_run_environment(self, env):
         env.set("ESMFMKFILE", os.path.join(self.prefix.lib, "esmf.mk"))
 
 
 class PythonPipBuilder(spack.build_systems.python.PythonPipBuilder):
-
-    def setup_build_environment(self, env):
-        env.set("ESMFMKFILE", os.path.join(self.prefix.lib, "esmf.mk"))
 
     @property
     def build_directory(self):

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -68,6 +68,10 @@ class Esmf(MakefilePackage):
         deprecated=True,
     )
 
+    # In esmf@8.4.0, esmx was introduced which depends on py-pyyaml
+    depends_on("python", when="@8.4.0:", type="run")
+    depends_on("py-pyyaml", when="@8.4.0:", type="run")
+
     variant("mpi", default=True, description="Build with MPI support")
     variant("external-lapack", default=False, description="Build with external LAPACK library")
     variant("netcdf", default=True, description="Build with NetCDF support")


### PR DESCRIPTION
## Description

Cherry-picking the changes from PR https://github.com/spack/spack/pull/45504/commits for our `spack-stack-dev` branch. With the exception of the "depends-on c/c++/fortran" changes (that our spack lib code doesn't support yet) and the disabling of OpenMP for macOS (only in our fork), the esmf package.py files are identical between spack develop and jcsda spack-stack-dev as of beginning of September 2024.

See https://github.com/JCSDA/spack-stack/pull/1304 for the associated spack-stack PR that enables the `python` variant in our spack-stack configs.
