### PR TITLE
Add rust-bootstrap variant to py-maturin and py-rpds-py

### DIFF
--- a/var/spack/repos/builtin/packages/py-maturin/package.py
+++ b/var/spack/repos/builtin/packages/py-maturin/package.py
@@ -25,6 +25,8 @@ class PyMaturin(PythonPackage):
     version("0.14.17", sha256="fb4e3311e8ce707843235fbe8748a05a3ae166c3efd6d2aa335b53dfc2bd3b88")
     version("0.13.7", sha256="c0a77aa0c57f945649ca711c806203a1b6888ad49c2b8b85196ffdcf0421db77")
 
+    variant("rust_bootstrap", default=False, when="@0.13.3:", description="Use pre-compiled Rust")
+
     with default_args(type="build"):
         depends_on("py-setuptools")
         depends_on("py-wheel@0.36.2:")
@@ -32,13 +34,15 @@ class PyMaturin(PythonPackage):
 
     with default_args(type=("build", "run")):
         depends_on("py-tomli@1.1:", when="^python@:3.10")
-        for rust, maturin in [
-            ("1.70", "1.5.0"),
-            ("1.64", "1.0.0"),
-            ("1.62", "0.14.3"),
-            ("1.59", "0.13.3"),
-        ]:
-            depends_on(f"rust@{rust}:", when=f"@{maturin}:")
+        with when("~rust_bootstrap"):
+            for rust, maturin in [
+                ("1.70", "1.5.0"),
+                ("1.64", "1.0.0"),
+                ("1.62", "0.14.3"),
+                ("1.59", "0.13.3"),
+            ]:
+                depends_on(f"rust@{rust}:", when=f"@{maturin}:")
+        depends_on("rust-bootstrap", when="+rust_bootstrap")
 
     # May be an accidental dependency, remove in the future
     # https://git.alpinelinux.org/aports/commit/?id=7ad298b467403b96a6b97d050170e367f147a75f

--- a/var/spack/repos/builtin/packages/py-rpds-py/package.py
+++ b/var/spack/repos/builtin/packages/py-rpds-py/package.py
@@ -19,6 +19,9 @@ class PyRpdsPy(PythonPackage):
     version("0.20.0", sha256="d72a210824facfdaf8768cf2d7ca25a042c30320b3020de2fa04640920d4e121")
     version("0.18.1", sha256="dc48b479d540770c811fbd1eb9ba2bb66951863e448efec2e2c102625328e92f")
 
-    depends_on("rust@1.76:", when="@0.19:")
+    variant("rust_bootstrap", default=False, when="@0.19:", description="Use pre-compiled Rust")
+
+    depends_on("rust@1.76:", when="@0.19: ~rust_bootstrap")
+    depends_on("rust-bootstrap", when="@0.19: +rust_bootstrap")
     depends_on("py-maturin@1.0:1", type="build")
     depends_on("py-maturin@1.2:", type="build", when="@0.20:")


### PR DESCRIPTION
## Description

This PR adds a rust-bootstrap variant to py-maturin and py-rpds-py to avoid a dependency on the full rust package.

See upstream spack PR https://github.com/spack/spack/pull/49046 for more information.

See https://github.com/JCSDA/spack-stack/pull/1519 for testing in spack-stack.
