### PR TITLE
NCEPLIBS testing-related updates

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -23,6 +23,7 @@ class Bufr(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA", "jbathegit")
 
     version("develop", branch="develop")
+    version("12.2.0", sha256="a0dad13b905f3e0311e2b50df47418660b47442dfc3843232712044b47f26a71")
     version("12.1.0", sha256="b5eae61b50d4132b2933b6e6dfc607e5392727cdc4f46ec7a94a19109d91dcf3")
     version("12.0.1", sha256="525f26238dba6511a453fc71cecc05f59e4800a603de2abbbbfb8cbb5adf5708")
     version("12.0.0", sha256="d01c02ea8e100e51fd150ff1c4a1192ca54538474acb1b7f7a36e8aeab76ee75")
@@ -57,6 +58,24 @@ class Bufr(CMakePackage):
 
     conflicts("%oneapi@:2024.1", msg="Requires oneapi 2024.2 or later")
 
+    resource(
+        name="testfiles",
+        url="https://ftp.emc.ncep.noaa.gov/static_files/public/bufr-12.2.0.tgz",
+        sha256="0ebc27f6260dc964d38c3966fb583e3ef68279a9879fc28cd4d923e2fc2ea42c",
+        when="@12.2:",
+        expand=False,
+        placement="testfiles",
+    )
+
+    resource(
+        name="testfiles",
+        url="https://ftp.emc.ncep.noaa.gov/static_files/public/bufr-12.1.0.tgz",
+        sha256="28024963cc855b85303def23f2c2c423d21545322c1eff54416229062fed013a",
+        when="@12.1",
+        expand=False,
+        placement="testfiles",
+    )
+
     def url_for_version(self, version):
         pre = "bufr_" if version < Version("12.0.1") else ""
         return (
@@ -75,10 +94,8 @@ class Bufr(CMakePackage):
             self.define("BUILD_TESTS", self.run_tests),
             self.define("BUILD_TESTING", self.run_tests),
             self.define_from_variant("BUILD_UTILS", "utils"),
+            self.define("TEST_FILE_DIR", join_path(self.stage.source_path, "testfiles")),
         ]
-
-        if not self.spec.satisfies("test_files=none"):
-            args.append(self.define_from_variant("TEST_FILE_DIR", "test_files"))
 
         return args
 
@@ -127,6 +144,10 @@ class Bufr(CMakePackage):
             suffixes += ["8", "d"]
         for suffix in suffixes:
             self._setup_bufr_environment(env, suffix)
+
+    @on_package_attributes(run_tests=True)
+    def setup_build_environment(self, env):
+        env.append_path("LD_LIBRARY_PATH", join_path(self.build_directory, "src"))
 
     def check(self):
         with working_dir(self.builder.build_directory):

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -111,5 +111,8 @@ class G2(CMakePackage):
             env.set("G2_INC" + suffix, join_path(self.prefix, "include_" + suffix))
 
     def check(self):
-        with working_dir(self.builder.build_directory):
-            make("test")
+        with working_dir(self.build_directory):
+            if self.spec.satisfies("%intel@:2022"):
+                ctest("--exclude-regex", "test_gribcreate_.")
+            else:
+                ctest()

--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -63,6 +63,8 @@ class Ip(CMakePackage):
         description="Build deprecated spectral interpolation functions",
         when="@5.0:",
     )
+    # JCSDA repo only:
+    variant("alltests", default=False, description="Run full unit test suite", when="@5.3:")
 
     conflicts("+shared ~pic")
 
@@ -74,12 +76,31 @@ class Ip(CMakePackage):
     depends_on("lapack", when="@5.1:")
     depends_on("cmake@3.18:", when="@5.1:", type="build")
 
+    # JCSDA repo only:
+    resource(
+        name="ip-test-data-20241230.tgz",
+        url="https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz",
+        sha256="3a33309f2451699c255717ffa60645f6c6862201a234b7bb77a340f5f5d345a8",
+        placement="testfiles",
+        expand=False,
+        when="+alltests",
+    )
+
     def cmake_args(self):
         args = [
             self.define_from_variant("OPENMP", "openmp"),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
-            self.define("FTP_TEST_FILES", self.run_tests),
         ]
+
+        # JCSDA repo only:
+        if self.spec.satisfies("+alltests"):
+            args.append(self.define("FTP_TEST_FILES", self.run_tests))
+            args.append(
+                self.define(
+                    "TEST_FILES_CACHE",
+                    join_path(self.stage.source_path, "testfiles/ip-test-data-20241230.tgz"),
+                )
+            )
 
         if self.spec.satisfies("@4:"):
             args.append(self.define("BUILD_TESTING", self.run_tests))
@@ -126,4 +147,8 @@ class Ip(CMakePackage):
     @when("@4:")
     def check(self):
         with working_dir(self.builder.build_directory):
-            make("test")
+            # JCSDA repo only; main Spack repo should just use `ctest("-L", "NO_INPUT_DATA")`
+            if self.spec.satisfies("+alltests") or self.spec.satisfies("@:5.2"):
+                ctest()
+            else:
+                ctest("-L", "NO_INPUT_DATA")

--- a/var/spack/repos/builtin/packages/wrf-io/package.py
+++ b/var/spack/repos/builtin/packages/wrf-io/package.py
@@ -33,3 +33,6 @@ class WrfIo(CMakePackage):
     def cmake_args(self):
         args = [self.define_from_variant("OPENMP", "openmp")]
         return args
+
+    def check(self):
+        make("test")


### PR DESCRIPTION
This PR adds testing-related updates for several packages. Everything that should be in main Spack has already been merged into develop and has been appropriately merged into this target branch.
 - ip: add resources for test files (these changes are for JCSDA repo only as they involve a testing-related variant)
 - bufr: create resources for test files
 - wrf-io: specify `make("test")` for `check()`
 - g2: skip one test that is failing an Acorn with both intel's (19 & 2022)

Part of https://github.com/JCSDA/spack-stack/issues/1581