### PR TITLE
Cherry-pick from spack develop: py-uxarray with dependencies, update of ECMWF packages

### DIFF
--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -20,6 +20,8 @@ class Eckit(CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.28.3", sha256="24b2b8d9869849a646aa3fd9d95e4181a92358cd837d95b22e25d718a6ad7738")
+    version("1.28.2", sha256="d122db8bb5bcaadf3256a24f0f90d9bcedad35ef8f25e7eccd8c93c506dbdd24")
     version("1.27.0", sha256="499f3f8c9aec8d3f42369e3ceedc98b2b09ac04993cfd38dfdf7d38931703fe7")
     version("1.25.2", sha256="a611d26d50a9f2133b75100567a890eb0e0a48a96669b8c8475baf9d6f359397")
     version("1.24.5", sha256="2fd74e04c20a59f9e13635828d9da880e18f8a2cb7fd3bfd0201e07071d6ec41")

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -22,6 +22,8 @@ class EcmwfAtlas(CMakePackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.40.0", sha256="9aa2c8945a04aff3d50f752147e2b7cf0992c33e7e5a0e7bcd6fe575b0f853b0")
+    version("0.39.0", sha256="bdfc37b5f3f871651b1bb47ae4742988b03858037e36fdca775e220e3abe3bd6")
     version("0.38.1", sha256="c6868deb483c1d6c241aae92f8af63f3351062c2611c9163e8a9bbf6c97a9798")
     version("0.38.0", sha256="befe3bfc045bc0783126efb72ed55db9f205eaf176e1b8a2059eaaaaacc4880a")
     version("0.36.0", sha256="39bf748aa7b22df80b9791fbb6b4351ed9a9f85587b58fc3225314278a2a68f8")

--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -23,6 +23,8 @@ class Ectrans(CMakePackage):
 
     version("develop", branch="develop", no_cache=True)
     version("main", branch="main", no_cache=True)
+    version("1.5.0", sha256="8b2b24d1988b92dc3793b29142946614fca9e9c70163ee207d2a123494430fde")
+    version("1.4.0", sha256="1364827511a2eb11716aaee85062c3ab0e6b5d5dca7a7b9c364e1c43482b8691")
     version("1.2.0", sha256="2ee6dccc8bbfcc23faada1d957d141f24e41bb077c1821a7bc2b812148dd336c")
     version("1.1.0", sha256="3c9848bb65033fbe6d791084ee347b3adf71d5dfe6d3c11385000017b6469a3e")
 

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -22,6 +22,8 @@ class Fckit(CMakePackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.13.2", sha256="990623eb4eb999145f2d852da9fbd71a69e2e0be601c655c274e8382750dfda2")
+    version("0.13.1", sha256="89a067a7b5b1f2c7909739b567bd43b69f8a2d91e8cbcbac58655fb2d861db51")
     version("0.11.0", sha256="846f5c369940c0a3d42cd12932f7d6155339e79218d149ebbfdd02e759dc86c5")
     version("0.10.1", sha256="9cde04fefa50624bf89068ab793cc2e9437c0cd1c271a41af7d54dbd37c306be")
     version("0.10.0", sha256="f16829f63a01cdef5e158ed2a51f6d4200b3fe6dce8f251af158141a1afe482b")

--- a/var/spack/repos/builtin/packages/fiat/package.py
+++ b/var/spack/repos/builtin/packages/fiat/package.py
@@ -19,6 +19,8 @@ class Fiat(CMakePackage):
     license("Apache-2.0")
 
     version("main", branch="main", no_cache=True)
+    version("1.4.1", sha256="7d49316150e59afabd853df0066b457a268731633898ab51f6f244569679c84a")
+    version("1.4.0", sha256="5dc5a8bcac5463690529d0d96d2c805cf9c0214d125cd483ee69d36995ff15d3")
     version("1.2.0", sha256="758147410a4a3c493290b87443b4091660b915fcf29f7c4d565c5168ac67745f")
     version("1.1.0", sha256="58354e60d29a1b710bfcea9b87a72c0d89c39182cb2c9523ead76a142c695f82")
     version("1.0.0", sha256="45afe86117142831fdd61771cf59f31131f2b97f52a2bd04ac5eae9b2ab746b8")

--- a/var/spack/repos/builtin/packages/py-antimeridian/package.py
+++ b/var/spack/repos/builtin/packages/py-antimeridian/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAntimeridian(PythonPackage):
+    """Fix shapes that cross the antimeridian."""
+
+    homepage = "https://antimeridian.readthedocs.io/"
+    pypi = "antimeridian/antimeridian-0.3.11.tar.gz"
+    git = "https://github.com/gadomski/antimeridian.git"
+
+    license("Apache-2.0")
+
+    version("0.3.11", sha256="fde0134e6799676ec68765d3e588f5f32cabd4041b1f969b923758d0a6cd0c7f")
+
+    depends_on("python@3.10:", type=("build", "run"))
+    depends_on("py-hatchling", type="build")
+
+    depends_on("py-numpy@1.22.4:", type="run")
+    depends_on("py-shapely@2:", type="run")

--- a/var/spack/repos/builtin/packages/py-bokeh/package.py
+++ b/var/spack/repos/builtin/packages/py-bokeh/package.py
@@ -14,6 +14,7 @@ class PyBokeh(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.5.2", sha256="03a54a67db677b8881834271c620a781b383ae593af5c3ea2149164754440d07")
     version("3.3.1", sha256="2a7b3702d7e9f03ef4cd801b02b7380196c70cff2773859bcb84fa565218955c")
     version("2.4.3", sha256="ef33801161af379665ab7a34684f2209861e3aefd5c803a21fbbb99d94874b03")
     version("2.4.1", sha256="d0410717d743a0ac251e62480e2ea860a7341bdcd1dbe01499a904f233c90512")
@@ -33,6 +34,7 @@ class PyBokeh(PythonPackage):
     depends_on("python@3.7:", type=("build", "run"), when="@2.4.0:")
     depends_on("python@3.8:", type=("build", "run"), when="@3.0.0:")
     depends_on("python@3.9:", type=("build", "run"), when="@3.2.0:")
+    depends_on("python@3.10:", type=("build", "run"), when="@3.5.0:")
 
     depends_on("py-requests@1.2.3:", type=("build", "run"), when="@0.12.2")
     depends_on("py-six@1.5.2:", type=("build", "run"), when="@:1.3.4")
@@ -42,6 +44,7 @@ class PyBokeh(PythonPackage):
     depends_on("py-jinja2@2.9:", type=("build", "run"), when="@2.3.3:")
 
     depends_on("py-contourpy@1:", type=("build", "run"), when="@3:")
+    depends_on("py-contourpy@1.2:", type=("build", "run"), when="@3.5:")
 
     depends_on("py-numpy@1.7.1:", type=("build", "run"))
     depends_on("py-numpy@1.11.3:", type=("build", "run"), when="@2.3.3:")
@@ -60,6 +63,7 @@ class PyBokeh(PythonPackage):
 
     depends_on("py-tornado@4.3:", type=("build", "run"))
     depends_on("py-tornado@5.1:", type=("build", "run"), when="@2.3.3:")
+    depends_on("py-tornado@6.2:", type=("build", "run"), when="@3.5:")
 
     depends_on("py-typing-extensions@3.7.4:", type=("build", "run"), when="@2.3.3:3.0.0")
     depends_on("py-typing-extensions@3.10.0:", type=("build", "run"), when="@2.4.0:3.0.0")

--- a/var/spack/repos/builtin/packages/py-dask-expr/package.py
+++ b/var/spack/repos/builtin/packages/py-dask-expr/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyDaskExpr(PythonPackage):
+    """Dask DataFrames with query optimization."""
+
+    homepage = "https://github.com/dask/dask-expr"
+    url = "https://github.com/dask/dask-expr/archive/refs/tags/v1.1.9.tar.gz"
+
+    license("BSD-3-Clause")
+
+    version("1.1.9", sha256="e5a1b82de1142c29fed899a80541a98ca5e12cb85ce9d86bc8ada204a22599d3")
+
+    depends_on("python@3.10:", type=("build", "run"))
+    depends_on("py-setuptools@62.6:", type="build")
+    depends_on("py-versioneer@0.28+toml", type="build")
+
+    # Can't do circular run-time dependencies yet?
+    # depends_on("py-dask@2024.7.1", type="run")
+    depends_on("py-pyarrow@7: +dataset", type="run")
+    depends_on("py-pandas@2:", type="run")

--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -41,6 +41,8 @@ class PyDask(PythonPackage):
         description="Install requirements for dask.delayed (dask.imperative)",
     )
 
+    conflicts("~array", when="@2023.8: +dataframe", msg="From 2023.8, +dataframe requires +array")
+
     depends_on("python@3.8:", type=("build", "run"), when="@2022.10.2:")
 
     depends_on("py-setuptools", type="build")
@@ -102,6 +104,9 @@ class PyDask(PythonPackage):
     depends_on("py-partd@0.3.10:", type=("build", "run"), when="@:2021.3.0 +dataframe")
     # The dependency on py-fsspec is non-optional starting version 2021.3.1
     depends_on("py-fsspec@0.6.0:", type=("build", "run"), when="@:2021.3.0 +dataframe")
+    # Starting with version 2024.3.0, dataframe requires a separate package py-dask-expr
+    depends_on("py-dask-expr", type=("build", "run"), when="@2024.3: +dataframe")
+    depends_on("py-dask-expr@1.1.9", type=("build", "run"), when="@2024.7.1 +dataframe")
 
     # Requirements for dask.distributed
     depends_on(

--- a/var/spack/repos/builtin/packages/py-datashader/package.py
+++ b/var/spack/repos/builtin/packages/py-datashader/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyDatashader(PythonPackage):
+    """Datashader is a data rasterization pipeline for automating the process of creating
+    meaningful representations of large amounts of data"""
+
+    homepage = "https://datashader.org"
+    pypi = "datashader/datashader-0.16.3.tar.gz"
+    git = "https://github.com/holoviz/datashader.git"
+
+    license("BSD-3-Clause", checked_by="climbfuji")
+
+    version("0.16.3", sha256="9d0040c7887f7a5a5edd374c297402fd208a62bf6845e87631b54f03b9ae479d")
+
+    # pyproject.toml
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-pyct", type=("build", "run"))
+    depends_on("py-hatchling", type="build")
+    depends_on("py-hatch-vcs", type="build")
+    depends_on("py-param", type=("build", "run"))
+
+    depends_on("py-colorcet", type="run")
+    depends_on("py-dask", type="run")
+    depends_on("py-multipledispatch", type="run")
+    depends_on("py-numba", type="run")
+    depends_on("py-numpy", type="run")
+    depends_on("py-packaging", type="run")
+    depends_on("py-pandas", type="run")
+    depends_on("py-pillow", type="run")
+    depends_on("py-requests", type="run")
+    depends_on("py-scipy", type="run")
+    depends_on("py-toolz", type="run")
+    depends_on("py-xarray", type="run")

--- a/var/spack/repos/builtin/packages/py-geoviews/package.py
+++ b/var/spack/repos/builtin/packages/py-geoviews/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyGeoviews(PythonPackage):
+    """A Python library designed to make data analysis and visualization seamless and simple."""
+
+    homepage = "https://geoviews.org/"
+    pypi = "geoviews/geoviews-1.13.0.tar.gz"
+    git = "https://github.com/holoviz/geoviews.git"
+
+    license("BSD-3-Clause", checked_by="climbfuji")
+
+    version("1.13.0", sha256="7554a1e9114995acd243546fac6c6c7f157fc28529fde6ab236a72a6e77fe0bf")
+    # version("1.12.0", sha256="e2cbef0605e8fd1529bc643a31aeb61997f8f93c9b41a5aff8b2b355a76fa789")
+
+    depends_on("python@3.10:", type=("build", "run"))
+    depends_on("py-hatchling", type="build")
+    depends_on("py-hatch-vcs", type="build")
+    depends_on("py-bokeh@3.5", type=("build", "run"))
+
+    depends_on("py-cartopy@0.18:", type="run")
+    depends_on("py-holoviews@1.16:", type="run")
+    depends_on("py-numpy", type="run")
+    depends_on("py-packaging", type="run")
+    depends_on("py-panel@1:", type="run")
+    depends_on("py-param", type="run")
+    depends_on("py-pyproj", type="run")
+    depends_on("py-shapely", type="run")
+    depends_on("py-xyzservices", type="run")

--- a/var/spack/repos/builtin/packages/py-holoviews/package.py
+++ b/var/spack/repos/builtin/packages/py-holoviews/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyHoloviews(PythonPackage):
+    """A Python library designed to make data analysis and visualization seamless and simple."""
+
+    homepage = "https://holoviews.org/"
+    pypi = "holoviews/holoviews-1.19.1.tar.gz"
+    git = "https://github.com/holoviz/holoviews.git"
+
+    license("BSD-3-Clause", checked_by="climbfuji")
+
+    version("1.19.1", sha256="b9e85e8c07275a456c0ef8d06bc157d02b37eff66fb3602aa12f5c86f084865c")
+    # version("1.19.0", sha256="cab1522f75a9b46377f9364b675befd79812e220059714470a58e21475d531ba")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-hatchling", type="build")
+    depends_on("py-hatch-vcs", type="build")
+
+    depends_on("py-bokeh@3.1:", type="run")
+    depends_on("py-colorcet", type="run")
+    depends_on("py-numpy@1.21:", type="run")
+    depends_on("py-packaging", type="run")
+    depends_on("py-pandas@1.3:", type="run")
+    depends_on("py-panel@1:", type="run")
+    depends_on("py-param@2", type="run")
+    depends_on("py-pyviz-comms@2.1:", type="run")

--- a/var/spack/repos/builtin/packages/py-hvplot/package.py
+++ b/var/spack/repos/builtin/packages/py-hvplot/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyHvplot(PythonPackage):
+    """A high-level plotting API for pandas, dask, xarray, and networkx built on HoloViews."""
+
+    homepage = "https://hvplot.holoviz.org/"
+    pypi = "hvplot/hvplot-1.19.1.tar.gz"
+    git = "http://github.com/holoviz/hvplot.git"
+
+    license("BSD-3-Clause", checked_by="climbfuji")
+
+    version("0.11.1", sha256="989ed0389189adc47edcd2601d2eab18bf366e74b07f5e2873e021323c4a14bb")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-setuptools@30.3:", type="build")
+    depends_on("py-setuptools-scm@6:", type="build")
+
+    depends_on("py-bokeh@3.1:", type="run")
+    depends_on("py-colorcet", type="run")
+    depends_on("py-holoviews@1.19:", type="run")
+    depends_on("py-numpy@1.21:", type="run")
+    depends_on("py-packaging", type="run")
+    depends_on("py-pandas@1.3:", type="run")
+    depends_on("py-panel@1:", type="run")
+    depends_on("py-param@1.12:2", type="run")

--- a/var/spack/repos/builtin/packages/py-panel/package.py
+++ b/var/spack/repos/builtin/packages/py-panel/package.py
@@ -14,16 +14,43 @@ class PyPanel(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.5.2", sha256="30a45f314716bdde2de5c002fbd3a0b4d6ff85459e2179284df559455ff1534b")
     version("0.14.4", sha256="b853d2f53d7738ec6372525360c5bf9427a71ed990685ccac703bc9b442e9951")
 
-    depends_on("py-param@1.12:", type=("build", "run"))
-    depends_on("py-pyct@0.4.4:", type=("build", "run"))
-    depends_on("py-setuptools@42:", type=("build", "run"))
-    depends_on("py-bokeh@2.4.3:2.4", type=("build", "run"))
-    depends_on("py-pyviz-comms@0.7.4:", type=("build", "run"))
-    depends_on("py-requests", type=("build", "run"))
-    depends_on("py-bleach", type=("build", "run"))
-    depends_on("py-packaging", type="build")
-    depends_on("py-tqdm@4.48:", type=("build", "run"))
-    depends_on("py-markdown", type=("build", "run"))
-    depends_on("py-typing-extensions", type=("build", "run"))
+    with when("@0.14.4"):
+        depends_on("py-param@1.12:", type=("build", "run"))
+        depends_on("py-pyct@0.4.4:", type=("build", "run"))
+        depends_on("py-setuptools@42:", type=("build", "run"))
+        depends_on("py-bokeh@2.4.3:2.4", type=("build", "run"))
+        depends_on("py-pyviz-comms@0.7.4:", type=("build", "run"))
+        depends_on("py-requests", type=("build", "run"))
+        depends_on("py-bleach", type=("build", "run"))
+        depends_on("py-packaging", type="build")
+        depends_on("py-tqdm@4.48:", type=("build", "run"))
+        depends_on("py-markdown", type=("build", "run"))
+        depends_on("py-typing-extensions", type=("build", "run"))
+
+    with when("@1.5.2"):
+        depends_on("python@3.10:", type=("build", "run"))
+        depends_on("py-hatchling", type="build")
+        depends_on("py-hatch-vcs", type="build")
+        depends_on("py-param@2.1:2", type=("build", "run"))
+        depends_on("py-bokeh@3.5:3.6", type=("build", "run"))
+        depends_on("py-pyviz-comms@2:", type=("build", "run"))
+        depends_on("py-requests", type=("build", "run"))
+        depends_on("py-packaging", type=("build", "run"))
+        # Version 18 or later are requested by py-panel
+        depends_on("node-js@18:", type=("build", "run"))
+        # Version 9 is not requested explicitly, it's
+        # a guess that the more recent version of node-js
+        # should go with a more recent version of npm
+        depends_on("npm@9:", type=("build", "run"))
+
+        depends_on("py-markdown", type="run")
+        depends_on("py-markdown-it-py", type="run")
+        depends_on("py-linkify-it-py", type="run")
+        depends_on("py-mdit-py-plugins", type="run")
+        depends_on("py-bleach", type="run")
+        depends_on("py-typing-extensions", type="run")
+        depends_on("py-pandas@1.2:", type="run")
+        depends_on("py-tqdm", type="run")

--- a/var/spack/repos/builtin/packages/py-param/package.py
+++ b/var/spack/repos/builtin/packages/py-param/package.py
@@ -19,7 +19,13 @@ class PyParam(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.1.1", sha256="3b1da14abafa75bfd908572378a58696826b3719a723bc31b40ffff2e9a5c852")
     version("1.12.0", sha256="35d0281c8e3beb6dd469f46ff0b917752a54bed94d1b0c567346c76d0ff59c4a")
 
-    depends_on("python@2.7:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("python@2.7:", when="@1", type=("build", "run"))
+    depends_on("python@3.8:", when="@2:", type=("build", "run"))
+
+    depends_on("py-setuptools", when="@1", type="build")
+
+    depends_on("py-hatchling", when="@2", type="build")
+    depends_on("py-hatch-vcs", when="@2", type="build")

--- a/var/spack/repos/builtin/packages/py-spatialpandas/package.py
+++ b/var/spack/repos/builtin/packages/py-spatialpandas/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySpatialpandas(PythonPackage):
+    """Pandas extension arrays for spatial/geometric operations."""
+
+    homepage = "https://holoviz.org/"
+    pypi = "spatialpandas/spatialpandas-1.19.1.tar.gz"
+    git = "https://github.com/holoviz/spatialpandas.git"
+
+    license("BSD-2-Clause", checked_by="climbfuji")
+
+    version("0.4.10", sha256="032e24ebb40f75c5c79cb79d7c281f2990e69ba382c0b24acb53da7bba60851c")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-hatchling", type="build")
+    depends_on("py-hatch-vcs", type="build")
+    depends_on("py-param", type="build")
+
+    depends_on("py-dask", type="run")
+    depends_on("py-fsspec@2022.8:", type="run")
+    depends_on("py-numba", type="run")
+    depends_on("py-packaging", type="run")
+    depends_on("py-pandas", type="run")
+    depends_on("py-pyarrow@10:", type="run")
+    depends_on("py-retrying", type="run")

--- a/var/spack/repos/builtin/packages/py-uxarray/package.py
+++ b/var/spack/repos/builtin/packages/py-uxarray/package.py
@@ -1,0 +1,56 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyUxarray(PythonPackage):
+    """Xarray extension for unstructured climate and global weather data analysis and
+    visualization"""
+
+    homepage = "https://uxarray.readthedocs.io"
+    pypi = "uxarray/uxarray-2024.10.0.tar.gz"
+    git = "https://github.com/uxarray/uxarray.git"
+
+    license("Apache-2.0", checked_by="climbfuji")
+
+    version("2024.10.0", sha256="f65a9920ce085af9a38349dc5ece4f9b83bc015dc8cb738d245d343f7816fd59")
+
+    # Build-time dependencies
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-setuptools@60:", type="build")
+    depends_on("py-setuptools-scm@8:", type="build")
+
+    # "Minimal" run-time dependencies
+    depends_on("py-antimeridian", type="run")
+    depends_on("py-cartopy", type="run")
+    depends_on("py-datashader", type="run")
+    depends_on("py-geopandas", type="run")
+    depends_on("py-geoviews", type="run")
+    depends_on("py-holoviews", type="run")
+    depends_on("py-hvplot", type="run")
+    # With older versions of py-dask (2021.6.2):
+    #    @derived_from(pd.core.strings.StringMethods)
+    #                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    #    AttributeError: module 'pandas.core.strings' has no attribute 'StringMethods'
+    # With py-dask@2023.4.1:
+    #      return get(descriptor, obj, type(obj))
+    #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    #      TypeError: descriptor '__call__' for 'type' objects doesn't apply to a 'property' object
+    # https://github.com/dask/dask/issues/11038
+    depends_on("py-dask@2024.7.1 +dataframe", type="run")
+    depends_on("py-dask-expr@1.1.9", type="run")
+    depends_on("py-matplotlib", type="run")
+    depends_on("py-matplotlib-inline", type="run")
+    depends_on("py-netcdf4", type="run")
+    depends_on("py-numba", type="run")
+    depends_on("py-pandas", type="run")
+    depends_on("py-pyarrow", type="run")
+    depends_on("py-pytest", type="run")
+    depends_on("py-requests", type="run")
+    depends_on("py-scipy", type="run")
+    depends_on("py-spatialpandas", type="run")
+    depends_on("py-scikit-learn", type="run")
+    depends_on("py-xarray", type="run")


### PR DESCRIPTION
This PR cherry-picks two PRs that were merged into spack develop recently and that are needed for spack-stack-1.9.0:
- https://github.com/spack/spack/pull/47573
- https://github.com/spack/spack/pull/47749

Both PRs merged cleanly into our spack-stack-dev branch.

This PR is just to add these new versions/packages to spack-stack-dev, a PR to update default versions or add the new package `py-uxarray` will be made later.