### PR TITLE
Update py-arch, py-statsmodels (add 0.14.1), py-patsy (add 0.5.4) to be able to use py-cython@3 (spack develop #48769)

### DIFF
--- a/var/spack/repos/builtin/packages/py-arch/package.py
+++ b/var/spack/repos/builtin/packages/py-arch/package.py
@@ -32,7 +32,7 @@ class PyArch(PythonPackage):
     # "numpy>=2.0.0rc1,<3" ???
     # https://github.com/bashtage/arch/blob/9ced09e2566c0ebcad962d2441b1e79e2aaa7c9f/requirements.txt#L1
     # numpy>=1.22.3 ???
-    depends_on("py-numpy@1.22.3", type=("build", "run"))
+    depends_on("py-numpy@1.22.3:", type=("build", "run"))
 
     depends_on("py-scipy@1.8:", type="run")
     depends_on("py-pandas@1.4:", type="run")

--- a/var/spack/repos/builtin/packages/py-patsy/package.py
+++ b/var/spack/repos/builtin/packages/py-patsy/package.py
@@ -16,6 +16,7 @@ class PyPatsy(PythonPackage):
 
     license("PSF-2.0")
 
+    version("0.5.4", sha256="7dabc527597308de0e8f188faa20af7e06a89bdaa306756dfc7783693ea16af4")
     version("0.5.3", sha256="bdc18001875e319bc91c812c1eb6a10be4bb13cb81eb763f466179dca3b67277")
     version("0.5.2", sha256="5053de7804676aba62783dbb0f23a2b3d74e35e5bfa238b88b7cbf148a38b69d")
     version("0.5.1", sha256="f115cec4201e1465cd58b9866b0b0e7b941caafec129869057405bfe5b5e3991")

--- a/var/spack/repos/builtin/packages/py-patsy/package.py
+++ b/var/spack/repos/builtin/packages/py-patsy/package.py
@@ -14,6 +14,8 @@ class PyPatsy(PythonPackage):
     homepage = "https://github.com/pydata/patsy"
     pypi = "patsy/patsy-0.5.2.tar.gz"
 
+    maintainers("climbfuji")
+
     license("PSF-2.0")
 
     version("0.5.4", sha256="7dabc527597308de0e8f188faa20af7e06a89bdaa306756dfc7783693ea16af4")

--- a/var/spack/repos/builtin/packages/py-statsmodels/package.py
+++ b/var/spack/repos/builtin/packages/py-statsmodels/package.py
@@ -16,6 +16,8 @@ class PyStatsmodels(PythonPackage):
     pypi = "statsmodels/statsmodels-0.8.0.tar.gz"
     git = "https://github.com/statsmodels/statsmodels.git"
 
+    maintainers("climbfuji")
+
     license("BSD-3-Clause")
 
     version("0.14.1", sha256="2260efdc1ef89f39c670a0bd8151b1d0843567781bcafec6cda0534eb47a94f6")
@@ -55,8 +57,8 @@ class PyStatsmodels(PythonPackage):
     #    https://github.com/pydata/patsy/pull/131
 
     # requirements.txt
-    depends_on("py-numpy@1.22.3:", when="@0.14.1:", type=("build", "link", "run"))
-    depends_on("py-numpy@1.18:", when="@0.14:", type=("build", "link", "run"))
+    depends_on("py-numpy@1.22.3:1", when="@0.14.1:", type=("build", "link", "run"))
+    depends_on("py-numpy@1.18:1", when="@0.14:", type=("build", "link", "run"))
     depends_on("py-numpy@1.17:", when="@0.13:", type=("build", "link", "run"))
     depends_on("py-numpy@1.15:", when="@0.12.1:", type=("build", "link", "run"))
     depends_on("py-numpy@1.11:", when="@0.10.1:", type=("build", "link", "run"))

--- a/var/spack/repos/builtin/packages/py-statsmodels/package.py
+++ b/var/spack/repos/builtin/packages/py-statsmodels/package.py
@@ -18,6 +18,7 @@ class PyStatsmodels(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.14.1", sha256="2260efdc1ef89f39c670a0bd8151b1d0843567781bcafec6cda0534eb47a94f6")
     version("0.14.0", sha256="6875c7d689e966d948f15eb816ab5616f4928706b180cf470fd5907ab6f647a4")
     version("0.13.5", sha256="593526acae1c0fda0ea6c48439f67c3943094c542fe769f8b90fe9e6c6cc4871")
     version("0.13.2", sha256="77dc292c9939c036a476f1770f9d08976b05437daa229928da73231147cde7d4")
@@ -34,22 +35,27 @@ class PyStatsmodels(PythonPackage):
     depends_on("python@3.8:", when="@0.14:", type=("build", "link", "run"))
     depends_on("python", type=("build", "link", "run"))
 
+    depends_on("py-setuptools@69.0.2:", when="@0.14.1: ^python@3.12:", type="build")
+    depends_on("py-setuptools@63.4.3:", when="@0.14.1:", type="build")
     depends_on("py-setuptools@59.2:", when="@0.13.3:", type="build")
     depends_on("py-setuptools@0.6c5:", type="build")
 
     # pyproject.toml
-    depends_on("py-cython@0.29.26:2", when="@0.14:", type="build")
+    depends_on("py-cython@0.29.33:3", when="@0.14.1", type="build")
+    depends_on("py-cython@0.29.26:2", when="@0.14.0", type="build")
     depends_on("py-cython@0.29.32:2", when="@0.13.5:0.13", type="build")
-    depends_on("py-cython@0.29.22:2", when="@0.13:", type="build")
-    depends_on("py-cython@0.29.14:2", when="@0.12:", type="build")
-    depends_on("py-cython@0.29:2", type="build")
-    depends_on("py-setuptools-scm+toml@7.0", when="@0.13.3:", type="build")
+    depends_on("py-cython@0.29.22:2", when="@0.13:0.13.4", type="build")
+    depends_on("py-cython@0.29.14:2", when="@0.12", type="build")
+    depends_on("py-cython@0.29:2", when="@:0.11", type="build")
+    depends_on("py-setuptools-scm+toml@8", when="@0.14.1:", type="build")
+    depends_on("py-setuptools-scm+toml@7.0", when="@0.13.3:0.14.0", type="build")
 
     # patsy@0.5.1 works around a Python change
     #    https://github.com/statsmodels/statsmodels/issues/5343 and
     #    https://github.com/pydata/patsy/pull/131
 
     # requirements.txt
+    depends_on("py-numpy@1.22.3:", when="@0.14.1:", type=("build", "link", "run"))
     depends_on("py-numpy@1.18:", when="@0.14:", type=("build", "link", "run"))
     depends_on("py-numpy@1.17:", when="@0.13:", type=("build", "link", "run"))
     depends_on("py-numpy@1.15:", when="@0.12.1:", type=("build", "link", "run"))
@@ -57,14 +63,16 @@ class PyStatsmodels(PythonPackage):
     # https://github.com/statsmodels/statsmodels/issues/9194
     depends_on("py-numpy@:1", when="@:0.14.1", type=("build", "link", "run"))
     depends_on("py-scipy@1.4:", when="@0.13.5:", type=("build", "run"))
-    conflicts("^py-scipy@1.9.2")
+    conflicts("^py-scipy@1.9.2", when="@:0.14.1")
     depends_on("py-scipy@1.3:", when="@0.13:", type=("build", "run"))
     depends_on("py-scipy@1.2:", when="@0.12:", type=("build", "run"))
     depends_on("py-scipy@0.18:", when="@0.10.1:", type=("build", "run"))
     depends_on("py-pandas@1:", when="@0.14:", type=("build", "run"))
+    conflicts("^py-scipy@2.1.0", when="@:0.14.1")
     depends_on("py-pandas@0.25:", when="@0.13:", type=("build", "run"))
     depends_on("py-pandas@0.23:", when="@0.12:", type=("build", "run"))
     depends_on("py-pandas@0.19:", when="@0.10.1:", type=("build", "run"))
+    depends_on("py-patsy@0.5.4:", when="@0.14.1:", type=("build", "run"))
     depends_on("py-patsy@0.5.2:", when="@0.13:", type=("build", "run"))
     depends_on("py-patsy@0.5.1:", when="@0.12:", type=("build", "run"))
     depends_on("py-patsy@0.4:", when="@0.10.1:", type=("build", "run"))


### PR DESCRIPTION
## Description


This PR is a cherry-pick of https://github.com/spack/spack/pull/48769 and contains the following changes. These allow us to build `py-arch` and all its dependencies with `py-cython@3`:
- [Correct py-numpy dependency in py-arch](https://github.com/spack/spack/commit/732ff445d042166a512d5389e90c0a77a431471e)
- [Add py-statsmodels@0.14.1 and update dependencies](https://github.com/spack/spack/commit/979cb65161ed1d4bd813a1735a72a9d579e090d5)
- [Add py-patsy@0.5.4](https://github.com/spack/spack/commit/019836036b34e1350b8c3670f29e63edcc3c7cfe)

For testing with spack-stack, see https://github.com/JCSDA/spack-stack/pull/1500