### PR TITLE
Support variant netcdf when=@3.6:

### DIFF
--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -177,6 +177,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     depends_on("ip@5.1:", when="@3.5: +ipolates")
     depends_on("lapack", when="@3.5: +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
+    depends_on("netcdf-c", when="@3.6: +netcdf")
     depends_on("netcdf-c", when="@3.2: +netcdf4")
     depends_on("jasper@:2", when="@3.2:3.4 +jasper")
     depends_on("g2c", when="@3.5: +jasper")


### PR DESCRIPTION
Provide support for variant `netcdf` for `wgrib2@3.6.0`

This is a **_simple_** and  **_temporary fix_** that will remain in the `release/1.9.0` branch; a more permanent and complete fix is necessary for `spack-stack-dev`

This was tested on hosts listed in / will resolve `spack-stack` issues [1685](https://github.com/JCSDA/spack-stack/issues/1685) and [1711](https://github.com/JCSDA/spack-stack/issues/1711)