### PR TITLE
For release/1.9.0: cherry-pick updates from spack-stack-dev as of 2025/01/29

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -68,22 +68,9 @@ class ParallelNetcdf(AutotoolsPackage):
 
     depends_on("perl", type="build")
 
-    # Suport for shared libraries was introduced in version 1.9.0
-    conflicts("+shared", when="@:1.8")
-    conflicts("+burstbuffer", when="@:1.10")
-
-    # Before 1.10.0, C utility programs (e.g. ncmpigen) were linked without
-    # explicit specification of the Fortran runtime libraries, which is
-    # required when libpnetcdf.so contains Fortran symbols. Libtool sets the
-    # required linking flags implicitly but only if the Fortran compiler
-    # produces verbose output with the '-v' flag (and, due to a bug in Libtool,
-    # when CXX is not set to 'no'; see macro _LT_LANG_FC_CONFIG in libtool.m4
-    # for more details). The latter is not the case for NAG. Starting 1.10.0,
-    # the required linking flags are explicitly set in the makefiles and
-    # detected using macro AC_FC_LIBRARY_LDFLAGS, which means that we can
-    # override the verbose output flag for Fortran compiler on the command line
-    # (see below).
-    conflicts("+shared", when="@:1.9%nag+fortran")
+    # https://github.com/JCSDA/spack-stack/issues/1436
+    patch("parallel-netcdf-1.12.3-intel-irc-intlc.patch", when="@1.12.3 %intel")
+    patch("parallel-netcdf-1.12.3-intel-irc-intlc.patch", when="@1.12.3 %oneapi")
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -37,17 +37,22 @@ class ParallelNetcdf(AutotoolsPackage):
 
     version("master", branch="master")
     version("1.12.3", sha256="439e359d09bb93d0e58a6e3f928f39c2eae965b6c97f64e67cd42220d6034f77")
-    version("1.12.2", sha256="3ef1411875b07955f519a5b03278c31e566976357ddfc74c2493a1076e7d7c74")
-    version("1.12.1", sha256="56f5afaa0ddc256791c405719b6436a83b92dcd5be37fe860dea103aee8250a2")
-    version("1.11.2", sha256="d2c18601b364c35b5acb0a0b46cd6e14cae456e0eb854e5c789cf65f3cd6a2a7")
-    version("1.11.1", sha256="0c587b707835255126a23c104c66c9614be174843b85b897b3772a590be45779")
-    version("1.11.0", sha256="a18a1a43e6c4fd7ef5827dbe90e9dcf1363b758f513af1f1356ed6c651195a9f")
-    version("1.10.0", sha256="ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09")
-    version("1.9.0", sha256="356e1e1fae14bc6c4236ec11435cfea0ff6bde2591531a4a329f9508a01fbe98")
-    version("1.8.1", sha256="8d7d4c9c7b39bb1cbbcf087e0d726551c50f0cc30d44aed3df63daf3772c9043")
-    version("1.8.0", sha256="ac00bb2333bee96354de9d9c32d3dfdaa919d878098762f146996578b7f0ede9")
-    version("1.7.0", sha256="52f0d106c470a843c6176318141f74a21e6ece3f70ee8fe261c6b93e35f70a94")
-    version("1.6.1", sha256="8cf1af7b640475e3cc931e5fbcfe52484c5055f2fab526691933c02eda388aae")
+    with default_args(deprecated=True):
+        version(
+            "1.12.2", sha256="3ef1411875b07955f519a5b03278c31e566976357ddfc74c2493a1076e7d7c74"
+        )
+        version(
+            "1.12.1", sha256="56f5afaa0ddc256791c405719b6436a83b92dcd5be37fe860dea103aee8250a2"
+        )
+        version(
+            "1.11.2", sha256="d2c18601b364c35b5acb0a0b46cd6e14cae456e0eb854e5c789cf65f3cd6a2a7"
+        )
+        version(
+            "1.11.1", sha256="0c587b707835255126a23c104c66c9614be174843b85b897b3772a590be45779"
+        )
+        version(
+            "1.11.0", sha256="a18a1a43e6c4fd7ef5827dbe90e9dcf1363b758f513af1f1356ed6c651195a9f"
+        )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/builtin/packages/parallel-netcdf/parallel-netcdf-1.12.3-intel-irc-intlc.patch
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/parallel-netcdf-1.12.3-intel-irc-intlc.patch
@@ -1,0 +1,22 @@
+--- a/configure	2024-12-23 18:30:28.919868886 +0000
++++ b/configure	2024-12-23 18:34:25.317866633 +0000
+@@ -23603,6 +23603,9 @@
+ 	  ;;
+ 	-[lLR]*)
+ 	    ac_exists=false
++            if test x"$ac_arg" = x"-lirc"; then
++	      ac_arg="-lintlc"
++	    fi
+   for ac_i in $ac_cv_f77_libs; do
+     if test x"$ac_arg" = x"$ac_i"; then
+       ac_exists=true
+@@ -27343,6 +27346,9 @@
+ 	  ;;
+ 	-[lLR]*)
+ 	    ac_exists=false
++            if test x"$ac_arg" = x"-lirc"; then
++              ac_arg="-lintlc"
++            fi
+   for ac_i in $ac_cv_fc_libs; do
+     if test x"$ac_arg" = x"$ac_i"; then
+       ac_exists=true


### PR DESCRIPTION
For release/1.9.0, cherry-pick:
6b9525b3b64852812d7e2003e26e40a76cf87976
2b160a5c8c61ff707ac4e439e8092480e4927bec

For testing, see https://github.com/JCSDA/spack-stack/pull/1480