### PR TITLE
Add MET v12.0.0 and METplus v6.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -20,6 +20,7 @@ class Met(AutotoolsPackage):
     maintainers("AlexanderRichert-NOAA", "climbfuji")
 
     version("develop", branch="develop")
+    version("12.0.0", sha256="9a54275cfefbad6010d4449a8fa756ad40fae03fa62a766cbbfda170c422e5e4")
     version("11.1.1", sha256="d02f9281d46bc45c931ca233a51ce20ba2158c0dd26acac2cb76c5a68788022a")
     version("11.1.0", sha256="e2e371ae1f49185ff8bf08201b1a3e90864a467aa3369b04132d231213c3c9e5")
     version("11.0.2", sha256="f720d15e1d6c235c9a41fd97dbeb0eb1082fb8ae99e1bcdcb5e51be9b50bdfbf")

--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -44,6 +44,7 @@ class Met(AutotoolsPackage):
 
     depends_on("gsl")
     depends_on("bufr")
+    depends_on("proj", when="@12")
     depends_on("zlib-api")
     depends_on("netcdf-c")
     depends_on("netcdf-cxx4")

--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -20,6 +20,7 @@ class Met(AutotoolsPackage):
     maintainers("AlexanderRichert-NOAA", "climbfuji")
 
     version("develop", branch="develop")
+    version("12.0.1", sha256="ef396a99ca6c2248855848cd194f9ceaf3b051fb5e8c01a0b0b2a00110b1fcfb")
     version("12.0.0", sha256="9a54275cfefbad6010d4449a8fa756ad40fae03fa62a766cbbfda170c422e5e4")
     version("11.1.1", sha256="d02f9281d46bc45c931ca233a51ce20ba2158c0dd26acac2cb76c5a68788022a")
     version("11.1.0", sha256="e2e371ae1f49185ff8bf08201b1a3e90864a467aa3369b04132d231213c3c9e5")

--- a/var/spack/repos/builtin/packages/metplus/package.py
+++ b/var/spack/repos/builtin/packages/metplus/package.py
@@ -19,6 +19,7 @@ class Metplus(Package):
     maintainers("AlexanderRichert-NOAA", "climbfuji")
 
     version("develop", branch="develop")
+    version("6.0.0", sha256="e9358aede2fd2abecd81806227de7b165d68fdf2fc9defcbba24df229461b155")
     version("5.1.0", sha256="e80df2d1059176a453b7991a9f123cb5a187cc7ba7f48a75313b92c7a0e68474")
     version("5.0.1", sha256="0e22b4f6791496551d99f68247d382b2af02c90b34c172a64c6f060e774bdced")
     version("5.0.0", sha256="59d519bd062559b4cece9f8672e2e282b200057bc77e2e0937414003d8f2dd50")

--- a/var/spack/repos/builtin/packages/metplus/package.py
+++ b/var/spack/repos/builtin/packages/metplus/package.py
@@ -35,10 +35,18 @@ class Metplus(Package):
     variant("makeplots", default=False, description="Enable MakePlots Wrapper.")
     variant("plotdataplane", default=False, description="Generate images from Postscript output.")
 
+    depends_on("python@3.10.4:", when="@6.0.0", type=("run"))
+    depends_on("met@12:+python", when="@6.0.0", type=("run"))
     depends_on("met+python", type=("run"))
+    # https://metplus.readthedocs.io/en/main_v6.0/Users_Guide/installation.html
+    depends_on("netcdf-c@1.5.4:", when="@6.0.0")
+    depends_on("netcdf-c")
+    depends_on("py-python-dateutil@2.8:", when="@6.0.0", type=("run"))
     depends_on("py-python-dateutil", type=("run"))
 
+    depends_on("py-cartopy@0.20.3:", when="@6.0.0 +makeplots", type=("run"))
     depends_on("py-cartopy", when="+makeplots", type=("run"))
+    depends_on("py-matplotlib@3.5.2", when="@6.0.0 +cycloneplotter", type=("run"))
     depends_on("py-matplotlib", when="+cycloneplotter", type=("run"))
     depends_on("py-cartopy", when="+cycloneplotter", type=("run"))
 

--- a/var/spack/repos/builtin/packages/metplus/package.py
+++ b/var/spack/repos/builtin/packages/metplus/package.py
@@ -35,18 +35,18 @@ class Metplus(Package):
     variant("makeplots", default=False, description="Enable MakePlots Wrapper.")
     variant("plotdataplane", default=False, description="Generate images from Postscript output.")
 
-    depends_on("python@3.10.4:", when="@6.0.0", type=("run"))
-    depends_on("met@12:+python", when="@6.0.0", type=("run"))
+    depends_on("python@3.10.4:", when="@6:", type=("run"))
+    depends_on("met@12:+python", when="@6:", type=("run"))
     depends_on("met+python", type=("run"))
     # https://metplus.readthedocs.io/en/main_v6.0/Users_Guide/installation.html
-    depends_on("netcdf-c@1.5.4:", when="@6.0.0")
+    depends_on("netcdf-c@1.5.4:", when="@6:")
     depends_on("netcdf-c")
-    depends_on("py-python-dateutil@2.8:", when="@6.0.0", type=("run"))
+    depends_on("py-python-dateutil@2.8:", when="@6:", type=("run"))
     depends_on("py-python-dateutil", type=("run"))
 
-    depends_on("py-cartopy@0.20.3:", when="@6.0.0 +makeplots", type=("run"))
+    depends_on("py-cartopy@0.20.3:", when="@6: +makeplots", type=("run"))
     depends_on("py-cartopy", when="+makeplots", type=("run"))
-    depends_on("py-matplotlib@3.5.2", when="@6.0.0 +cycloneplotter", type=("run"))
+    depends_on("py-matplotlib@3.5.2", when="@6: +cycloneplotter", type=("run"))
     depends_on("py-matplotlib", when="+cycloneplotter", type=("run"))
     depends_on("py-cartopy", when="+cycloneplotter", type=("run"))
 


### PR DESCRIPTION
## Description

This PR adds `met@12.0.1` and `metplus@6.0.0`. Credits to @rickgrubin-noaa (cherry-picked add met@12 and metplus@6) for the original set of changes.

These new versions were tested by a NRL colleaguge using a spack-stack installation based on PR https://github.com/JCSDA/spack-stack/pull/1481 on Nautilus.