### PR TITLE
Add `py-phdf@0.11.4` and add conflict for `py-pyhdf@0.10.4` with `numpy@1.25:`

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyhdf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyhdf/package.py
@@ -20,6 +20,7 @@ class PyPyhdf(PythonPackage):
     license("MIT")
 
     version("master", branch="master")
+    version("0.11.4", sha256="f4d48ee6f297be76e07b1a31710ef898caa31757dfdf173e5a4b94988ea76164")
     version("0.10.4", sha256="ea09b2bdafc9be0f7f43d72ff122d8efbde61881f4da3a659b33be5e29215f93")
 
     depends_on("c", type="build")  # generated
@@ -31,6 +32,8 @@ class PyPyhdf(PythonPackage):
     depends_on("zlib-api", type=("build", "run"))
     depends_on("hdf@4.2", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
+    # https://github.com/fhs/pyhdf/issues/63
+    depends_on("py-numpy@:1.24", when="@0.10.4", type=("build", "run"))
     depends_on("jpeg", type=("build", "run"))
 
     def setup_build_environment(self, env):


### PR DESCRIPTION
## Description

`py-phdf@0.10.4` doesn't built with newer versions of `py-numpy@1.25:`, but `py-pyhdf@0.11.4` does. See https://github.com/fhs/pyhdf/issues/63. Credits to @rickgrubin for pointing me to this just when I needed it.

Upstream PR for spack develop: https://github.com/spack/spack/pull/47656 (merged)

Corresponding spack-stack PR for testing: https://github.com/JCSDA/spack-stack/pull/1384