### PR TITLE
release/1.9: Yet another crtm-fix bugfix

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -55,6 +55,7 @@ class CrtmFix(Package):
         for d in endian_dirs:
             fix_files = fix_files + find(".", "*/{}/*".format(d), recursive=False)
             fix_files = fix_files + find(".", "*/*/{}/*".format(d), recursive=False)
+            fix_files = fix_files + find(".", "*/*/*/{}/*".format(d), recursive=False)
         if self.spec.satisfies("~testfiles"):
             fix_files = [f for f in fix_files if "/fix/test_data/" not in f]
         fix_files = [f for f in fix_files if os.path.isfile(f)]


### PR DESCRIPTION
## Description

Yet another crtm-fix file bugfix for branch release/1.9. This will go into release tag 1.9.2. This and any other of the many crtm-fix bug fixes should be merged back to develop if not yet ...

Submodule pointer update will be handled in https://github.com/JCSDA/spack-stack/pull/1660, but since we've applied this bug fix manually on many platforms, this can be merged anytime.

Also, ignore the Ubuntu 20.04 / Python 3.6 errors, this runner doesn't exist anymore.