### PR TITLE
mapl: add v2.53.0 (#48712)

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -252,9 +252,11 @@ class Mapl(CMakePackage):
     conflicts("%gcc@13:", when="@:2.44")
 
     # MAPL can use ifx only from MAPL 2.51 onwards and only supports
-    # ifx 2025.0 and newer due to bugs in ifx
-    conflicts("%oneapi@:2024")
-    conflicts("%oneapi", when="@:2.50")
+    # ifx 2025.0 and newer due to bugs in ifx.
+    conflicts("%oneapi@2025:", when="@:2.50")
+    # NOTE there is a further check on oneapi in the cmake_args below
+    # that is hard to conflict since we don't know the fortran compiler
+    # at this point.
 
     variant("flap", default=False, description="Build with FLAP support", when="@:2.39")
     variant("pflogger", default=True, description="Build with pFlogger support")
@@ -387,6 +389,22 @@ class Mapl(CMakePackage):
                 fflags.append("-fallow-argument-mismatch")
         if fflags:
             args.append(self.define("CMAKE_Fortran_FLAGS", " ".join(fflags)))
+
+        # If oneapi@:2025 is used and it gets past the conflict above, we might be
+        # using ifx or ifort. If we are using ifx and the MAPL version is 2.50 or older
+        # we need to raise an error
+
+        if self.spec.satisfies("%oneapi@:2025"):
+            # We now need to get which Fortran compiler is used here but there
+            # isn't an easy way like:
+            #   if self.spec["fortran"].name == "ifx":
+            # yet (see https://github.com/spack/spack/pull/45189)
+            # So we need to parse the output of $FC --version
+            output = spack.compiler.get_compiler_version_output(
+                self.compiler.fc, "-diag-disable=10448 --version", ignore_errors=True
+            )
+            if "ifx" in output:
+                raise InstallError("MAPL versions 2.50 and older do not support ifx")
 
         # Scripts often need to know the MPI stack used to setup the environment.
         # Normally, we can autodetect this, but building with Spack does not

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -38,6 +38,12 @@ class Mapl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("2.53.0", sha256="68c24e6c0e3340645b1fb685972c96ef80746d5a289572c9883e520680708ebe")
+    version("2.52.0", sha256="c30be3a6ed3fca40aea903e10ee51e2fb50b4ef2445fdc959d4871baf3c20585")
+    version("2.51.2", sha256="f6df2be24d0c113af3d0424b674d970621660bf11e59a699373f014a14d0716e")
+    version("2.51.1", sha256="337dba3980de1d5e603361ecf8f001c5bf99d0addecbeb5c207f3604183ca623")
+    version("2.51.0", sha256="56213d845f5287e599213aab1dea60bf6b64c29cd8093313639304b270c45676")
+    version("2.50.3", sha256="506f73d511b6a63645bbf953bf04f663da06f5069cb559340786e9fe8eeb170f")
     version("2.50.2", sha256="1c72f8598cf01bab6ef30c1f461444ba5a13f55c61164b7b3c15efb0cd1096c0")
     version("2.50.1", sha256="26dd7a3ec82d484d60a559bb90a20ad9a2a717af52c25b6a752dd971aeeb5075")
     version("2.50.0", sha256="12282e547936f667f85c95d466273dcbaccbd600add72fa5981c0c734ccb1f7d")

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -386,6 +386,7 @@ class Mapl(CMakePackage):
         # - MVAPICH --> mvapich
         # - HPE MPT --> mpt
         # - Cray MPICH --> mpich
+        # - HPC-X --> openmpi
 
         if self.spec.satisfies("^mpich"):
             args.append(self.define("MPI_STACK", "mpich"))
@@ -401,6 +402,8 @@ class Mapl(CMakePackage):
             args.append(self.define("MPI_STACK", "mpt"))
         elif self.spec.satisfies("^cray-mpich"):
             args.append(self.define("MPI_STACK", "mpich"))
+        elif self.spec.satisfies("^hpcx-mpi"):
+            args.append(self.define("MPI_STACK", "openmpi"))
         else:
             raise InstallError("Unsupported MPI stack")
 

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -444,7 +444,7 @@ class Mapl(CMakePackage):
     @run_after("build")
     @on_package_attributes(run_tests=True)
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             # The test suite contains a lot of tests. We select only those
             # that are cheap. Note this requires MPI and 6 processes
             ctest("--output-on-failure", "-L", "ESSENTIAL")

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -390,11 +390,11 @@ class Mapl(CMakePackage):
         if fflags:
             args.append(self.define("CMAKE_Fortran_FLAGS", " ".join(fflags)))
 
-        # If oneapi@:2025 is used and it gets past the conflict above, we might be
+        # If oneapi@:2024 is used and it gets past the conflict above, we might be
         # using ifx or ifort. If we are using ifx and the MAPL version is 2.50 or older
         # we need to raise an error
 
-        if self.spec.satisfies("%oneapi@:2025"):
+        if self.spec.satisfies("@:2.50 %oneapi@:2024"):
             # We now need to get which Fortran compiler is used here but there
             # isn't an easy way like:
             #   if self.spec["fortran"].name == "ifx":

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -78,6 +78,7 @@ class Mapl(CMakePackage):
     version("2.41.0", sha256="1142f9395e161174e3ec1654fba8bda1d0bd93edc7438b1927d8f5d7b42a0a86")
     version("2.40.5", sha256="85b4a4ac0d843398452808b88d7a5c29435aa37b69b91a1f4bee664e9f367b7d")
     version("2.40.4", sha256="fb843b118d6e56cd4fc4b114c4d6f91956d5c8b3d9389ada56da1dfdbc58904f")
+    version("2.40.3.1", sha256="1e5a9d6a84d23febe826b1adcd2c2b1681bcc2e61c2959a8bbf4756357e22187")
     version("2.40.3", sha256="4b82a314c88a035fc2b91395750aa7950d6bee838786178ed16a3f39a1e45519")
     version("2.40.2", sha256="7327f6f5bce6e09e7f7b930013fba86ee7cbfe8ed4c7c087fc9ab5acbf6640fd")
     version("2.40.1", sha256="6f40f946fabea6ba73b0764092e495505d220455b191b4e454736a0a25ee058c")
@@ -287,6 +288,7 @@ class Mapl(CMakePackage):
 
     # ESMF dependency
     depends_on("esmf@8.6.1:", when="@2.45:")
+    depends_on("esmf@8.6.1:", when="@=2.40.3.1")
     depends_on("esmf@8.6.0", when="@2.44")
     depends_on("esmf@8.5:", when="@2.40:2.43")
     depends_on("esmf@8.4", when="@2.34:2.39")

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -164,8 +164,14 @@ class Mapl(CMakePackage):
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v3.55.0",
+        when="@2.51:",
+    )
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.51.0",
-        when="@2.48:",
+        when="@2.48:2.50",
     )
     resource(
         name="esma_cmake",
@@ -244,6 +250,11 @@ class Mapl(CMakePackage):
     # builds with gcc 13 from that version onwards
     conflicts("%gcc@13:", when="@:2.44")
 
+    # MAPL can use ifx only from MAPL 2.51 onwards and only supports
+    # ifx 2025.0 and newer due to bugs in ifx
+    conflicts("%oneapi@:2024")
+    conflicts("%oneapi", when="@:2.50")
+
     variant("flap", default=False, description="Build with FLAP support", when="@:2.39")
     variant("pflogger", default=True, description="Build with pFlogger support")
     variant("fargparse", default=True, description="Build with fArgParse support")
@@ -265,7 +276,8 @@ class Mapl(CMakePackage):
     conflicts("+pflogger", when="@:2.40.3 %intel@2021.7:")
     conflicts("+extdata2g", when="@:2.40.3 %intel@2021.7:")
 
-    depends_on("cmake@3.23:", type="build", when="@2.50:")
+    depends_on("cmake@3.24:", type="build", when="@2.51:")
+    depends_on("cmake@3.23:", type="build", when="@2.50")
     depends_on("cmake@3.17:", type="build", when="@:2.49")
     depends_on("mpi")
     depends_on("hdf5")


### PR DESCRIPTION
Add mapl@2.50.3 through 2.53.0 (cherry-picked from spack develop). For testing, see https://github.com/JCSDA/spack-stack/pull/1470