### PR TITLE
Add variant shared-intel for met and parallel-netcdf (avoid linking to libirc.so)

### DIFF
--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -39,6 +39,9 @@ class Met(AutotoolsPackage):
     variant("modis", default=False, description="Enable compilation of modis")
     variant("graphics", default=False, description="Enable compilation of mode_graphics")
 
+    # JCSDA fork only
+    variant("shared-intel", default=False, when="%oneapi", description="Enable linking to shared intel libraries (libintlc instead of libirc)")
+
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
@@ -89,6 +92,8 @@ class Met(AutotoolsPackage):
     def setup_build_environment(self, env):
         spec = self.spec
         cppflags = []
+        fflags = []
+        fcflags = []
         ldflags = []
         libs = []
 
@@ -99,6 +104,10 @@ class Met(AutotoolsPackage):
         cppflags.append(netcdfcxx.libs.search_flags)
         ldflags.append(netcdfcxx.libs.ld_flags)
         libs.append(netcdfcxx.libs.link_flags)
+
+        if spec.satisfies("%oneapi") and spec.satisfies("+shared-intel"):
+            fflags.append("-shared-intel")
+            fcflags.append("-shared-intel")
 
         netcdfc = spec["netcdf-c"]
         if netcdfc.satisfies("+shared"):
@@ -166,6 +175,10 @@ class Met(AutotoolsPackage):
             env.set("MET_FREETYPE", freetype.prefix)
 
         env.set("CPPFLAGS", " ".join(cppflags))
+        if fflags:
+            env.set("FFLAGS", " ".join(fflags))
+        if fcflags:
+            env.set("FCFLAGS", " ".join(fcflags))
         env.set("LIBS", " ".join(libs))
         env.set("LDFLAGS", " ".join(ldflags))
 

--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -43,7 +43,7 @@ class Met(AutotoolsPackage):
     variant(
         "shared-intel",
         default=False,
-        when="@1.12.3 %oneapi",
+        when="%oneapi",
         description="Enable linking to shared intel libraries (libintlc instead of libirc)",
     )
 

--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -40,7 +40,12 @@ class Met(AutotoolsPackage):
     variant("graphics", default=False, description="Enable compilation of mode_graphics")
 
     # JCSDA fork only
-    variant("shared-intel", default=False, when="%oneapi", description="Enable linking to shared intel libraries (libintlc instead of libirc)")
+    variant(
+        "shared-intel",
+        default=False,
+        when="@1.12.3 %oneapi",
+        description="Enable linking to shared intel libraries (libintlc instead of libirc)",
+    )
 
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -65,6 +65,9 @@ class ParallelNetcdf(AutotoolsPackage):
     variant("examples", default=False, description="Install example programs")
     conflicts("+examples", when="@:1.12")
 
+    # JCSDA fork only
+    variant("shared-intel", default=False, when="@1.12.3 %oneapi", description="Enable linking to shared intel libraries (libintlc instead of libirc)")
+
     depends_on("mpi")
 
     depends_on("m4", type="build")
@@ -75,8 +78,7 @@ class ParallelNetcdf(AutotoolsPackage):
     depends_on("perl", type="build")
 
     # https://github.com/JCSDA/spack-stack/issues/1436
-    patch("parallel-netcdf-1.12.3-intel-irc-intlc.patch", when="@1.12.3 %intel")
-    patch("parallel-netcdf-1.12.3-intel-irc-intlc.patch", when="@1.12.3 %oneapi")
+    patch("parallel-netcdf-1.12.3-intel-irc-intlc.patch", when="@1.12.3 +shared-intel %oneapi")
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -66,7 +66,12 @@ class ParallelNetcdf(AutotoolsPackage):
     conflicts("+examples", when="@:1.12")
 
     # JCSDA fork only
-    variant("shared-intel", default=False, when="@1.12.3 %oneapi", description="Enable linking to shared intel libraries (libintlc instead of libirc)")
+    variant(
+        "shared-intel",
+        default=False,
+        when="@1.12.3 %oneapi",
+        description="Enable linking to shared intel libraries (libintlc instead of libirc)",
+    )
 
     depends_on("mpi")
 


### PR DESCRIPTION
## Description

This PR does the following:
- Adds a variant `shared-intel`, default `False`, for the oneAPI compilers to `met` to avoid linking to `libirc.so`.  This is required to fix the error in https://github.com/JCSDA/spack-stack/actions/runs/15167592640/job/42649358844?pr=1639

- Adds the same variant `shared-intel`, default `False`, to `parallel-netcdf` for the oneAPI compilers. This is instead of the current implementation that enforces the `shared-intel` behavior for Intel Classic and oneAPI.

These changes are for the JCSDA fork only, because we've gotten push back for the default version of the changes for parallel-netcdf (i.e. what we currently have in our spack for for parallel-netcdf) in spack develop.

See https://github.com/JCSDA/spack-stack/pull/1639 for more information.

## Testing

- [x]  CI
- [ ] See https://github.com/JCSDA/spack-stack/pull/1639
