### PR TITLE
install_test.py: append to install-time test log for multiple test phases (#50477)

### DIFF
--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -300,7 +300,9 @@ class PackageTest:
         fs.touch(self.test_log_file)  # Otherwise log_parse complains
         fs.set_install_permissions(self.test_log_file)
 
-        with spack.llnl.util.tty.log.log_output(self.test_log_file, verbose) as self._logger:
+        with spack.llnl.util.tty.log.log_output(
+            self.test_log_file, verbose, append=True
+        ) as self._logger:
             with self.logger.force_echo():  # type: ignore[union-attr]
                 tty.msg("Testing package " + colorize(r"@*g{" + self.pkg_id + r"}"))
 

--- a/lib/spack/spack/llnl/util/tty/log.py
+++ b/lib/spack/spack/llnl/util/tty/log.py
@@ -336,13 +336,14 @@ class FileWrapper:
     object.
     """
 
-    def __init__(self, file_like):
+    def __init__(self, file_like, append=False):
         # This records whether the file-like object returned by "unwrap" is
         # purely in-memory. In that case a subprocess will need to explicitly
         # transmit the contents to the parent.
         self.write_in_parent = False
 
         self.file_like = file_like
+        self.append = append
 
         if isinstance(file_like, str):
             self.open = True
@@ -358,7 +359,8 @@ class FileWrapper:
     def unwrap(self):
         if self.open:
             if self.file_like:
-                self.file = open(self.file_like, "w", encoding="utf-8")
+                mode = "a" if self.append else "w"
+                self.file = open(self.file_like, mode, encoding="utf-8")
             else:
                 self.file = io.StringIO()
             return self.file
@@ -424,7 +426,14 @@ class nixlog:
     """
 
     def __init__(
-        self, file_like=None, echo=False, debug=0, buffer=False, env=None, filter_fn=None
+        self,
+        file_like=None,
+        echo=False,
+        debug=0,
+        buffer=False,
+        env=None,
+        filter_fn=None,
+        append=False,
     ):
         """Create a new output log context manager.
 
@@ -437,6 +446,7 @@ class nixlog:
                 this doesn't set up any *new* buffering
             filter_fn (callable, optional): Callable[str] -> str to filter each
                 line of output
+            append (bool): whether to append to file ('a' mode)
 
         log_output can take either a file object or a filename. If a
         filename is passed, the file will be opened and closed entirely
@@ -456,6 +466,7 @@ class nixlog:
         self.debug = debug
         self.buffer = buffer
         self.filter_fn = filter_fn
+        self.append = append
 
         self._active = False  # used to prevent re-entry
 
@@ -496,7 +507,7 @@ class nixlog:
             raise RuntimeError("file argument must be set by either __init__ or __call__")
 
         # set up a stream for the daemon to write to
-        self.log_file = FileWrapper(self.file_like)
+        self.log_file = FileWrapper(self.file_like, append=self.append)
 
         # record parent color settings before redirecting.  We do this
         # because color output depends on whether the *original* stdout
@@ -735,7 +746,9 @@ class winlog:
     Does not support the use of 'v' toggling as nixlog does.
     """
 
-    def __init__(self, file_like=None, echo=False, debug=0, buffer=False, filter_fn=None):
+    def __init__(
+        self, file_like=None, echo=False, debug=0, buffer=False, filter_fn=None, append=False
+    ):
         self.debug = debug
         self.echo = echo
         self.logfile = file_like
@@ -745,6 +758,7 @@ class winlog:
         self._ioflag = False
         self.old_stdout = sys.stdout
         self.old_stderr = sys.stderr
+        self.append = append
 
     def __enter__(self):
         if self._active:
@@ -760,7 +774,8 @@ class winlog:
             sys.stdout = self.logfile
             sys.stderr = self.logfile
         else:
-            self.writer = open(self.logfile, mode="wb+")
+            write_mode = "ab+" if self.append else "wb+"
+            self.writer = open(self.logfile, mode=write_mode)
             self.reader = open(self.logfile, mode="rb+")
 
             # Dup stdout so we can still write to it after redirection

--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -133,6 +133,23 @@ def test_log_output_with_filter(capfd, tmp_path: pathlib.Path):
     assert capfd.readouterr()[0] == "bar blah\nblah bar\nbar bar\n"
 
 
+def test_log_output_with_filter_and_append(capfd, tmp_path: pathlib.Path):
+    with working_dir(str(tmp_path)):
+        with log.log_output("foo.txt", filter_fn=_log_filter_fn):
+            print("foo blah")
+            print("blah foo")
+            print("foo foo")
+
+        with open("foo.txt", encoding="utf-8") as f:
+            assert f.read() == "foo blah\nblah foo\nfoo foo\n"
+
+        with log.log_output("foo.txt", filter_fn=_log_filter_fn, append=True):
+            print("more foo more blah")
+
+        with open("foo.txt", encoding="utf-8") as f:
+            assert f.read() == "foo blah\nblah foo\nfoo foo\nmore foo more blah\n"
+
+
 @pytest.mark.skipif(not which("echo"), reason="needs echo command")
 def test_log_subproc_and_echo_output_no_capfd(capfd, tmp_path: pathlib.Path):
     echo = which("echo", required=True)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/printing_package/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/printing_package/package.py
@@ -4,12 +4,12 @@
 
 import os
 
-from spack_repo.builtin_mock.build_systems.generic import Package
+from spack_repo.builtin_mock.build_systems.makefile import MakefilePackage
 
 from spack.package import *
 
 
-class PrintingPackage(Package):
+class PrintingPackage(MakefilePackage):
     """This package prints some output from its install method.
 
     We use this to test whether that output is properly logged.
@@ -27,6 +27,14 @@ class PrintingPackage(Package):
         touch(os.path.join(prefix, "dummyfile"))
 
         print("AFTER INSTALL")
+
+    def check(self):
+        """Run build-time tests."""
+        print("PRINTING PACKAGE CHECK")
+
+    def installcheck(self):
+        """Run install-time tests."""
+        print("PRINTING PACKAGE INSTALLCHECK")
 
     def test_print(self):
         """Test print example."""


### PR DESCRIPTION
This PR cherry-picks https://github.com/spack/spack/commit/cdb2edfd5738f38cd2b3a5028fdabb77d89ac1c8, which fixes the problem of install-time test logs getting overwritten for MakefilePackage's (so now we can retain 'make test' output for, e.g., `spack install --test root esmf`).