### PR TITLE
Fix bug in crtm for recently added cmake_config_softlinks patch

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -105,8 +105,8 @@ class Crtm(CMakePackage):
                 "-fbacktrace", "-fbacktrace -ffree-line-length-none", "libsrc/CMakeLists.txt"
             )
 
-    @run_after("install")
     @when("@3.1.1-build1")
+    @run_after("install")
     def cmake_config_softlinks(self):
         cmake_config_files = glob.glob(join_path(self.prefix, "cmake/crtm/*"))
         for srcpath in cmake_config_files:


### PR DESCRIPTION
## Description

For release/1.9.0: In `var/spack/repos/builtin/packages/crtm/package.py`, reverse `run_after` and `when` before `cmake_config_softlinks` (credits: @AlexanderRichert-NOAA)

This fixes the CI failures reported in https://github.com/JCSDA/spack-stack/issues/1540#issuecomment-2698531024, see https://github.com/JCSDA/spack-stack/pull/1537
