### PR TITLE
release/1.8.0: bug fix for compiling g2@3.5.1 with gfortran < 10

### DIFF
--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -59,6 +59,12 @@ class G2(CMakePackage):
 
         return args
 
+# GNU compiler is complaining if not using -fno-range-check argument
+    def flag_handler(self, name, flags):
+        if name == "fflags" and self.compiler.fc.endswith("gfortran"):
+            flags.append("-fno-range-check")
+        return (None, None, flags)
+
     def setup_run_environment(self, env):
         precisions = (
             self.spec.variants["precision"].value if self.spec.satisfies("@3.4.6:") else ("4", "d")

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -59,10 +59,17 @@ class G2(CMakePackage):
 
         return args
 
-    # GNU compiler is complaining if not using -fno-range-check argument
+    # https://github.com/JCSDA/spack/issues/475
     def flag_handler(self, name, flags):
-        if name == "fflags" and self.compiler.fc.endswith("gfortran"):
-            flags.append("-fno-range-check")
+        if self.spec.satisfies("@3.5.1") and name == "fflags" and "gfortran" in self.compiler.fc:
+            with self.compiler.compiler_environment():
+                gfortran_major_version = int(
+                    spack.compiler.get_compiler_version_output(
+                        self.compiler.fc, "-dumpversion"
+                    ).split(".")[0]
+                )
+            if gfortran_major_version < 10:
+                flags.append("-fno-range-check")
         return (None, None, flags)
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -59,7 +59,7 @@ class G2(CMakePackage):
 
         return args
 
-# GNU compiler is complaining if not using -fno-range-check argument
+    # GNU compiler is complaining if not using -fno-range-check argument
     def flag_handler(self, name, flags):
         if name == "fflags" and self.compiler.fc.endswith("gfortran"):
             flags.append("-fno-range-check")


### PR DESCRIPTION
For release/1.8.0: This PR is based on https://github.com/JCSDA/spack/pull/476 (credits @RatkoVasic-NOAA), but narrowed down to one specific version of `g2` and for `gfortran` earlier than version 10.

Corresponding spack-stack PR: https://github.com/JCSDA/spack-stack/pull/1287