### PR TITLE
Updates for wgrib2 v3.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -20,6 +20,8 @@ variant_map_common = {
     "g2c": "USE_G2CLIB",
     "png": "USE_PNG",
     "jasper": "USE_JASPER",
+    "g2c_low": "USE_G2CLIB_LOW",
+    "g2c_high": "USE_G2CLIB_HIGH",
     "openmp": "USE_OPENMP",
     "wmo_validation": "USE_WMO_VALIDATION",
     "ipolates": "USE_IPOLATES",
@@ -57,6 +59,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     )
 
     version("develop", branch="develop")
+    version("3.7.0", sha256="b741a07710a8195c99a7d50de05bde90182ab4334f5c4a0d6d057c4e20cc6a75")
     version("3.6.0", sha256="55913cb58f2b329759de17f5a84dd97ad1844d7a93956d245ec94f4264d802be")
     version("3.5.0", sha256="b27b48228442a08bddc3d511d0c6335afca47252ae9f0e41ef6948f804afa3a1")
     version("3.4.0", sha256="ecbce2209c09bd63f1bca824f58a60aa89db6762603bda7d7d3fa2148b4a0536")
@@ -83,9 +86,6 @@ class Wgrib2(MakefilePackage, CMakePackage):
         extension="tar.gz",
     )
 
-    depends_on("c", type="build")
-    depends_on("fortran", type="build")
-
     def url_for_version(self, version):
         if version >= Version("3.2.0"):
             url_fmt = "https://github.com/NOAA-EMC/wgrib2/archive/refs/tags/v{0}.tar.gz"
@@ -108,7 +108,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     variant(
         "netcdf",
         default=False,
-        description="Link in netcdf4 library to write netcdf3/4 files",
+        description="Link in netcdf library to write netcdf files",
         when="@3.4:",
     )
     variant("ipolates", default=False, description="Use to interpolate to new grids")
@@ -152,6 +152,18 @@ class Wgrib2(MakefilePackage, CMakePackage):
         when="@:3.1",
     )
     variant(
+        "g2c_low",
+        default=True,
+        description="Include NCEP g2clib (png,jpeg2000)",
+        when="@3.7:",
+    )
+    variant(
+        "g2c_high",
+        default=False,
+        description="Include NCEP g2clib (add -g2clib 2)",
+        when="@3.7:",
+    )
+    variant(
         "disable_timezone", default=False, description="Some machines do not support timezones"
     )
     variant(
@@ -159,13 +171,23 @@ class Wgrib2(MakefilePackage, CMakePackage):
         default=False,
         description="Some machines do not support the alarm to terminate wgrib2",
     )
-    variant("png", default=True, description="PNG encoding")
-    variant("jasper", default=True, description="JPEG compression using Jasper")
+    variant(
+        "png", 
+        default=True, 
+        description="PNG encoding",
+        when="@:3.7"
+    )
+    variant(
+        "jasper", 
+        default=True, 
+        description="JPEG compression using Jasper",
+        when="@:3.7"
+    )
     variant("openmp", default=True, description="OpenMP parallelization")
     variant("wmo_validation", default=False, description="WMO validation")
     #    variant("shared", default=False, description="Enable shared library", when="+lib")
     variant("disable_stat", default=False, description="Disable POSIX feature", when="@:3.1")
-    variant("openjpeg", default=False, description="Enable OpenJPEG")
+    variant("openjpeg", default=False, description="Enable OpenJPEG", when="@:3.7")
     variant(
         "enable_docs", default=False, description="Build doxygen documentation", when="@3.4.0:"
     )
@@ -173,9 +195,15 @@ class Wgrib2(MakefilePackage, CMakePackage):
     conflicts("+netcdf3", when="+netcdf4")
     conflicts("+netcdf3", when="+netcdf")
     conflicts("+openmp", when="%apple-clang")
+    conflicts("-g2c_low", when="+g2c_high")
 
-    depends_on("ip@5.1:", when="@3.5: +ipolates")
-    depends_on("lapack", when="@3.5: +ipolates")
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+    
+    depends_on("ip@5.2:", when="@develop +ipolates")
+    depends_on("g2c@2.2.0:", when="@3.7: +g2c_low")
+    depends_on("g2c@2.2.0:", when="@3.7: +g2c_high")
+    depends_on("lapack", when="@develop +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
     # Options to use netcdf3 or netcdf4 merged into a single option with v3.4.0
     depends_on("netcdf-c", when="@3.4: +netcdf")
@@ -184,6 +212,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     depends_on("g2c", when="@3.5: +jasper")
     depends_on("zlib-api", when="@3.2: +png")
     depends_on("libpng", when="@3.2: +png")
+    depends_on("g2c +png", when="@3.5: +png")
     depends_on("openjpeg", when="@3.2:3.4 +openjpeg")
     depends_on("g2c +openjpeg", when="@3.5: +openjpeg")
     requires("^g2c@1.9:", when="@3.5: ^g2c")


### PR DESCRIPTION
This PR contains recipe updates from wgrib2 version 3.7.0. This includes replacing options to use Jasper/OpenJPEG/PNG with USE_G2CLIB_LOW and the old USE_G2CLIB option with USE_G2CLIB_HIGH.

Part of [NOAA-EMC/wgrib2/#457](https://github.com/NOAA-EMC/wgrib2/issues/457)
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
