### PR TITLE
Silence warnings about non-existent index for mirrors that don't have and don't need a buildcache index

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -374,8 +374,12 @@ class BinaryCacheIndex:
                     except FetchIndexError as e:
                         fetch_errors.append(e)
                         self._last_fetch_times[urlAndVersion] = (now, False)
-                    except BuildcacheIndexNotExists as e:
-                        fetch_errors.append(e)
+                    except BuildcacheIndexNotExists:  # as e:
+                        # DH* JCSDA fork only - silence warnings about non-existent
+                        # index for mirrors, because this warning is issued for all
+                        # mirrors (source, bootstrap, ...)
+                        # fetch_errors.append(e)
+                        # *DH
                         self._last_fetch_times[urlAndVersion] = (now, False)
                         # Binary caches are not required to have an index, don't raise
                         # if it doesn't exist.
@@ -420,8 +424,12 @@ class BinaryCacheIndex:
             except FetchIndexError as e:
                 fetch_errors.append(e)
                 self._last_fetch_times[urlAndVersion] = (now, False)
-            except BuildcacheIndexNotExists as e:
-                fetch_errors.append(e)
+            except BuildcacheIndexNotExists:  # as e:
+                # DH* JCSDA fork only - silence warnings about non-existent
+                # index for mirrors, because this warning is issued for all
+                # mirrors (source, bootstrap, ...)
+                # fetch_errors.append(e)
+                # *DH
                 self._last_fetch_times[urlAndVersion] = (now, False)
                 # Binary caches are not required to have an index, don't raise
                 # if it doesn't exist.


### PR DESCRIPTION
## Description

`lib/spack/spack/binary_distribution.py`: silence warnings about non-existent index for mirrors, because this warning is issued for all mirrors (source, bootstrap, ...), even if they don't have or don't need a build cache index to function correctly. See comments from Spack developers just below my changes.

These warnings look like legitimate errors, clutter the output of automated build/deploy systems, and confuse users and developers.

I do not indent to send this upstream but maintain the diff in our fork/branch.

## Testing

See https://github.com/JCSDA/spack-stack/pull/1896