### PR TITLE
release/1.9.0: Bug fix in wgrib2: apply '-Wno-error=implicit-function-declaration' for LLVM clang

### DIFF
--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -189,7 +189,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     # Use Spack compiler wrapper flags
     def inject_flags(self, name, flags):
         if name == "cflags":
-            if self.spec.compiler.name == "apple-clang":
+            if self.spec.compiler.name in ["apple-clang", "clang"]:
                 flags.append("-Wno-error=implicit-function-declaration")
 
             # When mixing Clang/gfortran need to link to -lgfortran


### PR DESCRIPTION
Bug fix in `wgrib2`: apply `-Wno-error=implicit-function-declaration` for compiler name `apple-clang` and `clang`.

This PR is needed for building with LLVM clang (i.e. on Linux), not just for macOS clang.

This is part of https://github.com/JCSDA/spack-stack/pull/1486