### PR TITLE
crtm: softlink *cmake config files to usable path

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
+import os
+
 from spack.package import *
 
 
@@ -101,3 +104,10 @@ class Crtm(CMakePackage):
             filter_file(
                 "-fbacktrace", "-fbacktrace -ffree-line-length-none", "libsrc/CMakeLists.txt"
             )
+
+    @run_after("install")
+    @when("@3.1.1-build1")
+    def cmake_config_softlinks(self):
+        cmake_config_files = glob.glob(join_path(self.prefix, "cmake/crtm/*"))
+        for srcpath in cmake_config_files:
+            os.symlink(srcpath, join_path(self.prefix, "cmake", os.path.basename(srcpath)))


### PR DESCRIPTION
This PR adds a post-install patching function to the crtm recipe to soft link `<crtm root>/cmake/crtm/*cmake` to `<crtm root>/cmake/.`.

Addresses https://github.com/JCSDA/spack-stack/issues/1540