### PR TITLE
Update selected packages from spack develop 2025/01/13 (add esmf@8.8.0)

### DIFF
--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -61,6 +61,9 @@ class Ectrans(CMakePackage):
     depends_on("fiat~mpi", when="~mpi")
     depends_on("fiat+mpi", when="+mpi")
 
+    # https://github.com/ecmwf-ifs/ectrans/issues/194
+    conflicts("%oneapi@2025:", when="@1.3.1:1.5.1")
+
     def cmake_args(self):
         args = [
             self.define_from_variant("ENABLE_MPI", "mpi"),

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -29,7 +29,7 @@ class Esmf(MakefilePackage, PythonExtension):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
-    version("8.8.0b10", commit="dc03809c35e37482fc349011540f80c191c452eb")
+    version("8.8.0", sha256="f89327428aeef6ad34660b5b78f30d1c55ec67efb8f7df1991fdaa6b1eb3a27c")
     version("8.7.0", sha256="d7ab266e2af8c8b230721d4df59e61aa03c612a95cc39c07a2d5695746f21f56")
     version("8.6.1", sha256="dc270dcba1c0b317f5c9c6a32ab334cb79468dda283d1e395d98ed2a22866364")
     version("8.6.0", sha256="ed057eaddb158a3cce2afc0712b49353b7038b45b29aee86180f381457c0ebe7")

--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/py-arrow/package.py
+++ b/var/spack/repos/builtin/packages/py-arrow/package.py
@@ -30,12 +30,15 @@ class PyArrow(PythonPackage):
     version("0.14.7", sha256="67f8be7c0cf420424bc62d8d7dc40b44e4bb2f7b515f9cc2954fb36e35797656")
     version("0.14.1", sha256="2d30837085011ef0b90ff75aa0a28f5c7d063e96b7e76b6cbc7e690310256685")
 
-    depends_on("python@3.8:", type=("build", "run"), when="@1.3:")
+    # https://github.com/spack/spack/issues/48477
+    # depends_on("python@3.8:", type=("build", "run"), when="@1.3:")
     depends_on("python@3.6:", type=("build", "run"), when="@1.2.1:")
     depends_on("python@2.7:2.8,3.5:", type=("build", "run"), when="@:0.16.0")
     depends_on("py-setuptools", type="build", when="@:1.2")
-    depends_on("py-flit-core@3.2:3", type="build", when="@1.3:")
+    # https://github.com/spack/spack/issues/48477
+    # depends_on("py-flit-core@3.2:3", type="build", when="@1.3:")
     depends_on("py-python-dateutil", type=("build", "run"))
     depends_on("py-typing-extensions", type=("build", "run"), when="@1.2.1:1.2 ^python@:3.7")
     depends_on("py-python-dateutil@2.7.0:", type=("build", "run"), when="@1.2.1:")
-    depends_on("py-types-python-dateutil@2.8.10:", type=("build", "run"), when="@1.3:")
+    # https://github.com/spack/spack/issues/48477
+    # depends_on("py-types-python-dateutil@2.8.10:", type=("build", "run"), when="@1.3:")

--- a/var/spack/repos/builtin/packages/py-cylc-flow/package.py
+++ b/var/spack/repos/builtin/packages/py-cylc-flow/package.py
@@ -17,7 +17,8 @@ class PyCylcFlow(PythonPackage):
 
     license("GPL-3.0-only")
 
-    # 8.3.6 not on PyPI server?
+    # Version 8.3.6 is available at PyPI, but not at the URL that is considered canonical by Spack
+    # https://github.com/spack/spack/issues/48479
     version("8.3.6", commit="7f63b43164638e27636b992b14b3fa088b692b94")
     version("8.2.3", sha256="dd5bea9e4b8dad00edd9c3459a38fb778e5a073da58ad2725bc9b84ad718e073")
     version("8.2.0", sha256="cbe35e0d72d1ca36f28a4cebe9b9040a3445a74253bc94051a3c906cf179ded0")

--- a/var/spack/repos/builtin/packages/py-cylc-rose/package.py
+++ b/var/spack/repos/builtin/packages/py-cylc-rose/package.py
@@ -17,7 +17,8 @@ class PyCylcRose(PythonPackage):
 
     license("GPL-3.0-only")
 
-    # 1.4.2 not on PyPI server?
+    # Version 1.4.2 is available at PyPI, but not at the URL that is considered canonical by Spack
+    # https://github.com/spack/spack/issues/48479
     version("1.4.2", commit="8deda0480afed8cf92cfdf7938fc78d0aaf0c0e4")
     version("1.3.0", sha256="017072b69d7a50fa6d309a911d2428743b07c095f308529b36b1b787ebe7ab88")
 

--- a/var/spack/repos/builtin/packages/py-cylc-uiserver/package.py
+++ b/var/spack/repos/builtin/packages/py-cylc-uiserver/package.py
@@ -17,7 +17,8 @@ class PyCylcUiserver(PythonPackage):
 
     license("GPL-3.0-or-later")
 
-    # 1.5.1 not on PyPI server?
+    # Version 1.5.1 is available at PyPI, but not at the URL that is considered canonical by Spack
+    # https://github.com/spack/spack/issues/48479
     version("1.5.1", commit="3a41c6fbefbcea33c41410f3698de8b62c9871b8")
     version("1.3.0", sha256="f3526e470c7ac2b61bf69e9b8d17fc7a513392219d28baed9b1166dcc7033d7a")
 


### PR DESCRIPTION
## Description

This PR cherry-picks selected PRs from spack develop as of 2025/01/13. With the exception of `esmf` (new version 8.8.0), ectrans (conflict of specific versions with latest Intel OneAPI compilers), and `py-arrow` (also comment out dependencies for version 1.3.0, which was commented out both upstream and in our fork), these are all style changes or comments that were a result of the code review process in the upstream spack repository.

See https://github.com/JCSDA/spack-stack/pull/1450 for the corresponding spack-stack PR.