### PR TITLE
Add odc@1.6.1

### DIFF
--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -15,6 +15,7 @@ class Odc(CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.6.1", sha256="4f403e6b0ef94c880a15f3a99369d32e7a0c9d2f751b9332f1f80f300a063679")
     version("1.5.2", sha256="49575c3ef9ae8825d588357022d0ff6caf3e557849888c9d2f0677e9efe95869")
     version("1.4.6", sha256="ff99d46175e6032ddd0bdaa3f6a5e2c4729d24b698ba0191a2a4aa418f48867c")
     version("1.4.5", sha256="8532d0453531d62e1f15791d1c5c96540b842913bd211a8ef090211eaf4cccae")
@@ -30,6 +31,9 @@ class Odc(CMakePackage):
     depends_on("cmake@3.12:", type="build")
 
     depends_on("eckit@1.4:+sql")
+
+    # https://github.com/ecmwf/odc/issues/37
+    conflicts("@:1.5", when="oneapi@2025.1:")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
## Description

Add `odc@1.6.1`, required for `oneapi@2025.1:`. See https://github.com/ecmwf/odc/issues/37.

## Testing

See https://github.com/JCSDA/spack-stack/pull/1644