### PR TITLE
[spack-stack-dev] Add crtm-fix@3.1.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -18,6 +18,7 @@ class CrtmFix(Package):
     )
 
     version("3.1.2.0", sha256="4cfcba3030f13799c7543a9322669e3963038abf95f3eb5117bd909dea63fb4b")
+    version("3.1.1.3", sha256="a69778ff6bec7a1b7a76b79dbc94f442c1ed51fca1c4014464aada2730e63ca7")
     version("3.1.1.2", sha256="c2e289f690d82a3aa82d2239cbb567cd514fa0f476a8b498ceba11670685ca66")
     version(
         "2.4.0.1_emc", sha256="6e4005b780435c8e280d6bfa23808d8f12609dfd72f77717d046d4795cac0457"


### PR DESCRIPTION
## Description

Final update of `spack-stack-dev` from `release/1.9.0` branch: add crtm-fix@3.1.1.3. I cherry-picked this commit from the release branch. This update is already in the new `spack-stack-dev` branch of https://github.com/jcsda/spack-packages and also in the authoritative spack-packages repository, therefore no follow-up PR for the new spack v1 update branches is needed.

Corresponding spack-stack PR: https://github.com/JCSDA/spack-stack/pull/1790.

## Testing

Deployed on all systems as part of the spack-stack-1.9.3 release

Note that the CI test "prechecks" fail because of an unrelated `uwtools` dependency issues. This can be ignored, because this PR will be the last PR before we freeze JCSDA `spack-stack-dev` until the `feature/update_to_spack_v1` is merged. This merge will then remove the spack packages underneath the spack submodule and use the new repositories in the `spack-packages` repository.
