### PR TITLE
Workaround for freetype build error with external libz and spack-built pkg-config

### DIFF
--- a/share/spack/qa/run-style-tests
+++ b/share/spack/qa/run-style-tests
@@ -26,5 +26,9 @@ fi
 # verify that the code style is correct
 spack style --root-relative "${args[@]}"
 
-# verify that the license headers are present
-spack license verify
+# DH* 20250102 - temporarily comment out until
+# spack-stack-dev is updated from spack develop
+# and includes https://github.com/spack/spack/pull/48352
+## verify that the license headers are present
+#spack license verify
+# *DH

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.cmake import CMakeBuilder
@@ -54,6 +55,7 @@ class Freetype(AutotoolsPackage, CMakePackage):
 
     depends_on("bzip2")
     depends_on("libpng")
+    depends_on("zlib-api")
     for plat in ["linux", "darwin"]:
         depends_on("pkgconfig", type="build", when="platform=%s" % plat)
 
@@ -95,7 +97,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
             "--with-bzip2=yes",
             "--with-harfbuzz=no",
             "--with-png=yes",
-            "--with-zlib=no",
+            "--with-zlib=yes",
         ]
         if self.spec.satisfies("@2.9.1:"):
             args.append("--enable-freetype-config")
@@ -106,6 +108,11 @@ class AutotoolsBuilder(AutotoolsBuilder):
     def setup_build_environment(self, env):
         if self.spec.satisfies("+pic"):
             env.set("CFLAGS", "-fPIC")
+        if self.spec["zlib-api"].external:
+            env.append_path(
+                "PKG_CONFIG_PATH",
+                os.path.dirname(find_first(self.spec["zlib-api"].prefix, "zlib.pc", bfs_depth=10)),
+            )
 
 
 class CMakeBuilder(CMakeBuilder):


### PR DESCRIPTION
## Description

This is a specific workaround for more general problem that I logged as an issue the spack upstream repo: https://github.com/spack/spack/issues/48293

In order to build `freetype` with a spack-built `pkg-config` and an external `libz`, this workaround tells spack where to look for `zlib.pc` by finding the file in the prefix of the external zlib, and then adding it to `PKG_CONFIG_PATH`.

We need this solution until the general problem has been addressed (or we can push this solution upstream if the spack develop are ok with it).

## Testing

See https://github.com/JCSDA/spack-stack/pull/1439.

Temporarily deactivated license header check because it's 2025 now and our spack code still looks for 2024. The next update from spack develop will resolve the problem, and an issue in our spack fork will remind us to reenable the license header check.