### PR TITLE
Configure 'spack external find grep'

### DIFF
--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -34,13 +34,17 @@ class Grep(AutotoolsPackage):
 
     @classmethod
     def determine_version(cls, exe):
-        version_string = Executable(exe)("--version", output=str, error=str).split('\n')[0]
+        version_string = Executable(exe)("--version", output=str, error=str).split("\n")[0]
+        # Linux
         if "GNU grep" in version_string:
             return version_string.lstrip("grep (GNU grep)").strip()
+        # macOS
         elif "BSD grep, GNU compatible" in version_string:
-            return version_string.lstrip("grep (BSD grep, GNU compatible)").rstrip("-FreeBSD").strip()
+            return (
+                version_string.lstrip("grep (BSD grep, GNU compatible)").rstrip("-FreeBSD").strip()
+            )
+        # Don't know how to handle this version of grep, don't add it
         else:
-            # Don't know how to handle this version of grep, don't add it
             return None
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -29,6 +29,20 @@ class Grep(AutotoolsPackage):
     depends_on("pcre2", when="@3.8:+pcre")
     depends_on("pcre", when="@:3.7+pcre")
 
+    # For spack external find
+    executables = ["^grep$"]
+
+    @classmethod
+    def determine_version(cls, exe):
+        version_string = Executable(exe)("--version", output=str, error=str).split('\n')[0]
+        if "GNU grep" in version_string:
+            return version_string.lstrip("grep (GNU grep)").strip()
+        elif "BSD grep, GNU compatible" in version_string:
+            return version_string.lstrip("grep (BSD grep, GNU compatible)").rstrip("-FreeBSD").strip()
+        else:
+            # Don't know how to handle this version of grep, don't add it
+            return None
+
     def configure_args(self):
         args = []
 


### PR DESCRIPTION
## Description

Find external `grep` on macOS and Linux. Upstream spack develop PR is https://github.com/spack/spack/pull/48134. Note that spack develop already had a mechanism for finding external `grep` on Linux, but not on macOS.

See https://github.com/JCSDA/spack-stack/pull/1419 for the corresponding spack-stack PR.