### PR TITLE
Cherry-pick from spack develop: "esmf: add version 8.7.0 (#46860)"

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -29,6 +29,7 @@ class Esmf(MakefilePackage, PythonExtension):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
+    version("8.7.0", sha256="d7ab266e2af8c8b230721d4df59e61aa03c612a95cc39c07a2d5695746f21f56")
     version("8.7.0b11", commit="7b36ed9d21ecf904c95c436c8ecaa5075601893e")
     version("8.7.0b04", commit="609c81179572747407779492c43776e34495d267")
     version("8.6.1", sha256="dc270dcba1c0b317f5c9c6a32ab334cb79468dda283d1e395d98ed2a22866364")


### PR DESCRIPTION
Cherry-pick spack develop PR #46860 that adds the official esmf@8.7.0 release.

CI test failures for ubuntu-latest, Python 3.6 and 3.12 are known issues and unrelated to this PR (or fork needs updating from spack develop)