### PR TITLE
release/1.9.0: Add crtm-fix@3.1.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -17,6 +17,7 @@ class CrtmFix(Package):
         "BenjaminTJohnson", "edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "climbfuji"
     )
 
+    version("3.1.1.3", sha256="a69778ff6bec7a1b7a76b79dbc94f442c1ed51fca1c4014464aada2730e63ca7")
     version("3.1.1.2", sha256="c2e289f690d82a3aa82d2239cbb567cd514fa0f476a8b498ceba11670685ca66")
     version(
         "2.4.0.1_emc", sha256="6e4005b780435c8e280d6bfa23808d8f12609dfd72f77717d046d4795cac0457"


### PR DESCRIPTION
## Description

All in the title. I tested this on the Navy DSRC system Nautilus. Instructions for creating the chained environments for spack-stack-1.9.3 will be provided in the forthcoming spack-stack PR for `release/1.9.0`.

## Issues

Working towards #565 

## Additional context

I created a PR for spack-packages upstream and then work with @DavidHuber-NOAA to determine the correct dependencies for the various CRTM versions

https://github.com/spack/spack-packages/pull/1541