### PR TITLE
release/1.9.0: Fix bug in awcli-v2, add upper bound for py-cryptography

### DIFF
--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -23,9 +23,7 @@ class AwscliV2(PythonPackage):
         depends_on("py-flit-core@3.7.1:3.8.0")
         depends_on("py-colorama@0.2.5:0.4.6")
         depends_on("py-docutils@0.10:0.19")
-        # Remove upper bound to enable Python 3.12 support
-        # depends_on("py-cryptography@3.3.2:40.0.1")
-        depends_on("py-cryptography@3.3.2:")
+        depends_on("py-cryptography@3.3.2:40.0.1")
         depends_on("py-ruamel-yaml@0.15:0.17.21")
         depends_on("py-ruamel-yaml-clib@0.2:0.2.7", when="^python@:3.9")
         depends_on("py-prompt-toolkit@3.0.24:3.0.38")


### PR DESCRIPTION
In var/spack/repos/builtin/packages/awscli-v2/package.py, add back in upper bound for py-cryptography. This matches the logic of awscli-v2 in spack develop, see: https://github.com/spack/spack/blame/e1b579a8b491b01579a24e18e520c27e7089f24f/var/spack/repos/builtin/packages/awscli-v2/package.py#L29C9-L29C66.

We don't need to worry about Python 3.12 for this version 2.15 of awscli-v2 anyway, NS newer versions of awscli-v2 will be available in the next release when we pull in spack develop, opening the door to move to Python 3.12 if we want to.

This fixes the following bug reported by @xian22:
```
(venv) christian@boxie:~$ create_experiment.py skylab/experiments/gfs-3dfgat-c12.yaml --no-submit
/home/christian/skylab/skylabCDA/venv/bin/create_experiment.py:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('ewok==0.8.0')
Traceback (most recent call last):
  File "/home/christian/spack-stack-1.9.0/envs/unified-env.mylinux/install/gcc/12.2.0/py-setuptools-69.2.0-rv2nvbs/lib/python3.11/site-packages/pkg_resources/__init__.py", line 600, in _build_master
    ws.require(__requires__)
  File "/home/christian/spack-stack-1.9.0/envs/unified-env.mylinux/install/gcc/12.2.0/py-setuptools-69.2.0-rv2nvbs/lib/python3.11/site-packages/pkg_resources/__init__.py", line 937, in require
    needed = self.resolve(parse_requirements(requirements))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/christian/spack-stack-1.9.0/envs/unified-env.mylinux/install/gcc/12.2.0/py-setuptools-69.2.0-rv2nvbs/lib/python3.11/site-packages/pkg_resources/__init__.py", line 798, in resolve
    dist = self._resolve_dist(
           ^^^^^^^^^^^^^^^^^^^
  File "/home/christian/spack-stack-1.9.0/envs/unified-env.mylinux/install/gcc/12.2.0/py-setuptools-69.2.0-rv2nvbs/lib/python3.11/site-packages/pkg_resources/__init__.py", line 844, in _resolve_dist
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (cryptography 42.0.8 (/home/christian/spack-stack-1.9.0/envs/unified-env.mylinux/install/gcc/12.2.0/py-cryptography-42.0.8-7s5dqkl/lib/python3.11/site-packages), Requirement.parse('cryptography<40.0.2,>=3.3.2'), {'awscli'})
```