### PR TITLE
Fix ectrans: instead of declaring a conflict with Intel LLVM compilers, apply patch from upstream

### DIFF
--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -62,7 +62,11 @@ class Ectrans(CMakePackage):
     depends_on("fiat+mpi", when="+mpi")
 
     # https://github.com/ecmwf-ifs/ectrans/issues/194
-    conflicts("%oneapi@2025:", when="@1.3.1:1.5.1")
+    patch(
+        "https://github.com/ecmwf-ifs/ectrans/commit/98f0d505d5b0866cab68a15e86e1a495bafd93d2.patch?full_index=1",
+        sha256="17999486a320a5c6a1a442adcdf2c341b49d005f45d09ad0e525594d50bdc39c",
+        when="@1.3.1:1.5.1",
+    )
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
Fix var/spack/repos/builtin/packages/ectrans/package.py: instead of declaring a conflict with Intel LLVM compilers, apply patch from upstream.

Tested on my laptop with oneapi@2025.

Will create an identical update for spack develop: https://github.com/spack/spack/pull/48687