### PR TITLE
Add esmf@8.9.0b05

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -495,6 +495,3 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             # build the python library
             python_builder = PythonPipBuilder(pkg)
             python_builder.install(pkg, spec, prefix)
-
-        if spec.satisfies("@8.9:"):
-            install_tree("cmake", self.prefix.cmake)

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -29,6 +29,7 @@ class Esmf(MakefilePackage, PythonExtension):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
+    version("8.9.0b05", commit="5df19ab277b4517a093af0510f08171c478ec627")
     version("8.8.0", sha256="f89327428aeef6ad34660b5b78f30d1c55ec67efb8f7df1991fdaa6b1eb3a27c")
     version("8.7.0", sha256="d7ab266e2af8c8b230721d4df59e61aa03c612a95cc39c07a2d5695746f21f56")
     version("8.6.1", sha256="dc270dcba1c0b317f5c9c6a32ab334cb79468dda283d1e395d98ed2a22866364")

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -495,3 +495,6 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             # build the python library
             python_builder = PythonPipBuilder(pkg)
             python_builder.install(pkg, spec, prefix)
+
+        if spec.satisfies("@8.9:"):
+            install_tree("cmake", self.prefix.cmake)


### PR DESCRIPTION
## Description

Add esmf@8.9.0b05 and install ESMF's `findESMF.cmake` starting from this version. The former is required for recent NEPTUNE development (ESMX integration), the latter to remove `findESMF.cmake` from `CMakeModules` and various other places in order to always use the authoritative `findESMF.cmake`. See also https://github.com/NOAA-EMC/CMakeModules/pull/71

## Testing

- [x] Built `esmf@8.9.0b05` on my dev machine and verified that a simple `CMakeLists.txt` change is picking up the correct `findESMF.cmake` file:
```
list(APPEND CMAKE_MODULE_PATH $ENV{esmf_ROOT}/cmake)
find_package(ESMF 8.9.0 MODULE REQUIRED)
```
- [ ] Testing in spack-stack and with NEPTUNE: See https://github.com/JCSDA/spack-stack/pull/1599