### PR TITLE
parallelio: add commit hashes for resources

### DIFF
--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -33,6 +33,7 @@ class Cprnc(CMakePackage):
         name="genf90",
         git="https://github.com/PARALLELIO/genf90",
         tag="genf90_200608",
+        commit="4816965ba946731352bad195b7d946a5fe682ff5",
         destination="genf90-resource",
     )
 

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -60,11 +60,17 @@ class Parallelio(CMakePackage):
     depends_on("netcdf-fortran", type="link", when="+fortran")
     depends_on("parallel-netcdf", type="link", when="+pnetcdf")
 
-    resource(name="genf90", git="https://github.com/PARALLELIO/genf90.git", tag="genf90_200608")
+    resource(
+        name="genf90",
+        git="https://github.com/PARALLELIO/genf90.git",
+        tag="genf90_200608",
+        commit="4816965ba946731352bad195b7d946a5fe682ff5",
+    )
     resource(
         name="CMake_Fortran_utils",
         git="https://github.com/CESM-Development/CMake_Fortran_utils.git",
         tag="CMake_Fortran_utils_150308",
+        commit="c2572f19d671c35a4cca26911a55ef78b3ba2829",
     )
 
     # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility


### PR DESCRIPTION
This PR adds commit hashes for the parallelio resources to facilitate fetching without having to disable checksums.

See https://github.com/spack/spack-packages/pull/1053