### PR TITLE
netcdf-{c,fortran}: run tests on run_tests, not run_after(install)

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -562,7 +562,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
     # It looks like the issues with running the tests in parallel were fixed around version 4.6.0
     # (see https://github.com/Unidata/netcdf-c/commit/812c2fd4d108cca927582c0d84049c0f271bb9e0):
     @when("@:4.5.0")
-    @run_after("install")
+    @on_package_attributes(run_tests=True)
     def check(self):
         # h5_test fails when run in parallel
         make("check", parallel=False)

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -561,8 +561,11 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
 
     # It looks like the issues with running the tests in parallel were fixed around version 4.6.0
     # (see https://github.com/Unidata/netcdf-c/commit/812c2fd4d108cca927582c0d84049c0f271bb9e0):
-    @when("@:4.5.0")
-    @on_package_attributes(run_tests=True)
-    def check(self):
+    @run_after("install")
+    def run_checks(self):
         # h5_test fails when run in parallel
-        make("check", parallel=False)
+        if self.pkg.run_tests:
+            make("check", parallel=self.spec.satisfies("@4.6:"))
+
+    def check(self):
+        pass

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -157,7 +157,7 @@ class NetcdfFortran(AutotoolsPackage):
 
         return config_args
 
-    @run_after("install")
+    @on_package_attributes(run_tests=True)
     def check(self):
         make("check", parallel=self.spec.satisfies("@4.5:"))
 

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -157,9 +157,13 @@ class NetcdfFortran(AutotoolsPackage):
 
         return config_args
 
+    @run_after("install")
     @on_package_attributes(run_tests=True)
-    def check(self):
+    def run_checks(self):
         make("check", parallel=self.spec.satisfies("@4.5:"))
+
+    def check(self):
+        pass
 
     @run_after("install")
     def cray_module_filenames(self):


### PR DESCRIPTION
This PR fixes the netcdf-c and netcdf-fortran test run conditions by checking `run_tests` in addition to `@run_after("install")` (which is still needed in order to have the test output get logged). It nullifies the `check()` function to prevent duplicate tests. I have confirmed on my personal machine that the tests only run with 'spack install --test'. These changes can be reverted or made nicer once https://github.com/spack/spack/issues/49200 is resolved.