### PR TITLE
Add patch for py-netcdf4 so that we can build it ~mpi

### DIFF
--- a/var/spack/repos/builtin/packages/py-netcdf4/nompi.patch
+++ b/var/spack/repos/builtin/packages/py-netcdf4/nompi.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -392,7 +392,8 @@ if 'sdist' not in sys.argv[1:] and 'clean' not in sys.argv[1:] and '--version' n
+        (netcdf_lib_version > "4.4" and netcdf_lib_version < "4.5"):
+         has_cdf5_format = True
+
+-    has_parallel_support = check_has_parallel_support(inc_dirs)
++    #has_parallel_support = check_has_parallel_support(inc_dirs)
++    has_parallel_support = False
+     has_has_not = "has" if has_parallel_support else "does not have"
+     print(f"netcdf lib {has_has_not} parallel functions")

--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -42,9 +42,9 @@ class PyNetcdf4(PythonPackage):
     # https://github.com/Unidata/netcdf4-python/pull/1317
     depends_on("py-numpy@:1", when="@:1.6", type=("build", "link", "run"))
     depends_on("py-mpi4py", when="+mpi", type=("build", "run"))
-    depends_on("netcdf-c", when="-mpi")
+    depends_on("netcdf-c", when="~mpi")
     depends_on("netcdf-c+mpi", when="+mpi")
-    depends_on("hdf5@1.8.0:+hl", when="-mpi")
+    depends_on("hdf5@1.8.0:+hl", when="~mpi")
     depends_on("hdf5@1.8.0:+hl+mpi", when="+mpi")
 
     # The installation script tries to find hdf5 using pkg-config. However, the
@@ -53,6 +53,12 @@ class PyNetcdf4(PythonPackage):
     # Ubuntu/Debian package manager), it is definitely not what we need. The
     # following patch disables the usage of pkg-config at all.
     patch("disable_pkgconf.patch")
+
+    # Allow building py-netcdf4 ~mpi when netCDF was build with +mpi. This patch
+    # overrides the auto-decect feature (has_parallel_support) in setup.py. The
+    # logic in setup.py changed between 1.6.5 and 1.7.1, therefore this patch
+    # only works for versions 1.7.1 and later.
+    patch("nompi.patch", when="@1.7.1: ~mpi")
 
     # https://github.com/Unidata/netcdf4-python/pull/1322
     patch(


### PR DESCRIPTION
Add patch for `py-netcdf4` so that we can build it `~mpi` when `netcdf-c` was built with `+mpi`. See https://github.com/JCSDA/spack-stack/issues/1463 for more information.

See https://github.com/JCSDA/spack-stack/pull/1464 for testing.