### PR TITLE
Fix grib-util 1.4.0 for older ifort

### DIFF
--- a/var/spack/repos/builtin/packages/grib-util/package.py
+++ b/var/spack/repos/builtin/packages/grib-util/package.py
@@ -53,7 +53,7 @@ class GribUtil(CMakePackage):
     @when("@1.4.0 %intel@:20")
     def patch(self):
         filter_file("stop iret", "stop 9", "src/grb2index/grb2index.F90")
-    
+
     def check(self):
         with working_dir(self.builder.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/grib-util/package.py
+++ b/var/spack/repos/builtin/packages/grib-util/package.py
@@ -50,6 +50,10 @@ class GribUtil(CMakePackage):
         ]
         return args
 
+    @when("@1.4.0 %intel@:20")
+    def patch(self):
+        filter_file("stop iret", "stop 9", "src/grb2index/grb2index.F90")
+    
     def check(self):
         with working_dir(self.builder.build_directory):
             make("test")


### PR DESCRIPTION
grib-util 1.4.0 doesn't build with Intel 19 because it's too old to support using a variable as an argument to 'stop' (F2018). This PR adds a patch.