### PR TITLE
Merge release/1.9.0 into spack-stack-dev

### DIFF
--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
+import os
+
 from spack.package import *
 
 
@@ -101,3 +104,10 @@ class Crtm(CMakePackage):
             filter_file(
                 "-fbacktrace", "-fbacktrace -ffree-line-length-none", "libsrc/CMakeLists.txt"
             )
+
+    @run_after("install")
+    @when("@3.1.1-build1")
+    def cmake_config_softlinks(self):
+        cmake_config_files = glob.glob(join_path(self.prefix, "cmake/crtm/*"))
+        for srcpath in cmake_config_files:
+            os.symlink(srcpath, join_path(self.prefix, "cmake", os.path.basename(srcpath)))

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -105,8 +105,8 @@ class Crtm(CMakePackage):
                 "-fbacktrace", "-fbacktrace -ffree-line-length-none", "libsrc/CMakeLists.txt"
             )
 
-    @run_after("install")
     @when("@3.1.1-build1")
+    @run_after("install")
     def cmake_config_softlinks(self):
         cmake_config_files = glob.glob(join_path(self.prefix, "cmake/crtm/*"))
         for srcpath in cmake_config_files:

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -174,6 +174,21 @@ class Eckit(CMakePackage):
             # (the LAPACK backend is still built though):
             args.append(self.define("ENABLE_LAPACK", "linalg=lapack" in self.spec))
 
+        if self.spec.satisfies("linalg=lapack"):
+            lapack_vendors = {
+                "amdlibflame": "AOCL",
+                "atlas": "ATLAS",
+                "essl": "IBMESSL",
+                "flexiblas": "FlexiBLAS",
+                "fujitsu-ssl2": "Fujitsu_SSL2",
+                "netlib-lapack": "Generic",
+                "nvhpc": "NVHPC",
+                "openblas": "OpenBLAS",
+            }
+            if self.spec["lapack"].name in lapack_vendors.keys():
+                vendor = lapack_vendors[self.spec["lapack"].name]
+                args.append(self.define("BLA_VENDOR", vendor))
+
         if "+admin" in self.spec and "+termlib" in self.spec["ncurses"]:
             # Make sure that libeckit_cmd is linked to a library that resolves 'setupterm',
             # 'tputs', etc. That is either libncurses (when 'ncurses~termlib') or libtinfo (when

--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -77,5 +77,10 @@ class Ectrans(CMakePackage):
             self.define_from_variant("ENABLE_FFTW", "fftw"),
             self.define_from_variant("ENABLE_MKL", "mkl"),
             self.define_from_variant("ENABLE_TRANSI", "transi"),
+            # Turn off use of contiguous keyword in Fortran because a number
+            # of compilers have issues with it, and the hardcoded list of "bad"
+            # compilers in ectrans is incomplete and isn't kept up to date
+            # https://github.com/JCSDA/spack-stack/issues/1522
+            "-DECTRANS_HAVE_CONTIGUOUS_ISSUE=ON",
         ]
         return args

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -51,17 +51,6 @@ class Fckit(CMakePackage):
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant("shared", default=True, description="Build shared libraries")
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
-    variant(
-        "finalize_ddts",
-        default="auto",
-        description="Enable / disable automatic finalization of derived types",
-        values=("auto", "no", "yes"),
-    )
-
-    # fckit fails to auto-detect/switch off finalization
-    # of derived types for latest Intel compilers. If set
-    # to auto, turn off in cmake_args. If set to yes, abort.
-    conflicts("%intel@2021.8:", when="finalize_ddts=yes")
 
     def cmake_args(self):
         args = [
@@ -73,11 +62,11 @@ class Fckit(CMakePackage):
         if self.spec.satisfies("~shared"):
             args.append("-DBUILD_SHARED_LIBS=OFF")
 
-        if "finalize_ddts=auto" not in self.spec:
-            args.append(self.define_from_variant("ENABLE_FINAL", "finalize_ddts"))
-        elif "finalize_ddts=auto" in self.spec and self.spec.satisfies("%intel@2021.8:"):
-            # See comment above (conflicts for finalize_ddts)
-            args.append("-DENABLE_FINAL=OFF")
+        # Turn off finalization of derived data types (DDTs) because it is
+        # flaky and we can't rely on fckit to auto-detect if the compiler
+        # supports the feature or not.
+        # https://github.com/JCSDA/spack-stack/issues/1521
+        args.append("-DENABLE_FINAL=OFF")
 
         if (
             self.spec.satisfies("%intel")

--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -18,6 +18,7 @@ class G2c(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("2.1.0", sha256="74e3ef381f0339dc181bc3afaa54c98f76257508375ff664d243d76825006605")
     version("2.0.0", sha256="39c23bf1219c60101548c8525e3a879c84119558f768081779d404a8caf4cec9")
     version("1.9.0", sha256="5554276e18bdcddf387a08c2dd23f9da310c6598905df6a2a244516c22ded9aa")
     version("1.8.0", sha256="4ce9f5a7cb0950699fe08ebc5a463ab4d09ef550c050391a319308a2494f971f")
@@ -92,6 +93,9 @@ class G2c(CMakePackage):
         lib = find_libraries("libg2c", root=self.prefix, shared=shared, recursive=True)
         env.set("G2C_LIB", lib[0])
         env.set("G2C_INC", join_path(self.prefix, "include"))
+
+    def patch(self):
+        filter_file(r"^(\s+find_package\(PkgConfig REQUIRED\))", r"#\1", "CMakeLists.txt")
 
     def check(self):
         with working_dir(self.builder.build_directory):

--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -57,6 +57,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     )
 
     version("develop", branch="develop")
+    version("3.6.0", sha256="55913cb58f2b329759de17f5a84dd97ad1844d7a93956d245ec94f4264d802be")
     version("3.5.0", sha256="b27b48228442a08bddc3d511d0c6335afca47252ae9f0e41ef6948f804afa3a1")
     version("3.4.0", sha256="ecbce2209c09bd63f1bca824f58a60aa89db6762603bda7d7d3fa2148b4a0536")
     version("3.3.0", sha256="010827fba9c31f05807e02375240950927e9e51379e1444388153284f08f58e2")

--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -45,8 +45,8 @@ class Wgrib2(MakefilePackage, CMakePackage):
     """Utility for interacting with GRIB2 files"""
 
     homepage = "https://www.cpc.ncep.noaa.gov/products/wesley/wgrib2"
-    url = "https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz.v2.0.8"
-    git = "https://github.com/NOAA-EMC/wgrib2"
+    url = "https://github.com/NOAA-EMC/wgrib2/archive/refs/tags/v3.5.0.tar.gz"
+    git = "https://github.com/NOAA-EMC/wgrib2.git"
 
     maintainers(
         "AlysonStahl-NOAA", "t-brown", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett"
@@ -81,6 +81,9 @@ class Wgrib2(MakefilePackage, CMakePackage):
         sha256="d7f1a4f9872922c62b3c7818c022465532cca1f5666b75d3ac5735f0b2747793",
         extension="tar.gz",
     )
+
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     def url_for_version(self, version):
         if version >= Version("3.2.0"):


### PR DESCRIPTION
## Description

Merge release/1.9.0 into spack-stack-dev. Conflicts that needed to be resolved (please doublecheck):
```
Unmerged paths:
  (use "git add <file>..." to mark resolution)
        both modified:   var/spack/repos/builtin/packages/crtm/package.py
```

## Testing

- [x]  CI
- [x] Corresponding spack-stack PR: https://github.com/JCSDA/spack-stack/pull/1572