### PR TITLE
Updated version specs for bufr-query package. (#47752)

### DIFF
--- a/var/spack/repos/builtin/packages/bufr-query/package.py
+++ b/var/spack/repos/builtin/packages/bufr-query/package.py
@@ -18,6 +18,7 @@ class BufrQuery(CMakePackage, PythonExtension):
 
     license("Apache-2.0", checked_by="srherbener")
 
+    version("0.0.4", sha256="cc21a298c03ee3a8938823301606e91c7b321005da284ebf2c9b25044bfcbad8")
     version("0.0.3", sha256="f2952a190cc1d7714a3bfe481fb1545459639ba304fc31b941062b471dea1d41")
     version("0.0.2", sha256="b87a128246e79e3c76e3158d89823e2ae38e9ee1a5a81b6f7b423837bdb93a1f")
     version("0.0.1", sha256="001990d864533c101b93d1c351edf50cf8b5ccc575e442d174735f6c332d3d03")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR contains the upgrade for moving bufr-query from version 0.0.2 to 0.0.4. 

This partially addresses jcsda/spack-stack/issues/1377