### PR TITLE
Add sigio 2.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/sigio/package.py
+++ b/var/spack/repos/builtin/packages/sigio/package.py
@@ -19,11 +19,14 @@ class Sigio(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("2.3.3", sha256="2b4a04be3be10f222d0ff47f973f65a03b8b5521dcad8e8866f3bfe4e8dfafab")
     version("2.3.2", sha256="333f3cf3a97f97103cbafcafc2ad89b24faa55b1332a98adc1637855e8a5b613")
 
     variant("pfunit", default=False, description="Use pFunit to enable unit testing")
 
     depends_on("pfunit", when="+pfunit")
+
+    conflicts("%oneapi", when="@:2.3.2", msg="Requires @2.3.3: for Intel OneAPI")
 
     def cmake_args(self):
         args = [self.define("ENABLE_TESTS", self.run_tests)]


### PR DESCRIPTION
This PR cherry-picks commit 400dd40492f6a496e67331e9a97962572aed27de from main Spack, which adds sigio 2.3.3. Needed for https://github.com/ufs-community/UFS_UTILS/issues/879