### PR TITLE
Bug fix for wgrib2 from release/1.9.0: support variant netcdf when=@3.6: (#561)

### DIFF
--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -177,7 +177,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     depends_on("ip@5.1:", when="@3.5: +ipolates")
     depends_on("lapack", when="@3.5: +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
-    depends_on("netcdf-c", when="@3.6: +netcdf")
+    depends_on("netcdf-c", when="@3.4: +netcdf")
     depends_on("netcdf-c", when="@3.2: +netcdf4")
     depends_on("jasper@:2", when="@3.2:3.4 +jasper")
     depends_on("g2c", when="@3.5: +jasper")

--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -177,6 +177,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     depends_on("ip@5.1:", when="@3.5: +ipolates")
     depends_on("lapack", when="@3.5: +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
+    depends_on("netcdf-c", when="@3.6: +netcdf")
     depends_on("netcdf-c", when="@3.2: +netcdf4")
     depends_on("jasper@:2", when="@3.2:3.4 +jasper")
     depends_on("g2c", when="@3.5: +jasper")

--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -177,6 +177,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     depends_on("ip@5.1:", when="@3.5: +ipolates")
     depends_on("lapack", when="@3.5: +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
+    # Options to use netcdf3 or netcdf4 merged into a single option with v3.4.0
     depends_on("netcdf-c", when="@3.4: +netcdf")
     depends_on("netcdf-c", when="@3.2: +netcdf4")
     depends_on("jasper@:2", when="@3.2:3.4 +jasper")


### PR DESCRIPTION
## Description

Cherry-picking 30eb08b9937d364c28ce3864823c31fa68d0a9c4 from `release/1.9.0` for develop to fix the CI build errors discussed in https://github.com/JCSDA/spack-stack/pull/1790#discussion_r2407386123. This is the same as PR https://github.com/JCSDA/spack/pull/561 that went into `release/1.9.0`, but updated to match the correct wgrib2 versions that need the fix (see discussion below).

Because the JCSDA spack-stack-dev branch will have all of the packages removed as part of the move to spack v1 (spack-stack v2), this is going to be the last PR for the packages inside the old spack v0.23 code.

## Testing

See https://github.com/JCSDA/spack-stack/pull/1790