### PR TITLE
Add esmf@8.9.0b12

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -31,6 +31,7 @@ class Esmf(MakefilePackage, PythonExtension):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
+    version("8.9.0b12", commit="d0365bec321318d500a1bda3b60223afdcb72066")
     version("8.9.0b11", commit="c27280964764a0e1258ff9faab6bf4e2fac39406")
     version("8.9.0b09", commit="7e8c4b2f21bbea6432a3dadd6e6a7e143b786193")
     version("8.9.0b08", commit="56e26fde7b4890ae44eb3efdf2f6728b5eb4627e")


### PR DESCRIPTION
## Description

All in the title

## Testing

Concretized the unified environment for PR https://github.com/JCSDA/spack-stack/pull/1699 and ran `spack stage esmf@8.9.0b12` to verify commit hash.
