### PR TITLE
Add esmf@8.9.0b09

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -31,6 +31,7 @@ class Esmf(MakefilePackage, PythonExtension):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
+    version("8.9.0b09", commit="7e8c4b2f21bbea6432a3dadd6e6a7e143b786193")
     version("8.9.0b08", commit="56e26fde7b4890ae44eb3efdf2f6728b5eb4627e")
     version("8.9.0b05", commit="5df19ab277b4517a093af0510f08171c478ec627")
     version("8.8.1", sha256="b0acb59d4f000bfbdfddc121a24819bd2a50997c7b257b0db2ceb96f3111b173")


### PR DESCRIPTION
## Description

All in the title.

The latest ESMF beta tag [v8.9.0b09](https://github.com/esmf-org/esmf/releases/tag/v8.9.0b09) provides the following features:
- Fixed build issue under LLVM 20. Now supporting LLVM versions 20 and 21.
- Fixed build failure under GCC 15.
- ESMX supporting dashes in user specified component name.
- ESMX correctly handling BUILD_TYPE "auto" for components with defined CMake target.
- ESMF_RUNTIME_GARBAGE option available for more control over ESMF garbage collection. This is useful when debugging memory leaks (e.g. with AddressSanitizer).

## Testing

See https://github.com/JCSDA/spack-stack/pull/1644