### PR TITLE
release/1.9.0: bug fixes for fckit (disable finalization of DDTs) and ectrans (disable use of Fortran contiguous keyword)

### DIFF
--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -77,5 +77,10 @@ class Ectrans(CMakePackage):
             self.define_from_variant("ENABLE_FFTW", "fftw"),
             self.define_from_variant("ENABLE_MKL", "mkl"),
             self.define_from_variant("ENABLE_TRANSI", "transi"),
+            # Turn off use of contiguous keyword in Fortran because a number
+            # of compilers have issues with it, and the hardcoded list of "bad"
+            # compilers in ectrans is incomplete and isn't kept up to date
+            # TODO ADD LINK TO ECTRANS ISSUE HERE
+            "-DECTRANS_HAVE_CONTIGUOUS_ISSUE",
         ]
         return args

--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -80,7 +80,7 @@ class Ectrans(CMakePackage):
             # Turn off use of contiguous keyword in Fortran because a number
             # of compilers have issues with it, and the hardcoded list of "bad"
             # compilers in ectrans is incomplete and isn't kept up to date
-            # TODO ADD LINK TO ECTRANS ISSUE HERE
+            # https://github.com/JCSDA/spack-stack/issues/1522
             "-DECTRANS_HAVE_CONTIGUOUS_ISSUE",
         ]
         return args

--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -81,6 +81,6 @@ class Ectrans(CMakePackage):
             # of compilers have issues with it, and the hardcoded list of "bad"
             # compilers in ectrans is incomplete and isn't kept up to date
             # https://github.com/JCSDA/spack-stack/issues/1522
-            "-DECTRANS_HAVE_CONTIGUOUS_ISSUE",
+            "-DECTRANS_HAVE_CONTIGUOUS_ISSUE=ON",
         ]
         return args

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -51,17 +51,6 @@ class Fckit(CMakePackage):
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant("shared", default=True, description="Build shared libraries")
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
-    variant(
-        "finalize_ddts",
-        default="auto",
-        description="Enable / disable automatic finalization of derived types",
-        values=("auto", "no", "yes"),
-    )
-
-    # fckit fails to auto-detect/switch off finalization
-    # of derived types for latest Intel compilers. If set
-    # to auto, turn off in cmake_args. If set to yes, abort.
-    conflicts("%intel@2021.8:", when="finalize_ddts=yes")
 
     def cmake_args(self):
         args = [
@@ -73,11 +62,10 @@ class Fckit(CMakePackage):
         if self.spec.satisfies("~shared"):
             args.append("-DBUILD_SHARED_LIBS=OFF")
 
-        if "finalize_ddts=auto" not in self.spec:
-            args.append(self.define_from_variant("ENABLE_FINAL", "finalize_ddts"))
-        elif "finalize_ddts=auto" in self.spec and self.spec.satisfies("%intel@2021.8:"):
-            # See comment above (conflicts for finalize_ddts)
-            args.append("-DENABLE_FINAL=OFF")
+        # Turn off finalization of derived data types (DDTs) because it is
+        # flaky and we can't rely on fckit to auto-detect if the compiler
+        # supports the feature or not. TODO ADD LINK TO FCKIT ISSUE HERE
+        args.append("-DENABLE_FINAL=OFF")
 
         if (
             self.spec.satisfies("%intel")

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -64,7 +64,8 @@ class Fckit(CMakePackage):
 
         # Turn off finalization of derived data types (DDTs) because it is
         # flaky and we can't rely on fckit to auto-detect if the compiler
-        # supports the feature or not. TODO ADD LINK TO FCKIT ISSUE HERE
+        # supports the feature or not.
+        # https://github.com/JCSDA/spack-stack/issues/1521
         args.append("-DENABLE_FINAL=OFF")
 
         if (


### PR DESCRIPTION
## Description

All in the title.

Working towards https://github.com/JCSDA/spack-stack/issues/1521
Working towards https://github.com/JCSDA/spack-stack/issues/1522

See https://github.com/spack/spack/pull/49111 for the upstream PR for spack develop

For testing with spack-stack, see https://github.com/JCSDA/spack-stack/pull/1523