### PR TITLE
Fix gettext patch

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -62,6 +62,8 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     # depends_on('cvs')
 
     conflicts("+shared~pic")
+    # https://savannah.gnu.org/bugs/?65811
+    conflicts("%gcc@:5", when="@0.22:")
 
     patch("test-verify-parallel-make-check.patch", when="@:0.19.8.1")
     patch("nvhpc-builtin.patch", when="@:0.21.0 %nvhpc")
@@ -78,12 +80,13 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         # From the configure script: "we don't want to use an external libxml, because its
         # dependencies and their dynamic relocations have an impact on the startup time", well,
         # *we* do.
-        filter_file(
-            "gl_cv_libxml_force_included=yes",
-            "gl_cv_libxml_force_included=no",
-            "libtextstyle/configure",
-            string=True,
-        )
+        if self.spec.satisfies("@:19"):  # libtextstyle/configure not present
+            filter_file(
+                "gl_cv_libxml_force_included=yes",
+                "gl_cv_libxml_force_included=no",
+                "libtextstyle/configure",
+                string=True,
+            )
 
     def flag_handler(self, name, flags):
         # this goes together with gl_cv_libxml_force_included=no

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -80,7 +80,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         # From the configure script: "we don't want to use an external libxml, because its
         # dependencies and their dynamic relocations have an impact on the startup time", well,
         # *we* do.
-        if self.spec.satisfies("@:19"):  # libtextstyle/configure not present
+        if self.spec.satisfies("@20:"):  # libtextstyle/configure not present prior
             filter_file(
                 "gl_cv_libxml_force_included=yes",
                 "gl_cv_libxml_force_included=no",


### PR DESCRIPTION
On Acorn we have to install an older gettext, and there's currently a patch that breaks because it's looking for a file that doesn't exist in the older versions. This PR pulls in the relevant fixes from mainline Spack.