### PR TITLE
LLVM 20 support: patch for esmf@8.9.0b08, add ip@5.4.0 / turn off unit tests with Python 3.7

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -30,10 +30,12 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         on_develop:
         - ${{ github.ref == 'refs/heads/develop' }}
-        include:
-        - python-version: '3.7'
-          os: ubuntu-22.04
-          on_develop: ${{ github.ref == 'refs/heads/develop' }}
+        # DH 20250516 Comment out, can;t find pytest despite being installed
+        # https://github.com/JCSDA/spack/actions/runs/15067902641/job/42361423838?pr=539
+        #include:
+        #- python-version: '3.7'
+        #  os: ubuntu-22.04
+        #  on_develop: ${{ github.ref == 'refs/heads/develop' }}
         exclude:
         - python-version: '3.8'
           os: ubuntu-latest

--- a/var/spack/repos/builtin/packages/esmf/esmf890b08llvm20.patch
+++ b/var/spack/repos/builtin/packages/esmf/esmf890b08llvm20.patch
@@ -1,0 +1,20 @@
+--- a/build_config/Linux.llvm.default/build_rules.mk
++++ b/build_config/Linux.llvm.default/build_rules.mk
+@@ -6,7 +6,7 @@
+ ############################################################
+ # Default compiler setting.
+ #
+-ESMF_F90DEFAULT         = flang
++ESMF_F90DEFAULT         = flang-new
+ ESMF_CXXDEFAULT         = clang++
+ ESMF_CDEFAULT           = clang
+ ESMF_CPPDEFAULT		= clang -E -P -x c
+@@ -239,7 +239,7 @@
+ ############################################################
+ # Link against libesmf.a using the C++ linker front-end
+ #
+-ESMF_CXXLINKLIBS += -lrt -lFortranDecimal -lflang_rt.runtime -lstdc++ -lm -ldl
++ESMF_CXXLINKLIBS += -lrt -lFortranRuntime -lFortranDecimal -lstdc++ -lm -ldl
+ 
+ ############################################################
+ # Linker option that ensures that the specified libraries are 

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -144,6 +144,10 @@ class Esmf(MakefilePackage, PythonExtension):
 
     conflicts("%aocc", when="@:8.3")
 
+    # Fix esmf@8.9.0b08 with llvm@20
+    # https://github.com/esmf-org/esmf/issues/411
+    patch("esmf890b08llvm20.patch", when="@8.9.0b08 %clang@20")
+
     # explicit type cast of variables from long to int
     patch("longtoint.patch", when="@:8.3.2 %cce@14:")
     patch("longtoint.patch", when="@:8.3.2 %oneapi@2022:")

--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -17,6 +17,7 @@ class Ip(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
 
     version("develop", branch="develop")
+    version("5.4.0", sha256="918b2cc425d5f1fa7378346cad2d16ad68b03b575adeb40b8b37a7dc3e876041")
     version("5.3.0", sha256="17dfcb52bab58d3f1bcbbdda5e76430020d963097139e1ba240bfc5fb5c5a5d1")
     version("5.2.0", sha256="2f7b44abcf24e448855f57d107db55d3d58cbc271164ba083491d0c07a7ea3d0")
     version("5.1.0", sha256="5279f11f4c12db68ece74cec392b7a2a6b5166bc505877289f34cc3149779619")


### PR DESCRIPTION
## Description

1. Turn off unit testing on Ubuntu 22.04 with Python 3.7 - it complains about `pytest` not being found, even though it is installed previously. I did some digging into differences with spack develop and couldn't find anything that would explain this. But spack develop isn't running Python 3.7 unit tests by default (only of the spack core engine code is changed), and a few days ago the LLNL developers did some troubleshooting on exactly this issue w/o a resolution (pull request closed as not merged). We do unit testing on macOS with Python 3.11, and on Ubuntu latest with Python 3.12, that should be sufficient.
2. Patch for ESMF 8.9.0b08 with LLVM 20. The bug has since been fixed and will be in the next beta snapshot of ESMF.
3. Add `ip@5.4.0` which supports LLFMFlang (earlier versions didn't).

## Testing

See https://github.com/JCSDA/spack-stack/pull/1644