### PR TITLE
g2: re-add '.builder'

### DIFF
--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -111,7 +111,7 @@ class G2(CMakePackage):
             env.set("G2_INC" + suffix, join_path(self.prefix, "include_" + suffix))
 
     def check(self):
-        with working_dir(self.build_directory):
+        with working_dir(self.builder.build_directory):
             if self.spec.satisfies("%intel@:2022"):
                 ctest("--exclude-regex", "test_gribcreate_.")
             else:


### PR DESCRIPTION
I forgot that our Spack fork doesn't have some of the builder/build_directory changes, so I should have made this change when I updated the g2 recipe from main Spack. It (and various other recipes) will probably need to change back with a future Spack update, but at the moment this is breaking the weekly builds on Acorn.