### PR TITLE
Add crtm-fix@3.1.2.0, crtm@3.1.2, crtm@2.4.1-jedi.2; simplify crtm package

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -17,6 +17,7 @@ class CrtmFix(Package):
         "BenjaminTJohnson", "edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "climbfuji"
     )
 
+    version("3.1.2.0", sha256="4cfcba3030f13799c7543a9322669e3963038abf95f3eb5117bd909dea63fb4b")
     version("3.1.1.2", sha256="c2e289f690d82a3aa82d2239cbb567cd514fa0f476a8b498ceba11670685ca66")
     version(
         "2.4.0.1_emc", sha256="6e4005b780435c8e280d6bfa23808d8f12609dfd72f77717d046d4795cac0457"

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -27,33 +27,11 @@ class Crtm(CMakePackage):
         "climbfuji",
     )
 
-    variant(
-        "fix", default=False, description='Download CRTM coeffecient or "fix" files (several GBs).'
-    )
-
-    depends_on("cmake@3.15:", type="build")
-    depends_on("git-lfs")
-    depends_on("netcdf-fortran", when="@2.4.0:")
-    depends_on("netcdf-fortran", when="@v2.3-jedi.4")
-    depends_on("netcdf-fortran", when="@v2.4-jedi.1")
-    depends_on("netcdf-fortran", when="@v2.4-jedi.2")
-    depends_on("netcdf-fortran", when="@v2.4.1-jedi")
-    depends_on("netcdf-fortran", when="@v3")
-
-    depends_on("crtm-fix@2.3.0_emc", when="@2.3.0 +fix")
-    depends_on("crtm-fix@2.4.0_emc", when="@=2.4.0 +fix")
-    depends_on("crtm-fix@2.4.0.1_emc", when="@2.4.0.1 +fix")
-    depends_on("crtm-fix@3.1.1", when="@3.1.1 +fix")
-
-    depends_on("ecbuild", type=("build"), when="@v2.3-jedi.4")
-    depends_on("ecbuild", type=("build"), when="@v2.4-jedi.1")
-    depends_on("ecbuild", type=("build"), when="@v2.4-jedi.2")
-    depends_on("ecbuild", type=("build"), when="@v2.4.1-jedi")
-    depends_on("ecbuild", type=("build"), when="@v3.0")
-    depends_on("ecbuild", type=("build"), when="@v3.1.0-skylabv7")
-
     license("CC0-1.0")
 
+    version(
+        "3.1.2", sha256="a96598e5611c263fa80d6d6375a12d70d74389b261a8070515a6698e41563281"
+    )
     version(
         "3.1.1-build1", sha256="1ed49e594da5d3769cbaa52cc7fc19c1bb0325ee6324f6057227c31e2d95ca67"
     )
@@ -74,6 +52,12 @@ class Crtm(CMakePackage):
         sha256="4fa5dd2d65b4d4ff77d50992e8e0c02a59584b35599f424085fccdc2174d7bd2",
     )
     version(
+        "v2.4.1-jedi.2", sha256="e78c1a834dd337597b01e451c5c6e813c1b97d42b221049e8dbbbc590598f1de"
+    )
+    version(
+        "v2.4.1-jedi.1", sha256="94ff24051382d544c2e200a937bfe7d2047f6393a3e22f64284d5dc70e791ca6"
+    )
+    version(
         "v2.4.1-jedi", sha256="fd8bf4db4f2a3b420b4186de84483ba2a36660519dffcb1e0ff14bfe8c6f6a14"
     )
     version("v2.4-jedi.2", commit="62831cbb6c1ffcbb219eeec60e1b1c422526f597")
@@ -84,12 +68,45 @@ class Crtm(CMakePackage):
     # Uses the tip of REL-2.3.0_emc branch
     version("2.3.0", commit="99760e693ce3b90a3b3b0e97d80972b4dfb61196")
 
-    depends_on("fortran", type="build")  # generated
+    variant(
+        "fix", default=False, description='Download CRTM coeffecient or "fix" files (several GBs).'
+    )
+
+    depends_on("fortran", type="build")
+
+    depends_on("cmake@3.15:", type="build")
+    depends_on("git-lfs")
+    depends_on("netcdf-fortran", when="@2.4.0:")
+    depends_on("netcdf-fortran", when="@v2.3")
+    depends_on("netcdf-fortran", when="@v2.4")
+    depends_on("netcdf-fortran", when="@v3")
+
+    depends_on("crtm-fix@2.3.0_emc", when="@2.3.0 +fix")
+    depends_on("crtm-fix@2.4.0_emc", when="@=2.4.0 +fix")
+    depends_on("crtm-fix@2.4.0.1_emc", when="@2.4.0.1 +fix")
+    depends_on("crtm-fix@3.1.1", when="@3.1.1 +fix")
+    depends_on("crtm-fix@3.1.2", when="@3.1.2 +fix")
+
+    depends_on("ecbuild", type=("build"), when="@v2.3")
+    depends_on("ecbuild", type=("build"), when="@v2.4")
+    depends_on("ecbuild", type=("build"), when="@v3")
+
+    conflicts("%oneapi", when="@2")
+    conflicts("%oneapi", when="@v2.3")
+    conflicts("%oneapi", when="@v2.4-jedi")
+    conflicts("%oneapi", when="@=v2.4.1-jedi")
+    conflicts("%oneapi", when="@=v2.4.1-jedi.1")
+    conflicts("%oneapi", when="@v3")
+    conflicts("%oneapi", when="@3.1.1-build1")
 
     def url_for_version(self, version):
-        if version > Version("v3") or version >= Version("3"):
+        if self.spec.satisfies("@=3.1.1-build1"):
             fmtversion = str(version).replace("-build", "+build")
             return f"https://github.com/JCSDA/CRTMv3/archive/refs/tags/{fmtversion}.tar.gz"
+        elif version >= Version("3"):
+            return f"https://github.com/JCSDA/CRTMv3/archive/refs/tags/v{version}.tar.gz"
+        elif version > Version("v3"):
+            return f"https://github.com/JCSDA/CRTMv3/archive/refs/tags/{version}.tar.gz"
         else:
             return f"https://github.com/JCSDA/crtm/archive/refs/tags/{version}.tar.gz"
 

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -67,7 +67,7 @@ class Crtm(CMakePackage):
     version("2.3.0", commit="99760e693ce3b90a3b3b0e97d80972b4dfb61196")
 
     variant(
-        "fix", default=False, description='Download CRTM coeffecient or "fix" files (several GBs).'
+        "fix", default=False, description='Download CRTM coefficient or "fix" files (several GBs).'
     )
 
     depends_on("fortran", type="build")

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -29,9 +29,7 @@ class Crtm(CMakePackage):
 
     license("CC0-1.0")
 
-    version(
-        "3.1.2", sha256="a96598e5611c263fa80d6d6375a12d70d74389b261a8070515a6698e41563281"
-    )
+    version("3.1.2", sha256="a96598e5611c263fa80d6d6375a12d70d74389b261a8070515a6698e41563281")
     version(
         "3.1.1-build1", sha256="1ed49e594da5d3769cbaa52cc7fc19c1bb0325ee6324f6057227c31e2d95ca67"
     )


### PR DESCRIPTION
## Description

- Add crtm-fix@3.1.2.0
- Add crtm@3.1.2, crtm@2.4.1-jedi.2; add conflict of other versions with Intel oneAPI compilers
- Clean up crtm package (adjust ordering of blocks to be consistent with other packages, simplify dependencies and conflicts)

## Testing

- [x]  CI
- [ ] See https://github.com/JCSDA/spack-stack/pull/1680

## Dependencies

None, but corresponding spack-packages PR is https://github.com/spack/spack-packages/pull/285