### PR TITLE
wgrib2: add version 3.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -57,6 +57,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     )
 
     version("develop", branch="develop")
+    version("3.6.0", sha256="55913cb58f2b329759de17f5a84dd97ad1844d7a93956d245ec94f4264d802be")
     version("3.5.0", sha256="b27b48228442a08bddc3d511d0c6335afca47252ae9f0e41ef6948f804afa3a1")
     version("3.4.0", sha256="ecbce2209c09bd63f1bca824f58a60aa89db6762603bda7d7d3fa2148b4a0536")
     version("3.3.0", sha256="010827fba9c31f05807e02375240950927e9e51379e1444388153284f08f58e2")

--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -45,8 +45,8 @@ class Wgrib2(MakefilePackage, CMakePackage):
     """Utility for interacting with GRIB2 files"""
 
     homepage = "https://www.cpc.ncep.noaa.gov/products/wesley/wgrib2"
-    url = "https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz.v2.0.8"
-    git = "https://github.com/NOAA-EMC/wgrib2"
+    url = "https://github.com/NOAA-EMC/wgrib2/archive/refs/tags/v3.5.0.tar.gz"
+    git = "https://github.com/NOAA-EMC/wgrib2.git"
 
     maintainers(
         "AlysonStahl-NOAA", "t-brown", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett"
@@ -81,6 +81,9 @@ class Wgrib2(MakefilePackage, CMakePackage):
         sha256="d7f1a4f9872922c62b3c7818c022465532cca1f5666b75d3ac5735f0b2747793",
         extension="tar.gz",
     )
+
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     def url_for_version(self, version):
         if version >= Version("3.2.0"):


### PR DESCRIPTION
This PR pulls down changes for wgrib2 from main spack and adds v3.6.0.

Addresses https://github.com/JCSDA/spack-stack/issues/1515