### PR TITLE
Bug fix in py-scipy for versions 1.8.0 to 1.14.0 (small_dynamic_array.h: error: reference to non-static member function must be called) spack #47620

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -189,6 +189,13 @@ class PyScipy(PythonPackage):
     # Additional changes needed for scipy-1.8.0
     patch("use_stdc_no_threads_scipy180_addon.patch", when="@1.8: platform=darwin %gcc")
 
+    # https://github.com/scipy/scipy/issues/21884
+    patch(
+        "https://github.com/scipy/scipy/commit/ab7d08c6148286059f6498ab5c3070268d13cbd9.patch?full_index=1",
+        sha256="37209324c6c2d9bf9284bf4726ec3ea7ecafabf736c7a72cf6789af97aebd30b",
+        when="@1.8.0:1.14.0",
+    )
+
     @property
     def archive_files(self):
         return [join_path(self.stage.source_path, "build", "meson-logs", "meson-log.txt")]


### PR DESCRIPTION
## Description

This is the spack-stack-dev PR corresponding to spack develop PR https://github.com/spack/spack/pull/47620:

Bug fix in py-scipy for versions 1.8.0 to 1.14.0 that surfaces with latest Clang and Intel LLVM compilers. The error message is:
```
  >> 8899    FAILED: scipy/_lib/_uarray/_uarray.cpython-311-x86_64-linux-gnu.so.p/_uarray_dispatch.cxx.o
     8900      /home/dom/work/spack-stack-dev-20241107/spack/lib/spack/env/oneapi/icpx -Iscipy/_lib/_uarray/_uarray.cpython-311-x86_64-linux-gnu.so.p
             -Iscipy/_lib/_uarray -I../scipy/_lib/_uarray -I/home/dom/work/spack-stack-dev-20241107/envs/ue-oneapi-2025.0.0/install/oneapi/2025.0.0/py
             thon-3.11.7-d6nj3iw/include/python3.11 -fvisibility=hidden -fvisibility-inlines-hidden -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET
             _BITS=64 -Wall -Winvalid-pch -std=c++14 -O3 -fPIC -Wno-terminate -Wno-unused-function -MD -MQ scipy/_lib/_uarray/_uarray.cpython-311-x86_
             64-linux-gnu.so.p/_uarray_dispatch.cxx.o -MF scipy/_lib/_uarray/_uarray.cpython-311-x86_64-linux-gnu.so.p/_uarray_dispatch.cxx.o.d -o sci
             py/_lib/_uarray/_uarray.cpython-311-x86_64-linux-gnu.so.p/_uarray_dispatch.cxx.o -c ../scipy/_lib/_uarray/_uarray_dispatch.cxx
     8901      warning: unknown warning option '-Wno-terminate' [-Wunknown-warning-option]
     8902      In file included from ../scipy/_lib/_uarray/_uarray_dispatch.cxx:3:
  >> 8903      ../scipy/_lib/_uarray/small_dynamic_array.h:145:18: error: reference to non-static member function must be called
     8904        145 |     size_ = copy.size;
     8905            |             ~~~~~^~~~
     8906      1 warning and 1 error generated.
     8907      [1053/1618] Compiling C object scipy/_lib/messagestream.cpython-311-x86_64-linux-gnu.so.p/meson-generated_messagestream.c.o
     8908      [1054/1618] Compiling C++ object scipy/_lib/_uarray/_uarray.cpython-311-x86_64-linux-gnu.so.p/vectorcall.cxx.o
     8909      warning: unknown warning option '-Wno-terminate' [-Wunknown-warning-option]
```
See https://github.com/scipy/scipy/issues/21884 for a description and discussion and note that the developers said that this should be applied regardless of the compiler. I went back all the way to the first version of `scipy` where this particular file `small_dynamic_array.h` was added, and it already had the bug.

## Testing

Tested with Intel oneAPI 2025.0.0 on Alma Linux.
