### PR TITLE
netcdf-{c,fortran}: add parallel testing variants

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -145,6 +145,8 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     variant("szip", default=True, description="Enable Szip compression plugin")
     variant("blosc", default=True, description="Enable Blosc compression plugin")
     variant("zstd", default=True, description="Enable Zstandard compression plugin")
+    # JCSDA fork only:
+    variant("parallel_tests", default=False, description="Run parallel tests", when="+mpi")
 
     with when("build_system=cmake"):
         # Based on the versions required by the root CMakeLists.txt:
@@ -398,6 +400,10 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
             "--enable-netcdf-4",
         ]
 
+        # JCSDA fork only:
+        if self.spec.satisfies("+parallel_tests") and self.run_tests():
+            config_args.append("--enable-parallel-tests")
+
         # NCZarr was added in version 4.8.0 as an experimental feature and became a supported one
         # in version 4.8.1:
         if self.spec.satisfies("@4.8.1:"):
@@ -556,6 +562,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
     # It looks like the issues with running the tests in parallel were fixed around version 4.6.0
     # (see https://github.com/Unidata/netcdf-c/commit/812c2fd4d108cca927582c0d84049c0f271bb9e0):
     @when("@:4.5.0")
-    def check(self):
+    @run_after("install")
+    def install_check(self):
         # h5_test fails when run in parallel
         make("check", parallel=False)

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -401,7 +401,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
         ]
 
         # JCSDA fork only:
-        if self.spec.satisfies("+parallel_tests") and self.run_tests():
+        if self.spec.satisfies("+parallel_tests") and self.pkg.run_tests:
             config_args.append("--enable-parallel-tests")
 
         # NCZarr was added in version 4.8.0 as an experimental feature and became a supported one

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -563,6 +563,6 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
     # (see https://github.com/Unidata/netcdf-c/commit/812c2fd4d108cca927582c0d84049c0f271bb9e0):
     @when("@:4.5.0")
     @run_after("install")
-    def install_check(self):
+    def check(self):
         # h5_test fails when run in parallel
         make("check", parallel=False)

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -158,7 +158,7 @@ class NetcdfFortran(AutotoolsPackage):
         return config_args
 
     @run_after("install")
-    def install_check(self):
+    def check(self):
         make("check", parallel=self.spec.satisfies("@4.5:"))
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -38,6 +38,8 @@ class NetcdfFortran(AutotoolsPackage):
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")
     variant("shared", default=True, description="Enable shared library")
     variant("doc", default=False, description="Enable building docs")
+    # JCSDA fork only:
+    variant("parallel_tests", default=False, description="Enable parallel tests")
 
     depends_on("netcdf-c")
     depends_on("netcdf-c@4.7.4:", when="@4.5.3:")  # nc_def_var_szip required
@@ -130,12 +132,14 @@ class NetcdfFortran(AutotoolsPackage):
 
         netcdf_c_spec = self.spec["netcdf-c"]
         if "+mpi" in netcdf_c_spec or "+parallel-netcdf" in netcdf_c_spec:
-            # Prefixing with 'mpiexec -n 4' is not necessarily the correct way
-            # to launch MPI programs on a particular machine (e.g. 'srun -n 4'
-            # with additional arguments might be the right one). Therefore, we
-            # make sure the parallel tests are not launched at all (although it
-            # is the default behaviour currently):
-            config_args.append("--disable-parallel-tests")
+            # JCSDA fork only:
+            if self.spec.satisfies("+parallel_tests") and self.run_tests:
+                config_args.append("--enable-parallel-tests")
+                config_args.append("CC=%s" % self.spec["mpi"].mpicc)
+                config_args.append("FC=%s" % self.spec["mpi"].mpifc)
+                config_args.append("F77=%s" % self.spec["mpi"].mpifc)
+            else:
+                config_args.append("--disable-parallel-tests")
             if self.spec.satisfies("@4.5.0:4.5.2"):
                 # Versions from 4.5.0 to 4.5.2 check whether the Fortran MPI
                 # interface is available and fail the configuration if it is
@@ -153,7 +157,8 @@ class NetcdfFortran(AutotoolsPackage):
 
         return config_args
 
-    def check(self):
+    @run_after("install")
+    def install_check(self):
         make("check", parallel=self.spec.satisfies("@4.5:"))
 
     @run_after("install")


### PR DESCRIPTION
This PR adds a variant for enabling parallel testing for netcdf-c and netcdf-fortran. Note that it is disregarded if build-time tests are not being run anyway. The `run_after()`'s are related to https://github.com/spack/spack/issues/49200.