### PR TITLE
Follow-up bug fix in freetype when using external libz; add conflict for node-js@21: with gcc@11.2

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -105,9 +105,18 @@ class AutotoolsBuilder(AutotoolsBuilder):
         args.extend(self.with_or_without("pic"))
         return args
 
+    # https://github.com/spack/spack/issues/48293
     def setup_build_environment(self, env):
         if self.spec.satisfies("+pic"):
             env.set("CFLAGS", "-fPIC")
+        if self.spec["zlib-api"].external:
+            env.append_path(
+                "PKG_CONFIG_PATH",
+                os.path.dirname(find_first(self.spec["zlib-api"].prefix, "zlib.pc", bfs_depth=10)),
+            )
+
+    # https://github.com/spack/spack/issues/48293
+    def setup_dependent_build_environment(self, env, dependent_spec):
         if self.spec["zlib-api"].external:
             env.append_path(
                 "PKG_CONFIG_PATH",

--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -103,6 +103,13 @@ class NodeJs(Package):
     # See https://github.com/nodejs/node/issues/52223
     patch("fix-old-glibc-random-headers.patch", when="^glibc@:2.24")
 
+    # https://github.com/nodejs/node/issues/55596
+    # This patch is not sufficient, however, therefore
+    # add a conflict with this particular version of gcc
+    # until https://github.com/spack/spack/issues/48492 is resolved
+    patch("wasm-compiler-gcc11p2.patch", when="@21: %gcc@11.2")
+    conflicts("%gcc@11.2", when="@21:")
+
     def setup_build_environment(self, env):
         # Force use of experimental Python 3 support
         env.set("PYTHON", self.spec["python"].command.path)

--- a/var/spack/repos/builtin/packages/node-js/wasm-compiler-gcc11p2.patch
+++ b/var/spack/repos/builtin/packages/node-js/wasm-compiler-gcc11p2.patch
@@ -1,0 +1,40 @@
+diff --git a/deps/v8/src/compiler/wasm-compiler.cc b/deps/v8/src/compiler/wasm-compiler.cc
+--- a/deps/v8/src/compiler/wasm-compiler.cc     2024-10-28 21:25:11.000000000 -0400
++++ b/deps/v8/src/compiler/wasm-compiler.cc     2024-11-01 02:02:22.554537121 -0400
+@@ -8613,11 +8613,13 @@
+                  '-');
+ 
+   auto compile_with_turboshaft = [&]() {
++    wasm::WrapperCompilationInfo ci;
++    ci.code_kind = CodeKind::WASM_TO_JS_FUNCTION;
++    ci.import_info.import_kind = kind;
++    ci.import_info.expected_arity = expected_arity;
++    ci.import_info.suspend = suspend;
+     return Pipeline::GenerateCodeForWasmNativeStubFromTurboshaft(
+-        env->module, sig,
+-        wasm::WrapperCompilationInfo{
+-            .code_kind = CodeKind::WASM_TO_JS_FUNCTION,
+-            .import_info = {kind, expected_arity, suspend}},
++        env->module, sig, ci,
+         func_name, WasmStubAssemblerOptions(), nullptr);
+   };
+   auto compile_with_turbofan = [&]() {
+@@ -8774,12 +8776,14 @@
+       base::VectorOf(name_buffer.get(), kMaxNameLen) + kNamePrefixLen, sig);
+ 
+   auto compile_with_turboshaft = [&]() {
++    wasm::WrapperCompilationInfo ci;
++    ci.code_kind = CodeKind::WASM_TO_JS_FUNCTION;
++    ci.import_info.import_kind = kind;
++    ci.import_info.expected_arity = expected_arity;
++    ci.import_info.suspend = suspend;
+     std::unique_ptr<turboshaft::TurboshaftCompilationJob> job =
+         Pipeline::NewWasmTurboshaftWrapperCompilationJob(
+-            isolate, sig,
+-            wasm::WrapperCompilationInfo{
+-                .code_kind = CodeKind::WASM_TO_JS_FUNCTION,
+-                .import_info = {kind, expected_arity, suspend}},
++            isolate, sig, ci,
+             nullptr, std::move(name_buffer), WasmAssemblerOptions());
+ 
+     // Compile the wrapper


### PR DESCRIPTION
## Description

This PR contains two separate changes/commits:
1. A follow-up to a previous PR (#496) for `freetype` when using an external `libz`. We also need to add the location of the external `zlib.pc` to `PKG_CONFIG_PATH` to the dependents of `freetype`.
2. Add an incomplete bug fix and therefore an additional conflict for `node-js@21:` with one particular version of `gcc`, namely `gcc@11.2`. As noted in https://github.com/nodejs/node/issues/55596, `gcc@11.2` seems to have a bug that prevents building newer `node-js` versions. See https://github.com/spack/spack/issues/48492 for more information.

This PR is required for https://github.com/JCSDA/spack-stack/pull/1410 and it was tested as part of it on three HPC systems used by the Navy (Atlantis, Narwhal, Nautilus).