### PR TITLE
Fix ip recipe ('.builder')

### DIFF
--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -145,7 +145,7 @@ class Ip(CMakePackage):
 
     @when("@4:")
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             # JCSDA repo only; main Spack repo should just use `ctest("-L", "NO_INPUT_DATA")`
             if self.spec.satisfies("+alltests") or self.spec.satisfies("@:5.2"):
                 ctest()


### PR DESCRIPTION
This PR fixes testing for the ip recipe by removing the deprecated '.builder' part of the build directory identifier. This isn't urgent, so I don't currently plan to add a separate pointer update for spack-stack.