### PR TITLE
Update ESMF to support clang with gfortran and clang with flang (spack #48026); replace esmf@8.8.0b06 with esmf@8.8.0b10

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -271,14 +271,18 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             # to avoid having to add clang OpenMP libraries to the
             # Fortran linker command.
             env.set("ESMF_OPENMP", "OFF")
-            #
-            env.set("ESMF_COMPILER", "gfortranclang")
-            with self.pkg.compiler.compiler_environment():
-                gfortran_major_version = int(
-                    spack.compiler.get_compiler_version_output(
-                        self.pkg.compiler.fc, "-dumpversion"
-                    ).split(".")[0]
-                )
+            if "flang" in self.pkg.compiler.fc:
+                env.set("ESMF_COMPILER", "llvm")
+            elif "gfortran" in self.pkg.compiler.fc:
+                env.set("ESMF_COMPILER", "gfortranclang")
+                with self.pkg.compiler.compiler_environment():
+                    gfortran_major_version = int(
+                        spack.compiler.get_compiler_version_output(
+                            self.pkg.compiler.fc, "-dumpversion"
+                        ).split(".")[0]
+                    )
+            else:
+                raise InstallError("Unsupported C/C++/Fortran compiler combination")
         elif self.pkg.compiler.name == "nag":
             env.set("ESMF_COMPILER", "nag")
         elif self.pkg.compiler.name == "pgi":
@@ -313,6 +317,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
 
         if (
             self.pkg.compiler.name in ["gcc", "clang", "apple-clang"]
+            and "gfortran" in self.pkg.compiler.fc
             and gfortran_major_version >= 10
             and (self.spec.satisfies("@:8.2.99") or self.spec.satisfies("@8.3.0b09"))
         ):

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -29,6 +29,7 @@ class Esmf(MakefilePackage, PythonExtension):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
+    version("8.8.0b09", commit="b39311b3081c47250326ebdadb4ddf59be152155")
     version("8.8.0b06", commit="aed3278586544bb7687bb03b5c9b65dff67c18a8")
     version("8.7.0", sha256="d7ab266e2af8c8b230721d4df59e61aa03c612a95cc39c07a2d5695746f21f56")
     version("8.6.1", sha256="dc270dcba1c0b317f5c9c6a32ab334cb79468dda283d1e395d98ed2a22866364")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -29,8 +29,7 @@ class Esmf(MakefilePackage, PythonExtension):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
-    version("8.8.0b09", commit="b39311b3081c47250326ebdadb4ddf59be152155")
-    version("8.8.0b06", commit="aed3278586544bb7687bb03b5c9b65dff67c18a8")
+    version("8.8.0b10", commit="dc03809c35e37482fc349011540f80c191c452eb")
     version("8.7.0", sha256="d7ab266e2af8c8b230721d4df59e61aa03c612a95cc39c07a2d5695746f21f56")
     version("8.6.1", sha256="dc270dcba1c0b317f5c9c6a32ab334cb79468dda283d1e395d98ed2a22866364")
     version("8.6.0", sha256="ed057eaddb158a3cce2afc0712b49353b7038b45b29aee86180f381457c0ebe7")


### PR DESCRIPTION
## Description

So far, the ESMF package recipe in spack assumes that the spack compilers clang and apple-clang are using gfortran as the Fortran compiler. But with the latest improvements to the LLVM compilers, we need to also support clang with flang. See https://github.com/spack/spack/pull/48026 for more information and feedback from the package maintainers and spack developers if there's a better way (PR was reviewed and merged Dec 11, 2024).

Also add `esmf@8.8.0b09` (seems to be necessary for LLVM 19.1.4; regardless, both NEPTUNE and UFS need this version).

See https://github.com/JCSDA/spack-stack/pull/1409 for the corresponding spack-stack PR (this PR has some unrelated changes = cleanup on Derecho and is therefore still in draft; however, ESMF works as expected in CI and my manual testing with LLVM 19.1.4 on my dev machine).