### PR TITLE
Update package.py

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -53,7 +53,7 @@ class Crtm(CMakePackage):
     license("CC0-1.0")
 
     version(
-        "v3.1.1-build1", sha256="1ed49e594da5d3769cbaa52cc7fc19c1bb0325ee6324f6057227c31e2d95ca67"
+        "3.1.1-build1", sha256="1ed49e594da5d3769cbaa52cc7fc19c1bb0325ee6324f6057227c31e2d95ca67"
     )
     version(
         "v3.1.0-skylabv8",


### PR DESCRIPTION
@climbfuji this has to change anyway so that the crtm-fix dependency works correctly... So let's just go with the v-less version number.