### PR TITLE
release/1.9.0: Add conflict for scotch with oneapi

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -85,7 +85,8 @@ class Scotch(CMakePackage, MakefilePackage):
     conflicts("metis", when="+metis")
     conflicts("parmetis", when="+metis")
 
-    # ISSUE HERE
+    # https://github.com/ufs-community/ufs-weather-model/pull/2650
+    # replace with spack-package issue once created
     conflicts("@oneapi")
 
     parallel = False

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -85,6 +85,9 @@ class Scotch(CMakePackage, MakefilePackage):
     conflicts("metis", when="+metis")
     conflicts("parmetis", when="+metis")
 
+    # ISSUE HERE
+    conflicts("@oneapi")
+
     parallel = False
 
     # NOTE: Versions of Scotch up to version 6.0.0 don't include support for

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -86,7 +86,7 @@ class Scotch(CMakePackage, MakefilePackage):
     conflicts("parmetis", when="+metis")
 
     # https://github.com/ufs-community/ufs-weather-model/pull/2650
-    # replace with spack-package issue once created
+    # https://github.com/spack/spack-packages/issues/161
     conflicts("@oneapi")
 
     parallel = False


### PR DESCRIPTION
## Description

This change is in response to the issues found with building scotch with the Intel oneAPI compilers. See https://github.com/ufs-community/ufs-weather-model/pull/2650, and in particular comment https://github.com/ufs-community/ufs-weather-model/pull/2650#issuecomment-2940581597.

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/2650, in particular https://github.com/ufs-community/ufs-weather-model/pull/2650#issuecomment-2956377120
See https://github.com/JCSDA/spack-stack/pull/1660