### PR TITLE
spack-stack-1.9.2rc2 updates (WCOSS2/NCO)

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -38,6 +38,7 @@ class Mapl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("2.53.4", sha256="da38348a72fcbaa2b888578bfa630ab36261206136d33700344ed6792f9f9aeb")
     version("2.53.0", sha256="68c24e6c0e3340645b1fb685972c96ef80746d5a289572c9883e520680708ebe")
     version("2.52.0", sha256="c30be3a6ed3fca40aea903e10ee51e2fb50b4ef2445fdc959d4871baf3c20585")
     version("2.51.2", sha256="f6df2be24d0c113af3d0424b674d970621660bf11e59a699373f014a14d0716e")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -626,6 +626,8 @@ class Qt(Package):
             use_spack_dep("freetype")
             if spec.satisfies("platform=linux") or spec.satisfies("platform=freebsd"):
                 config_args.append("-fontconfig")
+            # Explicitly disable vulkan to avoid build-time bug; this could be a variant
+            config_args.append("-no-vulkan")
         else:
             config_args.append("-no-freetype")
             config_args.append("-no-gui")
@@ -805,8 +807,7 @@ class Qt(Package):
             config_args.extend(["-skip", "wayland"])
 
         if "~location" in spec:
-            if version >= Version("5.15"):
-                config_args.extend(["-skip", "qtlocation"])
+            config_args.extend(["-skip", "qtlocation"])
 
         if IS_WINDOWS:
             config_args.extend(["-skip", "qtspeech"])

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -88,7 +88,7 @@ class Scotch(CMakePackage, MakefilePackage):
 
     # https://github.com/ufs-community/ufs-weather-model/pull/2650
     # https://github.com/spack/spack-packages/issues/161
-    conflicts("@oneapi")
+    conflicts("%oneapi")
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -20,6 +20,7 @@ class Scotch(CMakePackage, MakefilePackage):
 
     maintainers("pghysels")
 
+    version("7.0.7", sha256="02084471d2ca525f8a59b4bb8c607eb5cca452d6a38cf5c89f5f92f7edc1a5b5")
     version("7.0.4", sha256="8ef4719d6a3356e9c4ca7fefd7e2ac40deb69779a5c116f44da75d13b3d2c2c3")
     version("7.0.3", sha256="5b5351f0ffd6fcae9ae7eafeccaa5a25602845b9ffd1afb104db932dd4d4f3c5")
     version("7.0.1", sha256="0618e9bc33c02172ea7351600fce4fccd32fe00b3359c4aabb5e415f17c06fed")


### PR DESCRIPTION
A few small updates:
 - Add scotch@7.0.7 and correct oneapi conflict ("%" not "@")
 - Add mapl@2.53.4
 - qt: Always skip building location; explicitly disable vulkan so it doesn't randomly get enabled on some builds