### PR TITLE
add g2c@2.1.0; patch to remove PkgConfig req

### DIFF
--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -95,7 +95,7 @@ class G2c(CMakePackage):
         env.set("G2C_INC", join_path(self.prefix, "include"))
 
     def patch(self):
-        filter_file("^(\s+find_package\(PkgConfig REQUIRED\))", r"#\1", "CMakeLists.txt")
+        filter_file(r"^(\s+find_package\(PkgConfig REQUIRED\))", r"#\1", "CMakeLists.txt")
 
     def check(self):
         with working_dir(self.builder.build_directory):

--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -18,6 +18,7 @@ class G2c(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("2.1.0", sha256="74e3ef381f0339dc181bc3afaa54c98f76257508375ff664d243d76825006605")
     version("2.0.0", sha256="39c23bf1219c60101548c8525e3a879c84119558f768081779d404a8caf4cec9")
     version("1.9.0", sha256="5554276e18bdcddf387a08c2dd23f9da310c6598905df6a2a244516c22ded9aa")
     version("1.8.0", sha256="4ce9f5a7cb0950699fe08ebc5a463ab4d09ef550c050391a319308a2494f971f")
@@ -92,6 +93,9 @@ class G2c(CMakePackage):
         lib = find_libraries("libg2c", root=self.prefix, shared=shared, recursive=True)
         env.set("G2C_LIB", lib[0])
         env.set("G2C_INC", join_path(self.prefix, "include"))
+
+    def patch(self):
+        filter_file("^(\s+find_package\(PkgConfig REQUIRED\))", r"#\1", "CMakeLists.txt")
 
     def check(self):
         with working_dir(self.builder.build_directory):


### PR DESCRIPTION
This PR updates the g2c recipe to include 2.1.0 (earlier versions fail building wgrib2 because of a missing function), and patches the CMakeLists.txt to avoid the (as far as I can tell unnecessary) check for PkgConfig.