### PR TITLE
Cherry-pick from spack develop: Temporarily pin Ubuntu to v22.04, where we use kcov (#48152)

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         on_develop:
         - ${{ github.ref == 'refs/heads/develop' }}
@@ -36,19 +36,19 @@ jobs:
           on_develop: ${{ github.ref == 'refs/heads/develop' }}
         exclude:
         - python-version: '3.7'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           on_develop: false
         - python-version: '3.8'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           on_develop: false
         - python-version: '3.9'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           on_develop: false
         - python-version: '3.10'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           on_develop: false
         - python-version: '3.11'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           on_develop: false
 
     steps:
@@ -103,7 +103,7 @@ jobs:
         include-hidden-files: true
   # Test shell integration
   shell:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:


### PR DESCRIPTION
Resolves #493