### PR TITLE
[spack v0.23 / spack-stack v1] Add esmf@8.9.1

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -31,6 +31,7 @@ class Esmf(MakefilePackage, PythonExtension):
     # Develop is a special name for spack and is always considered the newest version
     version("develop", branch="develop")
     # generate chksum with 'spack checksum esmf@x.y.z'
+    version("8.9.1", commit="6a091126030012504e2d42a21eb8764066f0bb6a")
     version("8.9.0", sha256="586e0101d76ff9842d9ad43567fae50317ee794d80293430d9f1847dec0eefa5")
     version("8.8.1", sha256="b0acb59d4f000bfbdfddc121a24819bd2a50997c7b257b0db2ceb96f3111b173")
     version("8.8.0", sha256="f89327428aeef6ad34660b5b78f30d1c55ec67efb8f7df1991fdaa6b1eb3a27c")


### PR DESCRIPTION
## Description

Add esmf@8.9.1.

A similar change already went into the feature/update_to_spack_v1 branches, but it turns out we need it in develop now.

I will resolve merge conflicts when I pull the updated spack-stack develop / spack spack-stack-dev branches into the feature/update_to_spack_v1 branches.

## Testing

spack-stack PR https://github.com/JCSDA/spack-stack/pull/1824

Note that the spack CI windows audit test is expected to fail; it did so ever since spack upstream updated to spack v1.
