### PR TITLE
WCOSS2/1.9.2(rc1) changes

### DIFF
--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -69,7 +69,7 @@ class Ecflow(CMakePackage):
 
     depends_on("openssl@1:", when="@5:")
     depends_on("pkgconfig", type="build", when="+ssl ^openssl ~shared")
-    depends_on("qt@5:", when="+ui")
+    depends_on("qt@5: +gui", when="+ui")
     # Requirement to use the Python3_EXECUTABLE variable
     depends_on("cmake@3.16:", type="build")
 

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -197,6 +197,10 @@ class Eckit(CMakePackage):
             # of a dependent package (e.g. fdb) might fail due to the undefined references.
             args.append(self.define("CURSES_NEED_NCURSES", True))
 
+        if "gcc-runtime" in self.spec:
+            args.append("-DCMAKE_Fortran_FLAGS=-L%s" % self.spec["gcc-runtime"].prefix.lib)
+            args.append("-DCMAKE_CXX_FLAGS=-L%s" % self.spec["gcc-runtime"].prefix.lib)
+
         return args
 
     def setup_build_environment(self, env):
@@ -206,6 +210,9 @@ class Eckit(CMakePackage):
         # when the admin variant is enabled.
         if self.spec.satisfies("platform=darwin") and self.spec.satisfies("+admin"):
             env.append_flags("LDFLAGS", self.spec["ncurses"].libs.ld_flags)
+
+        if "gcc-runtime" in self.spec:
+            env.append_flags("LDFLAGS", "-L%s" % self.spec["gcc-runtime"].prefix.lib)
 
     def check(self):
         ctest_args = ["-j", str(make_jobs)]

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -81,7 +81,15 @@ class Fckit(CMakePackage):
             raise InstallError("C++ library not configured for compiler")
         args.append("-DECBUILD_CXX_IMPLICIT_LINK_LIBRARIES={}".format(cxxlib))
 
+        if 'gcc-runtime' in self.spec:
+            args.append("-DCMAKE_Fortran_FLAGS=-L%s" % self.spec["gcc-runtime"].prefix.lib)
+            args.append("-DCMAKE_CXX_FLAGS=-L%s" % self.spec["gcc-runtime"].prefix.lib)
+
         return args
+
+    def setup_build_environment(self, env):
+        if 'gcc-runtime' in self.spec:
+            env.set("LDFLAGS", "-L%s" % self.spec["gcc-runtime"].prefix.lib)
 
     @when("+fismahigh")
     def patch(self):

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -81,14 +81,14 @@ class Fckit(CMakePackage):
             raise InstallError("C++ library not configured for compiler")
         args.append("-DECBUILD_CXX_IMPLICIT_LINK_LIBRARIES={}".format(cxxlib))
 
-        if 'gcc-runtime' in self.spec:
+        if "gcc-runtime" in self.spec:
             args.append("-DCMAKE_Fortran_FLAGS=-L%s" % self.spec["gcc-runtime"].prefix.lib)
             args.append("-DCMAKE_CXX_FLAGS=-L%s" % self.spec["gcc-runtime"].prefix.lib)
 
         return args
 
     def setup_build_environment(self, env):
-        if 'gcc-runtime' in self.spec:
+        if "gcc-runtime" in self.spec:
             env.set("LDFLAGS", "-L%s" % self.spec["gcc-runtime"].prefix.lib)
 
     @when("+fismahigh")

--- a/var/spack/repos/builtin/packages/git-lfs/package.py
+++ b/var/spack/repos/builtin/packages/git-lfs/package.py
@@ -63,6 +63,11 @@ class GitLfs(MakefilePackage):
         match = re.search(r"git-lfs/(\S+)", output)
         return match.group(1) if match else None
 
+    def build(self, spec, prefix):
+        tmpdir = join_path(self.build_directory, "tmp")
+        mkdirp(tmpdir)
+        make(f"TMPDIR={tmpdir}", "-j1")
+
     # Git-lfs does not provide an 'install' target in the Makefile
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/ip2/package.py
+++ b/var/spack/repos/builtin/packages/ip2/package.py
@@ -40,5 +40,5 @@ class Ip2(CMakePackage):
             env.set("IP2_INC" + suffix, join_path(self.prefix, "include_" + suffix))
 
     def patch(self):
-        filter_file("\(Intel\|", "(Intel|IntelLLVM|", "CMakeLists.txt")
-        filter_file("\(Intel\)", "(Intel|IntelLLVM)", "src/CMakeLists.txt")
+        filter_file(r"\(Intel\|", "(Intel|IntelLLVM|", "CMakeLists.txt")
+        filter_file(r"\(Intel\)", "(Intel|IntelLLVM)", "src/CMakeLists.txt")

--- a/var/spack/repos/builtin/packages/ip2/package.py
+++ b/var/spack/repos/builtin/packages/ip2/package.py
@@ -38,3 +38,7 @@ class Ip2(CMakePackage):
             )
             env.set("IP2_LIB" + suffix, lib[0])
             env.set("IP2_INC" + suffix, join_path(self.prefix, "include_" + suffix))
+
+    def patch(self):
+        filter_file("\(Intel\|", "(Intel|IntelLLVM|", "CMakeLists.txt")
+        filter_file("\(Intel\)", "(Intel|IntelLLVM)", "src/CMakeLists.txt")

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -166,60 +166,70 @@ class Mapl(CMakePackage):
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.55.0",
+        commit="ee49277f13b9b223cd86129a0c7094a359cbc4db",
         when="@2.51:",
     )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.51.0",
+        commit="53fae1237c88f9a6e60393dc6e4781555786b659",
         when="@2.48:2.50",
     )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.46.0",
+        commit="00bfd6ce4d7d8152433b2b1ad2cbb6d6f6c7066a",
         when="@2.47",
     )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.45.2",
+        commit="0f40e433189902d30af15fc92ace18dbf950d273",
         when="@2.45:2.46",
     )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.40.0",
+        commit="92e9910b1f70d6ea75e9f552fd672001b740b15b",
         when="@2.44",
     )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.36.0",
+        commit="e69296a5955ccc08618673125fccda0d0ca979ea",
         when="@2.42.0:2.43",
     )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.31.0",
+        commit="7dc4c819dc5169e6b887374aa0fa0a8f71846832",
         when="@2.40.0:2.41",
     )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.28.0",
+        commit="cb919eaea9489a2852d830a1eebf45b3c6acd223",
         when="@2.36.0:2.39",
     )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.24.0",
+        commit="5664d95fddff4afd01a2d7388a8bd99123d65e7d",
         when="@2.34.0:2.35",
     )
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.21.0",
+        commit="6df72eb873659eb55bc119f320a6e6e7bd23f5b1",
         when="@2.22.0:2.33",
     )
     # NOTE: Remove this resource(), the patch() commands below
@@ -228,6 +238,7 @@ class Mapl(CMakePackage):
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.13.0",
+        commit="e24f465000723630b4aef47d1d62cda5c0b38217",
         when="@:2.12.3",
     )
 

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -60,11 +60,17 @@ class Parallelio(CMakePackage):
     depends_on("netcdf-fortran", type="link", when="+fortran")
     depends_on("parallel-netcdf", type="link", when="+pnetcdf")
 
-    resource(name="genf90", git="https://github.com/PARALLELIO/genf90.git", tag="genf90_200608")
+    resource(
+        name="genf90",
+        git="https://github.com/PARALLELIO/genf90.git",
+        tag="genf90_200608",
+        commit="4816965ba946731352bad195b7d946a5fe682ff5",
+    )
     resource(
         name="CMake_Fortran_utils",
         git="https://github.com/CESM-Development/CMake_Fortran_utils.git",
         tag="CMake_Fortran_utils_150308",
+        commit="c2572f19d671c35a4cca26911a55ef78b3ba2829",
     )
 
     # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility

--- a/var/spack/repos/builtin/packages/upp/package.py
+++ b/var/spack/repos/builtin/packages/upp/package.py
@@ -79,5 +79,5 @@ class Upp(CMakePackage):
         return args
 
     def patch(self):
-        filter_file("\(Intel\)", "(Intel|IntelLLVM)", "CMakeLists.txt")
-        filter_file("\(Intel\)", "(Intel|IntelLLVM)", "sorc/ncep_post.fd/CMakeLists.txt")
+        filter_file(r"\(Intel\)", "(Intel|IntelLLVM)", "CMakeLists.txt")
+        filter_file(r"\(Intel\)", "(Intel|IntelLLVM)", "sorc/ncep_post.fd/CMakeLists.txt")

--- a/var/spack/repos/builtin/packages/upp/package.py
+++ b/var/spack/repos/builtin/packages/upp/package.py
@@ -77,3 +77,7 @@ class Upp(CMakePackage):
         ]
 
         return args
+
+    def patch(self):
+        filter_file("\(Intel\)", "(Intel|IntelLLVM)", "CMakeLists.txt")
+        filter_file("\(Intel\)", "(Intel|IntelLLVM)", "sorc/ncep_post.fd/CMakeLists.txt")


### PR DESCRIPTION
This PR updates the following recipes:
 - git-lfs: place gmake tmp dir under Spack build dir
 - parallelio: add commit hashes for resources (facilitates prefetching without having to disable checksum validation)
 - ecflow: +ui requires qt+gui
 - eckit, fckit: gcc-runtime isn't always in spec, so that logic is now conditional
 - ip2: patch for oneapi
 - mapl: add commit hashes for esma_cmake resources (also for fetching)
 - upp: patch for oneapi
 
Once merged, I intend to create a spack-stack-1.9.2rc1 tag on the release/1.9.0 branch.