### PR TITLE
crtm-fix: correct endian_dirs logic

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -4,6 +4,8 @@
 
 import os
 
+from spack_repo.builtin.build_systems.generic import Package
+
 from spack.package import *
 
 
@@ -55,6 +57,7 @@ class CrtmFix(Package):
         for d in endian_dirs:
             fix_files = fix_files + find(".", "*/{}/*".format(d), recursive=False)
             fix_files = fix_files + find(".", "*/*/{}/*".format(d), recursive=False)
+            fix_files = fix_files + find(".", "*/*/*/{}/*".format(d), recursive=False)
         if self.spec.satisfies("~testfiles"):
             fix_files = [f for f in fix_files if "/fix/test_data/" not in f]
         fix_files = [f for f in fix_files if os.path.isfile(f)]
@@ -88,5 +91,5 @@ class CrtmFix(Package):
         for f in fix_files:
             install(f, self.prefix.fix)
 
-    def setup_run_environment(self, env):
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
         env.set("CRTM_FIX", self.prefix.fix)

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -4,8 +4,6 @@
 
 import os
 
-from spack_repo.builtin.build_systems.generic import Package
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -91,5 +91,5 @@ class CrtmFix(Package):
         for f in fix_files:
             install(f, self.prefix.fix)
 
-    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+    def setup_run_environment(self, env):
         env.set("CRTM_FIX", self.prefix.fix)


### PR DESCRIPTION
Pull in crtm-fix fix from main Spack.

Addresses #1642